### PR TITLE
Fix Highlight effect and object layer bug

### DIFF
--- a/packages/engine/src/renderer/functions/configureEffectComposer.ts
+++ b/packages/engine/src/renderer/functions/configureEffectComposer.ts
@@ -46,6 +46,7 @@ import { CameraComponent } from '../../camera/components/CameraComponent'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineState } from '../../ecs/classes/EngineState'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
+import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { EffectMap, EffectPropsSchema, Effects } from '../../scene/constants/PostProcessing'
 import { HighlightState } from '../HighlightState'
 import { RendererState } from '../RendererState'
@@ -85,6 +86,7 @@ export const configureEffectComposer = (
   composer.SMAAEffect = smaaEffect
 
   const outlineEffect = new OutlineEffect(scene, camera, getState(HighlightState))
+  outlineEffect.selectionLayer = ObjectLayers.HighlightEffect
   composer.HighlightEffect = outlineEffect
 
   const OutlineAndSmaaEffectPass = new EffectPass(camera, smaaEffect, outlineEffect)

--- a/packages/engine/src/scene/components/ObjectLayerComponent.ts
+++ b/packages/engine/src/scene/components/ObjectLayerComponent.ts
@@ -75,7 +75,7 @@ export const ObjectLayerMaskComponent = defineComponent({
   },
 
   setLayer(entity: Entity, layer: number) {
-    const mask = ObjectLayerMaskComponent.mask[entity] | (1 << layer) | 0
+    const mask = ((1 << layer) | 0) >>> 0
     setComponent(entity, ObjectLayerMaskComponent, mask)
   },
 

--- a/packages/engine/src/scene/constants/ObjectLayers.ts
+++ b/packages/engine/src/scene/constants/ObjectLayers.ts
@@ -51,5 +51,8 @@ export const ObjectLayers = {
   Panel: 9 as const,
 
   // transform gizmo
-  TransformGizmo: 10 as const
+  TransformGizmo: 10 as const,
+
+  // transform gizmo
+  HighlightEffect: 11 as const
 }


### PR DESCRIPTION
## Summary
The logic behind setting object layer was incorrect and causing the highlight effect logic to not work properly.
Furthermore the default layer for the highlight effect is 10 which clashes with the transform gizmo. I have moved it to 11

## References
closes #_insert number here_

## QA Steps
