### PR TITLE
Updated Docker build to use BuildKit.

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -20,8 +20,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-            package-lock.json
-          key: ${{ runner.os }}-branch-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-branch-${{ hashFiles('**/package.json') }}
       - run: npm install --production=false --loglevel notice --legacy-peer-deps
       - run: npm run lint
       - run: npm run test:packages

--- a/Dockerfile-build-deploy
+++ b/Dockerfile-build-deploy
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
 FROM node:16-buster
 

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
 FROM node:16-buster
 

--- a/packages/ops/xrengine-builder/templates/builder-deployment.yaml
+++ b/packages/ops/xrengine-builder/templates/builder-deployment.yaml
@@ -59,7 +59,9 @@ spec:
             - name: RELEASE_NAME
               value: {{ $releaseName }}
             - name: DOCKER_HOST
-              value: tcp://localhost:2375
+              value: tcp://localhost:2376
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
             - name: TAG
               value: {{ .Values.builder.image.tag }}
           ports:
@@ -82,10 +84,16 @@ spec:
             periodSeconds: 600
           resources:
             {{- toYaml .Values.builder.resources | nindent 12 }}
+          volumeMounts:
+            - name: dind-storage
+              mountPath: /var/lib/docker
         - name: dind
-          image: docker:18.05-dind
+          image: docker:20.10-dind
           securityContext:
             privileged: true
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: /var/lib/docker/certs
           volumeMounts:
             - name: dind-storage
               mountPath: /var/lib/docker

--- a/packages/ops/xrengine/Chart.yaml
+++ b/packages/ops/xrengine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.4
+version: 3.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -10,5 +10,5 @@ docker image prune --force
 
 aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
 
-docker pull $ECR_URL/$REPO_NAME:latest_$STAGE || true
-docker build --cache-from $ECR_URL/$REPO_NAME:latest_$STAGE --tag $LABEL -f Dockerfile-build-deploy .
+#docker pull $ECR_URL/$REPO_NAME:latest_$STAGE || true
+DOCKER_BUILDKIT=1 docker build --cache-from $ECR_URL/$REPO_NAME:latest_$STAGE --build-arg BUILDKIT_INLINE_CACHE=1 --tag $LABEL -f Dockerfile-build-deploy .

--- a/scripts/build_docker_builder.sh
+++ b/scripts/build_docker_builder.sh
@@ -8,5 +8,5 @@ LABEL=$2
 
 aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
 
-docker pull $ECR_URL/$REPO_NAME-builder:latest_$STAGE || true
-docker build --cache-from $ECR_URL/$REPO_NAME-builder:latest_$STAGE --tag $LABEL -f Dockerfile-builder .
+#docker pull $ECR_URL/$REPO_NAME-builder:latest_$STAGE || true
+DOCKER_BUILDKIT=1 docker build --cache-from $ECR_URL/$REPO_NAME-builder:latest_$STAGE --build-arg BUILDKIT_INLINE_CACHE=1 --tag $LABEL -f Dockerfile-builder .

--- a/scripts/cleanup_builder.sh
+++ b/scripts/cleanup_builder.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+set -x
+
+TAG=$1
+LABEL=$2
+
+docker image prune -f
+IMAGE_ID="$(docker images $LABEL:latest --format {{.ID}})"
+docker image rm -f $IMAGE_ID

--- a/scripts/publish_ecr.sh
+++ b/scripts/publish_ecr.sh
@@ -7,11 +7,6 @@ TAG=$2
 LABEL=$3
 REGION=$4
 
-echo "publish_ecr paramters"
-echo $STAGE
-echo $TAG
-echo $LABEL
-echo $REGION
 aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
 node ./scripts/prune_ecr_images.js --repoName $REPO_NAME --region $REGION --public true
 

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -3,6 +3,8 @@ set -e
 set -x
 
 CURRENT_TIME=`date +"%d-%m-%yT%H-%M-%S"`
+mkdir -pv ~/.docker
+cp -v /var/lib/docker/certs/client/* ~/.docker
 touch ./builder-started.txt
 sh ./scripts/setup_helm.sh
 sh ./scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAME
@@ -14,4 +16,5 @@ echo ${TAG}__${CURRENT_TIME}
 sh ./scripts/publish_ecr.sh $RELEASE_NAME ${TAG}__${CURRENT_TIME} $DOCKER_LABEL $AWS_REGION
 sh ./scripts/deploy.sh $RELEASE_NAME ${TAG}__${CURRENT_TIME}
 sh ./scripts/publish_dockerhub.sh ${TAG}__${CURRENT_TIME} $DOCKER_LABEL
+sh ./scripts/cleanup_builder.sh ${TAG}__${CURRENT_TIME} $DOCKER_LABEL
 sleep infinity


### PR DESCRIPTION
BuildKit is sometimes faster than the default Docker builder.

Had to update Docker version of dind, and since TLS is on by default,
updated builder pod to use the certs that dind generates.

Builder now cleans up local images once they're built.