### PR TITLE
Fixed bug with handling Authorization message more than once.

### DIFF
--- a/packages/client/src/components/AlertModals/AlertModals.module.scss
+++ b/packages/client/src/components/AlertModals/AlertModals.module.scss
@@ -37,7 +37,9 @@
       }
 
       .closeButton {
+        background-color: lightgrey;
         &:hover {
+          background-color: lighten(lightgrey, 5%);
           cursor: pointer;
           color: red;
         }

--- a/packages/client/src/components/AlertModals/WarningRetryModal.tsx
+++ b/packages/client/src/components/AlertModals/WarningRetryModal.tsx
@@ -51,7 +51,7 @@ const WarningRetryModal = ({
     } else {
       clearInterval(countdown as any)
     }
-  }, [open])
+  }, [open, noCountdown])
 
   useEffect(() => {
     if (timeRemaining === 0) {

--- a/packages/client/src/components/World/GameServerWarnings.tsx
+++ b/packages/client/src/components/World/GameServerWarnings.tsx
@@ -7,7 +7,6 @@ import { SocketWebRTCClientTransport } from '../../transports/SocketWebRTCClient
 import { Network } from '@xrengine/engine/src/networking/classes/Network'
 import { selectLocationState } from '@xrengine/client-core/src/social/reducers/location/selector'
 import { provisionInstanceServer } from '../../reducers/instanceConnection/service'
-import { Network } from '@xrengine/engine/src/networking/classes/Network'
 
 type GameServerWarningsProps = {
   isTeleporting: boolean
@@ -43,7 +42,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 const GameServerWarnings = (props: GameServerWarningsProps) => {
+  const { locationState } = props
   const [modalValues, setModalValues] = useState(initialModalValues)
+  const invalidLocationState = locationState.get('invalidLocation')
 
   useEffect(() => {
     EngineEvents.instance.addEventListener(
@@ -71,12 +72,12 @@ const GameServerWarnings = (props: GameServerWarningsProps) => {
   }, [])
 
   useEffect(() => {
-    if (props.locationState.invalidLocation) {
+    if (invalidLocationState) {
       updateWarningModal(WarningModalTypes.INVALID_LOCATION)
     } else {
       reset()
     }
-  }, [props.locationState.invalidLocation])
+  }, [invalidLocationState])
 
   const updateWarningModal = (type: WarningModalTypes, message?: any) => {
     switch (type) {
@@ -96,7 +97,8 @@ const GameServerWarnings = (props: GameServerWarningsProps) => {
           title: 'No Available Servers',
           body: "There aren't any servers available for you to connect to. Attempting to re-connect in",
           action: async () => provisionInstanceServer(),
-          parameters: [currentLocation.id, props.instanceId, currentLocation.sceneId]
+          parameters: [currentLocation.id, props.instanceId, currentLocation.sceneId],
+          noCountdown: false
         })
         break
 
@@ -109,7 +111,8 @@ const GameServerWarnings = (props: GameServerWarningsProps) => {
           title: 'World disconnected',
           body: "You've lost your connection with the world. We'll try to reconnect before the following time runs out, otherwise you'll be forwarded to a different instance.",
           action: async () => window.location.reload(),
-          timeout: 30000
+          timeout: 30000,
+          noCountdown: false
         })
         break
 
@@ -121,7 +124,7 @@ const GameServerWarnings = (props: GameServerWarningsProps) => {
           title: 'WebGL not enabled',
           body: 'Your browser does not support WebGL, or it is disabled. Please enable WebGL or consider upgrading to the latest version of your browser.',
           action: async () => window.location.reload(),
-          timeout: 3600000
+          noCountdown: true
         })
         break
 

--- a/packages/gameserver/src/SocketWebRTCServerTransport.ts
+++ b/packages/gameserver/src/SocketWebRTCServerTransport.ts
@@ -107,6 +107,7 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
   }
 
   public async initialize(): Promise<void> {
+    let listenersSetUp = false
     // Set up our gameserver according to our current environment
     const localIp = await getLocalServerIp()
     let stringSubdomainNumber, gsResult
@@ -167,13 +168,7 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
       protocol: 'raw',
       appData: { peerID: 'outgoingProducer' }
     }
-    console.log('Producing data from outgoingDataTransport', this.outgoingDataTransport)
-    try {
-      this.outgoingDataProducer = await this.outgoingDataTransport.produceData(options)
-    } catch (err) {
-      console.log('outgoingDataTransport produceData error', err)
-      throw err
-    }
+    this.outgoingDataProducer = await this.outgoingDataTransport.produceData(options)
 
     const currentRouter = this.routers.instance[0]
 
@@ -232,9 +227,9 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
               }
             })
             .catch((error) => {
-              // They weren't found in the dabase, so send the client an error message and return
+              // They weren't found in the database, so send the client an error message and return
               callback({ success: false, message: error })
-              return console.warn('Failed to authorize user')
+              return console.warn('User avatar not found')
             })
 
           const avatar = {
@@ -251,95 +246,98 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
           // TODO: Check that they are supposed to be in this instance
           // TODO: Check that token is valid (to prevent users hacking with a manipulated user ID payload)
 
-          // Return an authorization success messaage to client
+          // Return an authorization success message to client
           callback({ success: true })
 
-          socket.on(MessageTypes.ConnectToWorld.toString(), async (data, callback) => {
-            // console.log('Got ConnectToWorld:');
-            // console.log(data);
-            // console.log(userId);
-            // console.log("Avatar", avatar)
-            handleConnectToWorld(socket, data, callback, userId, user, avatar)
-          })
+          if (!listenersSetUp) {
+            listenersSetUp = true
+            socket.on(MessageTypes.ConnectToWorld.toString(), async (data, callback) => {
+              // console.log('Got ConnectToWorld:');
+              // console.log(data);
+              // console.log(userId);
+              // console.log("Avatar", avatar)
+              handleConnectToWorld(socket, data, callback, userId, user, avatar)
+            })
 
-          socket.on(MessageTypes.JoinWorld.toString(), async (data, callback) =>
-            handleJoinWorld(socket, data, callback, userId, user)
-          )
+            socket.on(MessageTypes.JoinWorld.toString(), async (data, callback) =>
+              handleJoinWorld(socket, data, callback, userId, user)
+            )
 
-          socket.on(MessageTypes.ActionData.toString(), (data) => handleIncomingActions(socket, data))
+            socket.on(MessageTypes.ActionData.toString(), (data) => handleIncomingActions(socket, data))
 
-          // If a reliable message is received, add it to the queue
-          socket.on(MessageTypes.ReliableMessage.toString(), (data) => handleIncomingMessage(socket, data))
+            // If a reliable message is received, add it to the queue
+            socket.on(MessageTypes.ReliableMessage.toString(), (data) => handleIncomingMessage(socket, data))
 
-          socket.on(MessageTypes.Heartbeat.toString(), () => handleHeartbeat(socket))
+            socket.on(MessageTypes.Heartbeat.toString(), () => handleHeartbeat(socket))
 
-          socket.on('disconnect', () => handleDisconnect(socket))
+            socket.on('disconnect', () => handleDisconnect(socket))
 
-          socket.on(MessageTypes.LeaveWorld.toString(), (data, callback) => handleLeaveWorld(socket, data, callback))
+            socket.on(MessageTypes.LeaveWorld.toString(), (data, callback) => handleLeaveWorld(socket, data, callback))
 
-          socket.on(MessageTypes.WebRTCTransportCreate.toString(), async (data: WebRtcTransportParams, callback) =>
-            handleWebRtcTransportCreate(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCTransportCreate.toString(), async (data: WebRtcTransportParams, callback) =>
+              handleWebRtcTransportCreate(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCProduceData.toString(), async (data, callback) =>
-            handleWebRtcProduceData(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCProduceData.toString(), async (data, callback) =>
+              handleWebRtcProduceData(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCTransportConnect.toString(), async (data, callback) =>
-            handleWebRtcTransportConnect(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCTransportConnect.toString(), async (data, callback) =>
+              handleWebRtcTransportConnect(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCTransportClose.toString(), async (data, callback) =>
-            handleWebRtcTransportClose(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCTransportClose.toString(), async (data, callback) =>
+              handleWebRtcTransportClose(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCCloseProducer.toString(), async (data, callback) =>
-            handleWebRtcCloseProducer(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCCloseProducer.toString(), async (data, callback) =>
+              handleWebRtcCloseProducer(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCSendTrack.toString(), async (data, callback) =>
-            handleWebRtcSendTrack(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCSendTrack.toString(), async (data, callback) =>
+              handleWebRtcSendTrack(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCReceiveTrack.toString(), async (data, callback) =>
-            handleWebRtcReceiveTrack(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCReceiveTrack.toString(), async (data, callback) =>
+              handleWebRtcReceiveTrack(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCPauseConsumer.toString(), async (data, callback) =>
-            handleWebRtcPauseConsumer(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCPauseConsumer.toString(), async (data, callback) =>
+              handleWebRtcPauseConsumer(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCResumeConsumer.toString(), async (data, callback) =>
-            handleWebRtcResumeConsumer(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCResumeConsumer.toString(), async (data, callback) =>
+              handleWebRtcResumeConsumer(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCCloseConsumer.toString(), async (data, callback) =>
-            handleWebRtcCloseConsumer(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCCloseConsumer.toString(), async (data, callback) =>
+              handleWebRtcCloseConsumer(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCConsumerSetLayers.toString(), async (data, callback) =>
-            handleWebRtcConsumerSetLayers(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCConsumerSetLayers.toString(), async (data, callback) =>
+              handleWebRtcConsumerSetLayers(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCResumeProducer.toString(), async (data, callback) =>
-            handleWebRtcResumeProducer(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCResumeProducer.toString(), async (data, callback) =>
+              handleWebRtcResumeProducer(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCPauseProducer.toString(), async (data, callback) =>
-            handleWebRtcPauseProducer(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCPauseProducer.toString(), async (data, callback) =>
+              handleWebRtcPauseProducer(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.WebRTCRequestCurrentProducers.toString(), async (data, callback) =>
-            handleWebRtcRequestCurrentProducers(socket, data, callback)
-          )
+            socket.on(MessageTypes.WebRTCRequestCurrentProducers.toString(), async (data, callback) =>
+              handleWebRtcRequestCurrentProducers(socket, data, callback)
+            )
 
-          socket.on(MessageTypes.UpdateNetworkState.toString(), async (data) =>
-            handleNetworkStateUpdate(socket, data, true)
-          )
+            socket.on(MessageTypes.UpdateNetworkState.toString(), async (data) =>
+              handleNetworkStateUpdate(socket, data, true)
+            )
 
-          socket.on(MessageTypes.InitializeRouter.toString(), async (data, callback) =>
-            handleWebRtcInitializeRouter(socket, data, callback)
-          )
+            socket.on(MessageTypes.InitializeRouter.toString(), async (data, callback) =>
+              handleWebRtcInitializeRouter(socket, data, callback)
+            )
+          }
         })
       })
   }

--- a/packages/gameserver/src/WebRTCFunctions.ts
+++ b/packages/gameserver/src/WebRTCFunctions.ts
@@ -403,14 +403,7 @@ export async function handleWebRtcProduceData(socket, data, callback): Promise<a
     appData: { ...(appData || {}), peerID: userId, transportId }
   }
   if (transport != null) {
-    console.log('handleWebRtcProduceData', transport)
-    let dataProducer
-    try {
-      dataProducer = await transport.produceData(options)
-    } catch (err) {
-      console.log('Error with transport produceData', err)
-      throw err
-    }
+    const dataProducer = await transport.produceData(options)
     networkTransport.dataProducers.push(dataProducer)
     logger.info(`user ${userId} producing data`)
     if (Network.instance.clients[userId] != null) {

--- a/packages/gameserver/src/app.ts
+++ b/packages/gameserver/src/app.ts
@@ -163,9 +163,7 @@ export const createApp = (): Application => {
         ;(app as any).agonesSDK = agonesSDK
         setInterval(() => agonesSDK.health(), 1000)
 
-        console.log('Configuring GS channels')
         app.configure(channels)
-        console.log('GS channels configuration complete')
 
         WebRTCGameServer.instance.initialize(app).then(() => {
           console.log('Initialized new gameserver instance')

--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -22,9 +22,7 @@ export default (app: Application): void => {
   }
 
   app.on('connection', async (connection) => {
-    console.log('New connection', connection)
     await awaitEngineLoaded()
-    console.log('Engine has been loaded')
     if (
       (config.kubernetes.enabled && config.gameserver.mode === 'realtime') ||
       process.env.NODE_ENV === 'development' ||


### PR DESCRIPTION
Sending Authorization message at an interval rate was causing multiple socket
listeners to be created if the first call wasn't fully handled within the interval.
SocketWebRTCServerTransport.ts now tracks if the listeners have been created so
that it only makes them once.

Fixed a few bugs with GameServerWarnings.tsx. The noCountdown option should always be
set to override any other case of it being set (though maybe the real issue is that
the WebGL disconnected error is triggering when the real issue is something else,
like a location not existing or a gameserver going down).