### PR TITLE
Changes to add metadata in s3 client files

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,8 @@ name: dev-deploy
 
 on:
   push:
-    branches: [dev]
+    branches:
+      [dev]
 jobs:
   secrets-gate-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: dev-deploy
 
 on:
   push:
-    branches: [dev, s3-client-metadata]
+    branches: [dev]
 jobs:
   secrets-gate-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,8 +2,7 @@ name: dev-deploy
 
 on:
   push:
-    branches:
-      [dev]
+    branches: [dev, s3-client-metadata]
 jobs:
   secrets-gate-run:
     runs-on: ubuntu-latest

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -43,6 +43,7 @@ import {
   CompletedPart,
   CopyObjectCommand,
   CreateMultipartUploadCommand,
+  CreateMultipartUploadCommandInput,
   DeleteObjectsCommand,
   GetObjectCommand,
   HeadObjectCommand,
@@ -76,7 +77,6 @@ import {
   PutObjectParams,
   SignedURLResponse,
   StorageListObjectInterface,
-  StorageMultipartStartInterface,
   StorageObjectInterface,
   StorageObjectPutInterface,
   StorageProviderInterface
@@ -343,7 +343,13 @@ export class S3Provider implements StorageProviderInterface {
         Bucket: this.bucket,
         Key: key,
         ContentType: data.ContentType
-      } as StorageMultipartStartInterface
+      } as CreateMultipartUploadCommandInput
+
+      const cacheControl = data.Metadata?.['Cache-Control'] || ''
+      if (cacheControl) {
+        multiPartStartArgs.CacheControl = cacheControl
+        delete data.Metadata!['Cache-Control']
+      }
 
       if (data.ContentEncoding) multiPartStartArgs.ContentEncoding = data.ContentEncoding
       const startCommand = new CreateMultipartUploadCommand(multiPartStartArgs)

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -321,6 +321,12 @@ export class S3Provider implements StorageProviderInterface {
 
     if (data.Metadata) (args as StorageObjectInterface).Metadata = data.Metadata
 
+    const cacheControl = (args as StorageObjectInterface).Metadata?.['Cache-Control'] || ''
+    if (cacheControl) {
+      args['CacheControl'] = cacheControl
+      delete (args as StorageObjectInterface).Metadata!['Cache-Control']
+    }
+
     if (data.Body instanceof PassThrough) {
       try {
         const upload = new Upload(args as unknown as Options)
@@ -345,10 +351,8 @@ export class S3Provider implements StorageProviderInterface {
         ContentType: data.ContentType
       } as CreateMultipartUploadCommandInput
 
-      const cacheControl = data.Metadata?.['Cache-Control'] || ''
       if (cacheControl) {
         multiPartStartArgs.CacheControl = cacheControl
-        delete data.Metadata!['Cache-Control']
       }
 
       if (data.ContentEncoding) multiPartStartArgs.ContentEncoding = data.ContentEncoding

--- a/scripts/push-client-to-s3.ts
+++ b/scripts/push-client-to-s3.ts
@@ -83,7 +83,10 @@ cli.main(async () => {
     const putData = {
       Body: Buffer.from(JSON.stringify(filesToPrune)),
       ContentType: 'application/json',
-      Key: 'client/S3FilesToRemove.json'
+      Key: 'client/S3FilesToRemove.json',
+      Metadata: {
+        'Cache-Control': 'no-cache'
+      }
     }
     await storageProvider.putObject(putData, { isDirectory: false })
     await storageProvider.createInvalidation(['client/*'])

--- a/scripts/push-client-to-s3.ts
+++ b/scripts/push-client-to-s3.ts
@@ -59,13 +59,19 @@ cli.main(async () => {
             const putData: any = {
               Body: fileResult,
               ContentType: contentType,
-              Key: `client${filePathRelative}`
+              Key: `client${filePathRelative}`,
+              Metadata: {
+                'Cache-Control': 'no-cache'
+              }
             } as any
             if (/.br$/.exec(filePathRelative)) {
               filePathRelative = filePathRelative.replace(/.br$/, '')
               putData.ContentType = getContentType(filePathRelative)
               putData.ContentEncoding = 'br'
               putData.Key = `client${filePathRelative}`
+              putData.Metadata = {
+                'Cache-Control': 'no-cache'
+              }
             }
             await storageProvider.putObject(putData, { isDirectory: false })
             filesToPush.push(`client${filePathRelative}`)


### PR DESCRIPTION
## Summary
This PR adds 'Cache-Control': 'no-cache' policy for client files. This fix was suggested by AWS support to fix the CORS error.

## References
closes #_insert number here_

## QA Steps
