### PR TITLE
ECS Internal Fixes

### DIFF
--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -43,7 +43,9 @@ export class World {
   fixedElapsedTime = NaN
   fixedTick = -1
 
-  _removedComponents = new Map<Entity, Set<MappedComponent<any, any>>>()
+  _removedComponentsFixed = new Map<Entity, Set<MappedComponent<any, any>>>()
+  _removedComponentsFree = new Map<Entity, Set<MappedComponent<any, any>>>()
+  _isInFixedPipeline = false
   _pipeline = [] as SystemModuleType<any>[]
 
   physics = new Physics()
@@ -166,10 +168,10 @@ export class World {
     this.delta = delta
     this.elapsedTime = elapsedTime
     for (const system of this.freeSystems) system.execute()
-    for (const [entity, components] of this._removedComponents) {
+    for (const [entity, components] of this._removedComponentsFree) {
       for (const c of components) c.delete(entity)
     }
-    this._removedComponents.clear()
+    this._removedComponentsFree.clear()
   }
 
   async initSystems() {

--- a/packages/engine/src/ecs/functions/ComponentFunctions.ts
+++ b/packages/engine/src/ecs/functions/ComponentFunctions.ts
@@ -114,7 +114,8 @@ export const addComponent = <T, S extends bitECS.ISchema>(
       component[key][entity] = args[key]
     }
   }
-  world._removedComponents.get(entity)?.delete(component)
+  world._removedComponentsFixed.get(entity)?.delete(component)
+  world._removedComponentsFree.get(entity)?.delete(component)
   component.set(entity, args as T & SoAProxy<S>)
   return component.get(entity)
 }
@@ -141,8 +142,10 @@ export const removeComponent = <T, S extends bitECS.ISchema>(
     return
   }
   const componentRef = component.get(entity)
-  const removed = world._removedComponents.get(entity) ?? new Set()
-  world._removedComponents.set(entity, removed.add(component))
+  const removedFixed = world._removedComponentsFixed.get(entity) ?? new Set()
+  world._removedComponentsFixed.set(entity, removedFixed.add(component))
+  const removedFree = world._removedComponentsFree.get(entity) ?? new Set()
+  world._removedComponentsFree.set(entity, removedFree.add(component))
   bitECS.removeComponent(world, component, entity)
   return componentRef
 }

--- a/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
+++ b/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
@@ -33,6 +33,11 @@ export default async function FixedPipelineSystem(world: World, args: { updatesP
 
       for (const s of world.fixedSystems) s.execute()
 
+      for (const [entity, components] of world._removedComponentsFixed) {
+        for (const c of components) c.delete(entity)
+      }
+      world._removedComponentsFixed.clear()
+
       accumulator -= timestep
       ++updatesCount
 

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -225,7 +225,6 @@ const registerServerSystems = async (options: Required<InitializeOptions>) => {
   })
   // Network Incoming Systems
   registerSystem(SystemUpdateType.FIXED_EARLY, import('./networking/systems/IncomingNetworkSystem'))
-  registerSystem(SystemUpdateType.FIXED_EARLY, import('./networking/systems/MediaStreamSystem'))
 
   registerInjectedSystems(SystemUpdateType.FIXED_EARLY, options.systems)
 

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -50,7 +50,7 @@ export default async function PhysicsSystem(
   world: World,
   attributes: { simulationEnabled?: boolean }
 ): Promise<System> {
-  const colliderQuery = defineQuery([ColliderComponent, TransformComponent])
+  const colliderQuery = defineQuery([ColliderComponent])
   const raycastQuery = defineQuery([RaycastComponent])
   const collisionComponent = defineQuery([CollisionComponent])
   const networkColliderQuery = defineQuery([NetworkObjectComponent, ColliderComponent])


### PR DESCRIPTION
- [x] seperate component removal handling for fixed and free pipelines
- [ ] fix hasComponent returning false for removed components that have not been cleaned up
- [ ] add back third option getComponent to return removed components that have not been cleaned up