### PR TITLE
Added publish locations in studio

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -178,6 +178,11 @@
     "sceneScreenshot": {
       "lbl": "Screenshot",
       "info": "Takes a screenshot of your scene at the current view."
+    },
+    "publishLocation": {
+      "title": "Publish",
+      "lbl": "Publish Location",
+      "info": "Publish location for the selected scene."
     }
   },
   "properties": {

--- a/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
+++ b/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
@@ -56,6 +56,7 @@ interface Props {
   mode: LocationDrawerMode
   selectedLocation?: LocationType
   onClose: () => void
+  selectedScene?: SceneID | null
 }
 
 const defaultState = {
@@ -77,7 +78,7 @@ const defaultState = {
   }
 }
 
-const LocationDrawer = ({ open, mode, selectedLocation, onClose }: Props) => {
+const LocationDrawer = ({ open, mode, selectedLocation, selectedScene, onClose }: Props) => {
   const { t } = useTranslation()
   const editMode = useHookstate(false)
   const state = useHookstate({ ...defaultState })
@@ -91,12 +92,26 @@ const LocationDrawer = ({ open, mode, selectedLocation, onClose }: Props) => {
   const hasWriteAccess = user.scopes.get(NO_PROXY)?.find((item) => item?.type === 'location:write')
   const viewMode = mode === LocationDrawerMode.ViewEdit && !editMode.value
 
-  const sceneMenu: InputMenuItem[] = scenes.get(NO_PROXY).map((el) => {
-    return {
-      value: `${el.project}/${el.name}`,
-      label: `${el.name} (${el.project})`
-    }
-  })
+  const sceneName = selectedScene
+    ? selectedScene.replace(`${selectedScene.split('/', 1)[0]}/`, '').replace('.scene.json', '')
+    : ''
+  const projectName = selectedScene ? selectedScene.split('/', 1)[0].replace : ''
+
+  if (selectedScene) state.scene.set(sceneName)
+
+  const sceneMenu: InputMenuItem[] = selectedScene
+    ? [
+        {
+          value: `${projectName}/${sceneName}`,
+          label: `${sceneName} (${projectName})`
+        }
+      ]
+    : scenes.get(NO_PROXY).map((el) => {
+        return {
+          value: `${el.project}/${el.name}`,
+          label: `${el.name} (${el.project})`
+        }
+      })
 
   // const locationTypesMenu: InputMenuItem[] = locationTypes.map((el) => {
   //   return {
@@ -106,7 +121,7 @@ const LocationDrawer = ({ open, mode, selectedLocation, onClose }: Props) => {
   // })
 
   useEffect(() => {
-    AdminSceneService.fetchAdminScenes()
+    if (!selectedScene) AdminSceneService.fetchAdminScenes()
   }, [])
 
   useEffect(() => {

--- a/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
+++ b/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
@@ -95,7 +95,7 @@ const LocationDrawer = ({ open, mode, selectedLocation, selectedScene, onClose }
   const sceneName = selectedScene ? selectedScene.split('/')[1] : ''
   const projectName = selectedScene ? selectedScene.split('/', 1)[0] : ''
 
-  if (selectedScene) state.scene.set(sceneName)
+  if (selectedScene) state.scene.set(selectedScene)
 
   const sceneMenu: InputMenuItem[] = selectedScene
     ? [
@@ -259,7 +259,7 @@ const LocationDrawer = ({ open, mode, selectedLocation, selectedScene, onClose }
           value={state?.value?.scene}
           error={state?.value?.formErrors?.scene}
           menu={sceneMenu}
-          disabled={viewMode}
+          disabled={viewMode || selectedScene !== undefined}
           onChange={handleChange}
         />
 

--- a/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
+++ b/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
@@ -95,7 +95,9 @@ const LocationDrawer = ({ open, mode, selectedLocation, selectedScene, onClose }
   const sceneName = selectedScene ? selectedScene.split('/')[1] : ''
   const projectName = selectedScene ? selectedScene.split('/', 1)[0] : ''
 
-  if (selectedScene) state.scene.set(selectedScene)
+  useEffect(() => {
+    if (selectedScene) state.scene.set(selectedScene)
+  }, [selectedScene])
 
   const sceneMenu: InputMenuItem[] = selectedScene
     ? [

--- a/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
+++ b/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
@@ -92,10 +92,8 @@ const LocationDrawer = ({ open, mode, selectedLocation, selectedScene, onClose }
   const hasWriteAccess = user.scopes.get(NO_PROXY)?.find((item) => item?.type === 'location:write')
   const viewMode = mode === LocationDrawerMode.ViewEdit && !editMode.value
 
-  const sceneName = selectedScene
-    ? selectedScene.replace(`${selectedScene.split('/', 1)[0]}/`, '').replace('.scene.json', '')
-    : ''
-  const projectName = selectedScene ? selectedScene.split('/', 1)[0].replace : ''
+  const sceneName = selectedScene ? selectedScene.split('/')[1] : ''
+  const projectName = selectedScene ? selectedScene.split('/', 1)[0] : ''
 
   if (selectedScene) state.scene.set(sceneName)
 

--- a/packages/editor/src/components/projects/styles.module.scss
+++ b/packages/editor/src/components/projects/styles.module.scss
@@ -3,7 +3,6 @@
   align-items: center;
   color: var(--textColor);
   background: transparent;
-  margin-left: auto;
 
   span {
     margin-right: 5px;

--- a/packages/editor/src/components/toolbar/ToolBar.tsx
+++ b/packages/editor/src/components/toolbar/ToolBar.tsx
@@ -35,6 +35,7 @@ import * as styles from './styles.module.scss'
 import GridTool from './tools/GridTool'
 import HelperToggleTool from './tools/HelperToggleTool'
 import PlayModeTool from './tools/PlayModeTool'
+import PublishLocation from './tools/PublishLocation'
 import RenderModeTool from './tools/RenderModeTool'
 import SceneScreenshot from './tools/SceneScreenshot'
 import StatsTool from './tools/StatsTool'
@@ -64,6 +65,7 @@ export const ToolBar = (props: ToolBarProps) => {
       <StatsTool />
       <HelperToggleTool />
       <SceneScreenshot />
+      <PublishLocation />
       <EditorNavbarProfile />
     </div>
   )

--- a/packages/editor/src/components/toolbar/styles.module.scss
+++ b/packages/editor/src/components/toolbar/styles.module.scss
@@ -118,6 +118,7 @@
     background-color: var(--toolbar);
     border-radius: 4px;
     margin:0;
+    text-transform: none;
 
     &:hover {
       background-color: var(--iconButtonHoverColor);
@@ -129,6 +130,10 @@
       &:hover {
         opacity: 0.8;
       }
+    }
+
+    &:disabled {
+      color: revert;
     }
   }
 
@@ -193,9 +198,4 @@
       }
     }
   }
-}
-
-.btn {
-  color: var(--textColor) !important;
-  text-transform: none;
 }

--- a/packages/editor/src/components/toolbar/styles.module.scss
+++ b/packages/editor/src/components/toolbar/styles.module.scss
@@ -199,3 +199,7 @@
     }
   }
 }
+
+.publishButton {
+  margin-left: auto;
+}

--- a/packages/editor/src/components/toolbar/styles.module.scss
+++ b/packages/editor/src/components/toolbar/styles.module.scss
@@ -194,3 +194,8 @@
     }
   }
 }
+
+.btn {
+  color: var(--textColor) !important;
+  text-transform: none;
+}

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -28,10 +28,11 @@ import React from 'react'
 import LocationDrawer, {
   LocationDrawerMode
 } from '@etherealengine/client-core/src/admin/components/Location/LocationDrawer'
+import { AuthState } from '@etherealengine/client-core/src/user/services/AuthService'
 import { SceneID, locationPath } from '@etherealengine/common/src/schema.type.module'
 import { useFind } from '@etherealengine/engine/src/common/functions/FeathersHooks'
 import { SceneState } from '@etherealengine/engine/src/ecs/classes/Scene'
-import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import { NO_PROXY, getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import { Button } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { InfoTooltip } from '../../layout/Tooltip'
@@ -45,6 +46,8 @@ export const PublishLocation = () => {
     ? (activeScene.value!.replace('.scene.json', '').replace('projects/', '') as SceneID)
     : null
   const drawerMode = useHookstate<LocationDrawerMode>(LocationDrawerMode.Create)
+  const user = useHookstate(getMutableState(AuthState).user)
+  const hasWriteAccess = user.scopes.get(NO_PROXY)?.find((item) => item?.type === 'location:write')
 
   const existingLocation = useFind(locationPath, {
     query: {
@@ -72,7 +75,11 @@ export const PublishLocation = () => {
         className={styles.toolbarInputGroup + ' ' + styles.playButtonContainer + ' ' + styles.publishButton}
       >
         <InfoTooltip title={t('editor:toolbar.publishLocation.lbl')} info={t('editor:toolbar.publishLocation.info')}>
-          <Button onClick={handleOpenLocationDrawer} className={styles.toolButton} disabled={!activeScene.value}>
+          <Button
+            onClick={handleOpenLocationDrawer}
+            className={styles.toolButton}
+            disabled={!activeScene.value || !hasWriteAccess}
+          >
             {t(`editor:toolbar.publishLocation.title`)}
           </Button>
         </InfoTooltip>

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -37,7 +37,7 @@ import { useTranslation } from 'react-i18next'
 import { InfoTooltip } from '../../layout/Tooltip'
 import * as styles from '../styles.module.scss'
 
-export const PubishLocation = () => {
+export const PublishLocation = () => {
   const { t } = useTranslation()
   const openLocationDrawer = useHookstate(false)
   let activeScene = useHookstate(getMutableState(SceneState).activeScene).value
@@ -81,4 +81,4 @@ export const PubishLocation = () => {
   )
 }
 
-export default PubishLocation
+export default PublishLocation

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -60,6 +60,11 @@ export const PublishLocation = () => {
     }
   })
 
+  const handleCloseLocationDrawer = () => {
+    openLocationDrawer.set(false)
+    drawerMode.set(LocationDrawerMode.Create)
+  }
+
   const handleOpenLocationDrawer = async () => {
     existingLocation.refetch()
 
@@ -89,7 +94,7 @@ export const PublishLocation = () => {
         mode={drawerMode.value}
         selectedLocation={existingLocation.data[0]}
         selectedScene={selectedScene}
-        onClose={() => openLocationDrawer.set(false)}
+        onClose={handleCloseLocationDrawer}
       />
     </>
   )

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -40,7 +40,7 @@ import * as styles from '../styles.module.scss'
 export const PubishLocation = () => {
   const { t } = useTranslation()
   const openLocationDrawer = useHookstate(false)
-  const activeScene = useHookstate(getMutableState(SceneState).activeScene)
+  let activeScene = useHookstate(getMutableState(SceneState).activeScene).value
   let drawerMode = LocationDrawerMode.Create
 
   const existingLocation = useFind(locationPath, {
@@ -49,7 +49,7 @@ export const PubishLocation = () => {
       $limit: 1,
       action: 'studio',
       sceneId: {
-        $like: `%${activeScene.value}%` as SceneID
+        $like: `%${activeScene}%` as SceneID
       }
     }
   })
@@ -58,6 +58,7 @@ export const PubishLocation = () => {
     if (existingLocation.data.length > 0) {
       drawerMode = LocationDrawerMode.ViewEdit
     }
+    activeScene = activeScene!.replace('.scene.json', '').replace('projects/', '') as SceneID
     openLocationDrawer.set(true)
   }
 
@@ -65,7 +66,7 @@ export const PubishLocation = () => {
     <>
       <div id="publish-location" className={styles.toolbarInputGroup + ' ' + styles.playButtonContainer}>
         <InfoTooltip title={t('editor:toolbar.publishLocation.lbl')} info={t('editor:toolbar.publishLocation.info')}>
-          <Button onClick={handleOpenLocationDrawer} disabled={!activeScene.value} className={styles.btn}>
+          <Button onClick={handleOpenLocationDrawer} disabled={!activeScene} className={styles.btn}>
             {t(`editor:toolbar.publishLocation.title`)}
           </Button>
         </InfoTooltip>
@@ -73,7 +74,7 @@ export const PubishLocation = () => {
       <LocationDrawer
         open={openLocationDrawer.value}
         mode={drawerMode}
-        selectedScene={activeScene.value}
+        selectedScene={activeScene}
         onClose={() => openLocationDrawer.set(false)}
       />
     </>

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -67,7 +67,10 @@ export const PublishLocation = () => {
 
   return (
     <>
-      <div id="publish-location" className={styles.toolbarInputGroup + ' ' + styles.playButtonContainer}>
+      <div
+        id="publish-location"
+        className={styles.toolbarInputGroup + ' ' + styles.playButtonContainer + ' ' + styles.publishButton}
+      >
         <InfoTooltip title={t('editor:toolbar.publishLocation.lbl')} info={t('editor:toolbar.publishLocation.info')}>
           <Button onClick={handleOpenLocationDrawer} className={styles.toolButton} disabled={!activeScene.value}>
             {t(`editor:toolbar.publishLocation.title`)}

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -40,7 +40,10 @@ import * as styles from '../styles.module.scss'
 export const PublishLocation = () => {
   const { t } = useTranslation()
   const openLocationDrawer = useHookstate(false)
-  let activeScene = useHookstate(getMutableState(SceneState).activeScene).value
+  const activeScene = useHookstate(getMutableState(SceneState).activeScene)
+  const selectedScene = activeScene.value
+    ? (activeScene.value!.replace('.scene.json', '').replace('projects/', '') as SceneID)
+    : null
   let drawerMode = LocationDrawerMode.Create
 
   const existingLocation = useFind(locationPath, {
@@ -49,7 +52,7 @@ export const PublishLocation = () => {
       $limit: 1,
       action: 'studio',
       sceneId: {
-        $like: `%${activeScene}%` as SceneID
+        $like: `%${activeScene.value}%` as SceneID
       }
     }
   })
@@ -58,7 +61,6 @@ export const PublishLocation = () => {
     if (existingLocation.data.length > 0) {
       drawerMode = LocationDrawerMode.ViewEdit
     }
-    activeScene = activeScene!.replace('.scene.json', '').replace('projects/', '') as SceneID
     openLocationDrawer.set(true)
   }
 
@@ -66,7 +68,7 @@ export const PublishLocation = () => {
     <>
       <div id="publish-location" className={styles.toolbarInputGroup + ' ' + styles.playButtonContainer}>
         <InfoTooltip title={t('editor:toolbar.publishLocation.lbl')} info={t('editor:toolbar.publishLocation.info')}>
-          <Button onClick={handleOpenLocationDrawer} disabled={!activeScene} className={styles.btn}>
+          <Button onClick={handleOpenLocationDrawer} className={styles.toolButton} disabled={!activeScene.value}>
             {t(`editor:toolbar.publishLocation.title`)}
           </Button>
         </InfoTooltip>
@@ -74,7 +76,7 @@ export const PublishLocation = () => {
       <LocationDrawer
         open={openLocationDrawer.value}
         mode={drawerMode}
-        selectedScene={activeScene}
+        selectedScene={selectedScene}
         onClose={() => openLocationDrawer.set(false)}
       />
     </>

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -1,0 +1,83 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import React from 'react'
+
+import LocationDrawer, {
+  LocationDrawerMode
+} from '@etherealengine/client-core/src/admin/components/Location/LocationDrawer'
+import { SceneID, locationPath } from '@etherealengine/common/src/schema.type.module'
+import { useFind } from '@etherealengine/engine/src/common/functions/FeathersHooks'
+import { SceneState } from '@etherealengine/engine/src/ecs/classes/Scene'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import { Button } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { InfoTooltip } from '../../layout/Tooltip'
+import * as styles from '../styles.module.scss'
+
+export const PubishLocation = () => {
+  const { t } = useTranslation()
+  const openLocationDrawer = useHookstate(false)
+  const activeScene = useHookstate(getMutableState(SceneState).activeScene)
+  let drawerMode = LocationDrawerMode.Create
+
+  const existingLocation = useFind(locationPath, {
+    query: {
+      $sort: { name: 1 },
+      $limit: 1,
+      action: 'studio',
+      sceneId: {
+        $like: `%${activeScene.value}%` as SceneID
+      }
+    }
+  })
+
+  const handleOpenLocationDrawer = async () => {
+    if (existingLocation.data.length > 0) {
+      drawerMode = LocationDrawerMode.ViewEdit
+    }
+    openLocationDrawer.set(true)
+  }
+
+  return (
+    <>
+      <div id="publish-location" className={styles.toolbarInputGroup + ' ' + styles.playButtonContainer}>
+        <InfoTooltip title={t('editor:toolbar.publishLocation.lbl')} info={t('editor:toolbar.publishLocation.info')}>
+          <Button onClick={handleOpenLocationDrawer} disabled={!activeScene.value} className={styles.btn}>
+            {t(`editor:toolbar.publishLocation.title`)}
+          </Button>
+        </InfoTooltip>
+      </div>
+      <LocationDrawer
+        open={openLocationDrawer.value}
+        mode={drawerMode}
+        selectedScene={activeScene.value}
+        onClose={() => openLocationDrawer.set(false)}
+      />
+    </>
+  )
+}
+
+export default PubishLocation

--- a/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
+++ b/packages/editor/src/components/toolbar/tools/PublishLocation.tsx
@@ -44,7 +44,7 @@ export const PublishLocation = () => {
   const selectedScene = activeScene.value
     ? (activeScene.value!.replace('.scene.json', '').replace('projects/', '') as SceneID)
     : null
-  let drawerMode = LocationDrawerMode.Create
+  const drawerMode = useHookstate<LocationDrawerMode>(LocationDrawerMode.Create)
 
   const existingLocation = useFind(locationPath, {
     query: {
@@ -58,9 +58,10 @@ export const PublishLocation = () => {
   })
 
   const handleOpenLocationDrawer = async () => {
-    if (existingLocation.data.length > 0) {
-      drawerMode = LocationDrawerMode.ViewEdit
-    }
+    existingLocation.refetch()
+
+    if (existingLocation.data.length > 0) drawerMode.set(LocationDrawerMode.ViewEdit)
+
     openLocationDrawer.set(true)
   }
 
@@ -75,7 +76,8 @@ export const PublishLocation = () => {
       </div>
       <LocationDrawer
         open={openLocationDrawer.value}
-        mode={drawerMode}
+        mode={drawerMode.value}
+        selectedLocation={existingLocation.data[0]}
         selectedScene={selectedScene}
         onClose={() => openLocationDrawer.set(false)}
       />

--- a/packages/server-core/src/social/location/location.hooks.ts
+++ b/packages/server-core/src/social/location/location.hooks.ts
@@ -314,7 +314,7 @@ export default {
 
   before: {
     all: [() => schemaHooks.validateQuery(locationQueryValidator), schemaHooks.resolveQuery(locationQueryResolver)],
-    find: [discardQuery('action'), sortByLocationSetting],
+    find: [discardQuery('action'), discardQuery('studio'), sortByLocationSetting],
     get: [],
     create: [
       iff(isProvider('external'), verifyScope('location', 'write')),


### PR DESCRIPTION
Adds `Publish` button in studio toolbar, which opens `LocationDrawer` and lets user publish location for the active scene if they have the permission

closes #9333 

