### PR TITLE
Update Mediasoup to new Meson build system

### DIFF
--- a/packages/gameserver/package.json
+++ b/packages/gameserver/package.json
@@ -86,7 +86,7 @@
     "internal-ip": "6.2.0",
     "js-yaml": "4.1.0",
     "lodash": "4.17.21",
-    "mediasoup": "3.8.4",
+    "mediasoup": "3.9.0",
     "mime-types": "2.1.33",
     "moment": "2.29.1",
     "multer": "1.4.3",


### PR DESCRIPTION
This replaces Mediasoup's node-gyp build system with Meson. This should make installation success dramatically higher, since it reduces many of the installation requirements on the C++ side.

More info here:
https://github.com/versatica/mediasoup/pull/622