### PR TITLE
loadRoute return empty array if route is not in project

### DIFF
--- a/packages/projects/loadRoute.ts
+++ b/packages/projects/loadRoute.ts
@@ -1,4 +1,4 @@
 export const loadRoute = async (project: string, route: string) => {
   const { default: getPage } = await import(`./projects/${project}/routes.tsx`)
-  return getPage(route)
+  return getPage(route) ?? []
 }


### PR DESCRIPTION
loadRoute return empty array if route is not returned by getPage of project
will fix: "TypeError: (intermediate value) is not iterable (cannot read property undefined)"