### PR TITLE
remove one minute project auto update

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectFields.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectFields.tsx
@@ -637,10 +637,6 @@ const ProjectFields = ({ inputProject, existingProject = false, changeDestinatio
                 value={projectUpdateStatus.value?.updateSchedule || DefaultUpdateSchedule}
                 menu={[
                   {
-                    value: '* * * * *',
-                    label: `1 ${t('admin:components.project.minute')}`
-                  },
-                  {
                     value: '*/5 * * * *',
                     label: `5 ${t('admin:components.project.minutes')}`
                   },


### PR DESCRIPTION
## Summary

remove the option of 1 minute auto update from project update drawer

## References
closes #9579

## QA Steps

#### Earlier

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/f51ead58-6014-4152-8844-abe38780e439)


#### Now

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/de688e8a-243f-4cb4-938a-8e43576f7dd1)
