### PR TITLE
Fixes for deployment process.

### DIFF
--- a/Dockerfile-build-deploy
+++ b/Dockerfile-build-deploy
@@ -5,9 +5,6 @@ RUN apt update
 # Create app directory
 WORKDIR /app
 
-# copy then compile the code
-COPY . .
-
 RUN npm run build-docker
 
 ENV APP_ENV=production

--- a/packages/client-core/src/social/state/CreatorService.ts
+++ b/packages/client-core/src/social/state/CreatorService.ts
@@ -4,7 +4,7 @@
 import { AlertService } from '../../common/state/AlertService'
 import { client } from '../../feathers'
 import { Creator } from '@xrengine/common/src/interfaces/Creator'
-import { upload } from '../../../util/upload'
+import { upload } from '../../util/upload'
 import { Dispatch, bindActionCreators } from 'redux'
 
 import { CreatorAction } from './CreatorActions'

--- a/packages/ops/xrengine-builder/templates/builder-deployment.yaml
+++ b/packages/ops/xrengine-builder/templates/builder-deployment.yaml
@@ -72,12 +72,14 @@ spec:
                 - cat
                 - ./builder-started.txt
             initialDelaySeconds: 30
+            periodSeconds: 600
           readinessProbe:
             exec:
               command:
                 - cat
                 - ./builder-started.txt
             initialDelaySeconds: 30
+            periodSeconds: 600
           resources:
             {{- toYaml .Values.builder.resources | nindent 12 }}
         - name: dind

--- a/packages/social/src/components/TheFeedsCard/index.tsx
+++ b/packages/social/src/components/TheFeedsCard/index.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch } from '@xrengine/client-core/src/store'
 import { bindActionCreators, Dispatch } from 'redux'
 import { useCreatorState } from '@xrengine/client-core/src/social/state/CreatorState'
-import { TheFeedsFiresService } from '@xrengine/client-core/src/user/state/TheFeedsFiresService'
+import { TheFeedsFiresService } from '@xrengine/client-core/src/social/state/TheFeedsFiresService'
 import CreatorAsTitle from '../CreatorAsTitle'
 import styles from './TheFeedsCard.module.scss'
 

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -5,6 +5,8 @@ set -x
 STAGE=$1
 LABEL=$2
 
+docker container prune --force
+docker image prune --force
 
 aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
 


### PR DESCRIPTION
build-docker now prunes old containers and images.
Seeing if removing the `COPY . .` from Dockerfile-build-deploy
still works. The starting workdir of the builder image is /app, and
if we're putting the final image in /app, it should be the same directory,
meaning we don't have to copy anything.

Setting builder probe periodSeconds to 10 minutes, since sometimes the build process
seems to make the pod semi-unresponsive.