### PR TITLE
fix multiple history push when redirecting to homepage from admin

### DIFF
--- a/packages/client-core/src/admin/adminRoutes.tsx
+++ b/packages/client-core/src/admin/adminRoutes.tsx
@@ -65,8 +65,13 @@ const AdminRoutes = () => {
     }
   }, [scopes])
 
+  useEffect(() => {
+    if (admin?.id?.value?.length! > 0 && !admin?.scopes?.value?.find((scope) => scope.type === 'admin:admin')) {
+      RouterState.navigate('/', { redirectUrl: location.pathname })
+    }
+  }, [admin])
+
   if (admin?.id?.value?.length! > 0 && !admin?.scopes?.value?.find((scope) => scope.type === 'admin:admin')) {
-    RouterState.navigate('/', { redirectUrl: location.pathname })
     return <></>
   }
 


### PR DESCRIPTION
## Summary

Fix multiple browser history pushes when opening admin panel in unauthenticated mode. This is unsupported across many browsers which can throw an [error](https://crbug.com/1038223)

## References
closes #_insert number here_

## QA Steps

#### Earlier

Multiple history push using react-router `navigate`

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/7a5c69dc-ed10-4ad2-b7f8-c03a94231809)


#### Now

No multiple history pushes

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/6f30cd65-8745-4640-94a4-a5f3d5dc8cfd)
