### PR TITLE
replace file urls with configured file server

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -30,7 +30,7 @@ import path from 'path/posix'
 
 import { processFileName } from '@etherealengine/common/src/utils/processFileName'
 
-import config, { isDev } from '@etherealengine/common/src/config'
+import { isDev } from '@etherealengine/common/src/config'
 import {
   FileBrowserContentType,
   FileBrowserPatch,
@@ -127,7 +127,7 @@ export class FileBrowserService
 
     result = result.slice(skip, skip + limit)
     result.forEach((file) => {
-      file.url = `${config.client.fileServer}/${file.key}`
+      file.url = getCachedURL(file.key, storageProvider.cacheDomain)
     })
 
     if (params.provider && !isAdmin) {
@@ -307,7 +307,7 @@ export class FileBrowserService
       await storageProvider.createInvalidation([key])
     }
 
-    return `${config.client.fileServer}/${key}`
+    return getCachedURL(key, storageProvider.cacheDomain)
   }
 
   /**

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -30,7 +30,7 @@ import path from 'path/posix'
 
 import { processFileName } from '@etherealengine/common/src/utils/processFileName'
 
-import { isDev } from '@etherealengine/common/src/config'
+import config, { isDev } from '@etherealengine/common/src/config'
 import {
   FileBrowserContentType,
   FileBrowserPatch,
@@ -126,6 +126,9 @@ export class FileBrowserService
     const total = result.length
 
     result = result.slice(skip, skip + limit)
+    result.forEach((file) => {
+      file.url = `${config.client.fileServer}/${file.key}`
+    })
 
     if (params.provider && !isAdmin) {
       const knexClient: Knex = this.app.get('knexClient')
@@ -304,7 +307,7 @@ export class FileBrowserService
       await storageProvider.createInvalidation([key])
     }
 
-    return url
+    return `${config.client.fileServer}/${key}`
   }
 
   /**

--- a/packages/server-core/src/media/file-browser/file-browser.test.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.test.ts
@@ -30,6 +30,7 @@ import { destroyEngine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { fileBrowserPath } from '@etherealengine/common/src/schemas/media/file-browser.schema'
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { getCachedURL } from '../storageprovider/getCachedURL'
 import { getStorageProvider } from '../storageprovider/storageprovider'
 
 const getRandomizedName = (name: string, suffix = '', prefix = 'test') =>
@@ -106,6 +107,7 @@ describe('file-browser.test', () => {
     assert.ok(foundFile)
     assert.equal(foundFile.name, testFileName)
     assert.equal(foundFile.size, testFileSize)
+    assert.equal(foundFile.url, getCachedURL(foundFile.key, getStorageProvider().cacheDomain))
   })
 
   describe('update service', () => {


### PR DESCRIPTION
## Summary

Instead of using direct storageprovider links, this PR replaces them with the `config.client.fileServer`

## References
closes #9624

## QA Steps
