### PR TITLE
Fix incorrectly set group

### DIFF
--- a/packages/engine/src/scene/components/UVOL2Component.ts
+++ b/packages/engine/src/scene/components/UVOL2Component.ts
@@ -493,8 +493,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
   const mesh = useMemo(() => new Mesh(defaultGeometry, material), [])
   const group = useMemo(() => {
     const _group = new Group()
-    addObjectToGroup(entity, _group)
-    addObjectToGroup(entity, mesh)
+    _group.add(mesh)
     return _group
   }, [])
 


### PR DESCRIPTION
## Summary
Here Group is to be seen as a primitive object instead of a container to hold meshes. Because it allows to easily apply transforms (scale, position), without worrying about underlying mesh's non-default transforms.

Neverthless, this group is added to the GroupComponent with `addObjectToGroup` later in the program.


## References
closes #_insert number here_

## QA Steps
