### PR TITLE
Updated api server cluster role with new permissions.

### DIFF
--- a/packages/ops/xrengine/Chart.yaml
+++ b/packages/ops/xrengine/Chart.yaml
@@ -7,14 +7,14 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.5
+version: 3.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.4.0
 
 
-dependencies:
+#dependencies:
   #https://bitnami.com/stack/mariadb/helm
 #  - name: mariadb
 #    version: "7.3.16"

--- a/packages/ops/xrengine/templates/api-server-cluster-role.yaml
+++ b/packages/ops/xrengine/templates/api-server-cluster-role.yaml
@@ -11,10 +11,15 @@ rules:
     resources:
       - pods
       - endpoints
+      - deployments
     verbs:
       - get
       - list
       - watch
+      - create
+      - update
+      - delete
+      - patch
   - apiGroups:
       - "agones.dev"
     resources:

--- a/packages/ops/xrengine/templates/game-server-cluster-role.yaml
+++ b/packages/ops/xrengine/templates/game-server-cluster-role.yaml
@@ -14,12 +14,14 @@ rules:
       - services
       - configmaps
       - endpoints
+      - deployments
     verbs:
       - get
       - list
       - watch
       - create
       - update
+      - patch
       - delete
   - apiGroups:
     - "networking.k8s.io"


### PR DESCRIPTION
The API server needs to be able to patch the builder deployment or pods
when a project is updated so that it'll be rebuilt. Added create, update,
patch, and delete as allowed verbs, and added deployments as a core resource
that api-server can access.

Also added deployments and patch to gameserver cluster role just in case.