### PR TITLE
Improve Transform Editor

### DIFF
--- a/packages/editor/src/classes/TransformGizmoComponent.ts
+++ b/packages/editor/src/classes/TransformGizmoComponent.ts
@@ -40,7 +40,7 @@ import { addObjectToGroup, removeObjectFromGroup } from '@etherealengine/engine/
 import { NameComponent } from '@etherealengine/engine/src/scene/components/NameComponent'
 import { VisibleComponent } from '@etherealengine/engine/src/scene/components/VisibleComponent'
 import { ObjectLayers } from '@etherealengine/engine/src/scene/constants/ObjectLayers'
-import { SnapMode, TransformPivot, TransformSpace } from '@etherealengine/engine/src/scene/constants/transformConstants'
+import { SnapMode, TransformPivot } from '@etherealengine/engine/src/scene/constants/transformConstants'
 import { setObjectLayers } from '@etherealengine/engine/src/scene/functions/setObjectLayers'
 import { TransformComponent } from '@etherealengine/engine/src/transform/components/TransformComponent'
 import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
@@ -78,7 +78,7 @@ export const TransformGizmoComponent = defineComponent({
           [entity],
           [new Euler().setFromQuaternion(transformComponent.value.rotation)]
         )
-        EditorControlFunctions.scaleObject([entity], [transformComponent.value.scale], TransformSpace.local, true)
+        EditorControlFunctions.scaleObject([entity], [transformComponent.value.scale], true)
         EditorControlFunctions.commitTransformSave([entity])
       })
 

--- a/packages/editor/src/components/properties/TransformPropertyGroup.tsx
+++ b/packages/editor/src/components/properties/TransformPropertyGroup.tsx
@@ -34,12 +34,11 @@ import {
   useOptionalComponent
 } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { SceneDynamicLoadTagComponent } from '@etherealengine/engine/src/scene/components/SceneDynamicLoadTagComponent'
-import { TransformSpace } from '@etherealengine/engine/src/scene/constants/transformConstants'
 import { TransformComponent } from '@etherealengine/engine/src/transform/components/TransformComponent'
 import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 
-import { EntityTreeComponent } from '@etherealengine/engine/src/ecs/functions/EntityTree'
 import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
+import { EditorHelperState } from '../../services/EditorHelperState'
 import { SelectionState } from '../../services/SelectionServices'
 import BooleanInput from '../inputs/BooleanInput'
 import CompoundNumericInput from '../inputs/CompoundNumericInput'
@@ -60,13 +59,15 @@ export const TransformPropertyGroup: EditorComponentType = (props) => {
   const { t } = useTranslation()
 
   useOptionalComponent(props.entity, SceneDynamicLoadTagComponent)
-  const hasParentTransform = useOptionalComponent(props.entity, EntityTreeComponent)?.parentEntity?.value
   const transformComponent = useComponent(props.entity, TransformComponent)
-  const useGlobalTransformComponent = useHookstate(false)
+  const transformSpace = useHookstate(getMutableState(EditorHelperState).transformSpace)
 
-  useGlobalTransformComponent.value
+  transformSpace.value
     ? transformComponent.matrixWorld.value.decompose(position, rotation, scale)
     : transformComponent.matrix.value.decompose(position, rotation, scale)
+
+  /** Scaling only makes sense in local scale */
+  scale.copy(transformComponent.scale.value)
 
   const onRelease = () => {
     EditorControlFunctions.commitTransformSave([props.entity])
@@ -79,36 +80,17 @@ export const TransformPropertyGroup: EditorComponentType = (props) => {
 
   const onChangePosition = (value: Vector3) => {
     const nodes = getMutableState(SelectionState).selectedEntities.value
-    EditorControlFunctions.positionObject(
-      nodes,
-      [value],
-      useGlobalTransformComponent.value ? TransformSpace.world : TransformSpace.local
-    )
-    TransformComponent.stateMap[props.entity]!.set(TransformComponent.valueMap[props.entity])
+    EditorControlFunctions.positionObject(nodes, [value])
   }
 
   const onChangeRotation = (value: Euler) => {
     const nodes = getMutableState(SelectionState).selectedEntities.value
-    EditorControlFunctions.rotateObject(
-      nodes,
-      [value],
-      useGlobalTransformComponent.value ? TransformSpace.world : TransformSpace.local
-    )
-    TransformComponent.stateMap[props.entity]!.set(TransformComponent.valueMap[props.entity])
+    EditorControlFunctions.rotateObject(nodes, [value])
   }
 
   const onChangeScale = (value: Vector3) => {
-    if (useGlobalTransformComponent.value) {
-      transformComponent.scale.set(transformComponent.value.scale.copy(value))
-    }
     const nodes = getMutableState(SelectionState).selectedEntities.value
-    EditorControlFunctions.scaleObject(
-      nodes,
-      [value],
-      useGlobalTransformComponent.value ? TransformSpace.world : TransformSpace.local,
-      true
-    )
-    TransformComponent.stateMap[props.entity]!.set(TransformComponent.valueMap[props.entity])
+    EditorControlFunctions.scaleObject(nodes, [value], true)
   }
 
   return (
@@ -127,14 +109,6 @@ export const TransformPropertyGroup: EditorComponentType = (props) => {
           />
         )}
       </InputGroup>
-      {hasParentTransform && (
-        <InputGroup name="Use Global Transform" label={t('editor:properties.transform.lbl-useGlobalTransform')}>
-          <BooleanInput
-            value={useGlobalTransformComponent.value}
-            onChange={() => useGlobalTransformComponent.set((prev) => !prev)}
-          />
-        </InputGroup>
-      )}
       <InputGroup name="Position" label={t('editor:properties.transform.lbl-position')}>
         <Vector3Input
           value={position}

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 import { Euler, Material, MathUtils, Matrix4, Mesh, Quaternion, Vector3 } from 'three'
 
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
-import logger from '@etherealengine/engine/src/common/functions/logger'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { Entity } from '@etherealengine/engine/src/ecs/classes/Entity'
 import { SceneSnapshotAction, SceneState } from '@etherealengine/engine/src/ecs/classes/Scene'
@@ -48,17 +47,18 @@ import {
 import { materialFromId } from '@etherealengine/engine/src/renderer/materials/functions/MaterialLibraryFunctions'
 import { MaterialLibraryState } from '@etherealengine/engine/src/renderer/materials/MaterialLibrary'
 import { UUIDComponent } from '@etherealengine/engine/src/scene/components/UUIDComponent'
-import { TransformSpace, TransformSpaceType } from '@etherealengine/engine/src/scene/constants/transformConstants'
+import { TransformSpace } from '@etherealengine/engine/src/scene/constants/transformConstants'
 import obj3dFromUuid from '@etherealengine/engine/src/scene/util/obj3dFromUuid'
 import { TransformComponent } from '@etherealengine/engine/src/transform/components/TransformComponent'
 import { dispatchAction, getMutableState, getState } from '@etherealengine/hyperflux'
 
 import { ComponentJsonType, SceneID } from '@etherealengine/common/src/schema.type.module'
 import { getNestedObject } from '@etherealengine/common/src/utils/getNestedProperty'
+import { RigidBodyComponent } from '@etherealengine/engine/src/physics/components/RigidBodyComponent'
 import { SceneObjectComponent } from '@etherealengine/engine/src/scene/components/SceneObjectComponent'
 import { SourceComponent } from '@etherealengine/engine/src/scene/components/SourceComponent'
 import { VisibleComponent } from '@etherealengine/engine/src/scene/components/VisibleComponent'
-import { computeTransformMatrix } from '@etherealengine/engine/src/transform/systems/TransformSystem'
+import { EditorHelperState } from '../services/EditorHelperState'
 import { SelectionState } from '../services/SelectionServices'
 import { filterParentEntities } from './filterParentEntities'
 import { getDetachedObjectsRoots } from './getDetachedObjectsRoots'
@@ -319,35 +319,42 @@ const tempVector = new Vector3()
 const positionObject = (
   nodes: Entity[],
   positions: Vector3[],
-  space: TransformSpaceType = 'local',
+  space = getState(EditorHelperState).transformSpace,
   addToPosition?: boolean
 ) => {
   for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i]
+    const entity = nodes[i]
     const pos = positions[i] ?? positions[0]
 
-    const transform = getComponent(node, TransformComponent)
+    const transform = getComponent(entity, TransformComponent)
 
     if (space === TransformSpace.local) {
       if (addToPosition) transform.position.add(pos)
       else transform.position.copy(pos)
     } else {
-      const entityTreeComponent = getComponent(node, EntityTreeComponent)
+      const entityTreeComponent = getComponent(entity, EntityTreeComponent)
       const parentTransform = entityTreeComponent.parentEntity
         ? getComponent(entityTreeComponent.parentEntity, TransformComponent)
         : transform
 
+      tempVector.set(0, 0, 0)
       if (addToPosition) {
         tempVector.setFromMatrixPosition(transform.matrixWorld)
-        tempVector.add(pos)
       }
+      tempVector.add(pos)
 
       const _spaceMatrix = parentTransform.matrixWorld
       tempMatrix.copy(_spaceMatrix).invert()
       tempVector.applyMatrix4(tempMatrix)
 
       transform.position.copy(tempVector)
-      updateComponent(node, TransformComponent, { position: transform.position })
+    }
+
+    updateComponent(entity, TransformComponent, { position: transform.position })
+
+    if (hasComponent(entity, RigidBodyComponent)) {
+      getComponent(entity, RigidBodyComponent).position.copy(transform.position)
+      getComponent(entity, RigidBodyComponent).body.setTranslation(transform.position, true)
     }
   }
 }
@@ -355,18 +362,18 @@ const positionObject = (
 const T_QUAT_1 = new Quaternion()
 const T_QUAT_2 = new Quaternion()
 
-const rotateObject = (nodes: Entity[], rotations: Euler[], space: TransformSpaceType = TransformSpace.local) => {
+const rotateObject = (nodes: Entity[], rotations: Euler[], space = getState(EditorHelperState).transformSpace) => {
   for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i]
+    const entity = nodes[i]
 
-    const transform = getComponent(node, TransformComponent)
+    const transform = getComponent(entity, TransformComponent)
 
     T_QUAT_1.setFromEuler(rotations[i] ?? rotations[0])
 
     if (space === TransformSpace.local) {
       transform.rotation.copy(T_QUAT_1)
     } else {
-      const entityTreeComponent = getComponent(node, EntityTreeComponent)
+      const entityTreeComponent = getComponent(entity, EntityTreeComponent)
       const parentTransform = entityTreeComponent.parentEntity
         ? getComponent(entityTreeComponent.parentEntity, TransformComponent)
         : transform
@@ -376,8 +383,14 @@ const rotateObject = (nodes: Entity[], rotations: Euler[], space: TransformSpace
       const inverseParentWorldQuaternion = T_QUAT_2.setFromRotationMatrix(_spaceMatrix).invert()
       const newLocalQuaternion = inverseParentWorldQuaternion.multiply(T_QUAT_1)
 
-      updateComponent(node, TransformComponent, { rotation: newLocalQuaternion })
-      computeTransformMatrix(node)
+      transform.rotation.copy(newLocalQuaternion)
+    }
+
+    updateComponent(entity, TransformComponent, { rotation: transform.rotation })
+
+    if (hasComponent(entity, RigidBodyComponent)) {
+      getComponent(entity, RigidBodyComponent).rotation.copy(transform.rotation)
+      getComponent(entity, RigidBodyComponent).body.setRotation(transform.rotation, true)
     }
   }
 }
@@ -405,20 +418,15 @@ const rotateAround = (entities: Entity[], axis: Vector3, angle: number, pivot: V
       .decompose(transform.position, transform.rotation, transform.scale)
 
     updateComponent(entity, TransformComponent, { rotation: transform.rotation })
+
+    if (hasComponent(entity, RigidBodyComponent)) {
+      getComponent(entity, RigidBodyComponent).rotation.copy(transform.rotation)
+      getComponent(entity, RigidBodyComponent).body.setRotation(transform.rotation, true)
+    }
   }
 }
 
-const scaleObject = (
-  entities: Entity[],
-  scales: Vector3[],
-  space: TransformSpaceType = 'local',
-  overrideScale = false
-) => {
-  if (space === TransformSpace.world) {
-    logger.warn('Scaling an object in world space with a non-uniform scale is not supported')
-    return
-  }
-
+const scaleObject = (entities: Entity[], scales: Vector3[], overrideScale = false) => {
   for (let i = 0; i < entities.length; i++) {
     const entity = entities[i]
     const scale = scales[i] ?? scales[0]


### PR DESCRIPTION
## Summary

- Fixes bugs with colliders not updating from transform changes and clean up transform editor.
- Removes `Use Global Transforms` option as it is redundant with the World/Object drop down

## References
closes https://github.com/EtherealEngine/etherealengine/issues/9599

## QA Steps
