### PR TITLE
Fixed imports of vite.config.extension.ts from projects

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -135,11 +135,13 @@ const getProjectConfigExtensions = async (config: UserConfig) => {
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name)
   for (const project of projects) {
-    const staticPath = path.resolve(__dirname, `../projects/projects/`, project, 'vite.config.extension')
+    const staticPath = path.resolve(__dirname, `../projects/projects/`, project, 'vite.config.extension.ts')
     if (fs.existsSync(staticPath)) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { default: viteConfigExtension } = await import(staticPath)
+        const { default: viteConfigExtension } = await import(
+          `../projects/projects/${project}/vite.config.extension.ts`
+        )
         if (typeof viteConfigExtension === 'function') {
           const configExtension = await viteConfigExtension()
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## Summary

Path that was being used for fs.existsSync was not correct, missing .ts on the end, so no extensions were being found or applied.

Import of extensions from correct staticPath triggers a TypeError: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"

This is a known issue with vite importing from files in other packages in a monorepo: https://github.com/vitejs/vite/issues/5370

For now, using the workaround of importing via the relative path. Switching to bun will apparently solve this.


## References
closes #_insert number here_

## QA Steps
