### PR TITLE
expose CSM cascades in render settings

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -680,6 +680,8 @@
       "info-useShadows": "Enables shadows",
       "lbl-csm": "Cascading Shadow Maps",
       "info-csm": "Enables cascading shadow maps.",
+      "lbl-csm-cascades": "Cascades",
+      "info-csm-cascades": "Smaller the size of the scene. More efficient to have less cascades.",
       "lbl-toneMapping": "Tone Mapping",
       "info-toneMapping": "Enables tone mapping on the scene renderer. Has no effect when a post processing is enabled.",
       "lbl-toneMappingExposure": "Tone Mapping Exposure",

--- a/packages/editor/src/components/properties/RenderSettingsEditor.tsx
+++ b/packages/editor/src/components/properties/RenderSettingsEditor.tsx
@@ -122,6 +122,24 @@ export const RenderSettingsEditor: EditorComponentType = (props) => {
           onChange={commitProperty(RenderSettingsComponent, 'csm')}
         />
       </InputGroup>
+      {rendererSettingsState.csm.value === true ? (
+        <InputGroup
+          name="Cascades"
+          label={t('editor:properties.renderSettings.lbl-csm-cascades')}
+          info={t('editor:properties.renderSettings.info-csm-cascades')}
+        >
+          <CompoundNumericInput
+            min={1}
+            max={5}
+            step={1}
+            value={rendererSettingsState.cascades.value}
+            onChange={updateProperty(RenderSettingsComponent, 'cascades')}
+            onRelease={commitProperty(RenderSettingsComponent, 'cascades')}
+          />
+        </InputGroup>
+      ) : (
+        <></>
+      )}
       <InputGroup
         name="Tone Mapping"
         label={t('editor:properties.renderSettings.lbl-toneMapping')}

--- a/packages/engine/src/scene/components/RenderSettingsComponent.ts
+++ b/packages/engine/src/scene/components/RenderSettingsComponent.ts
@@ -45,6 +45,7 @@ export const RenderSettingsComponent = defineComponent({
     if (!json) return
 
     if (typeof json.csm === 'boolean') component.csm.set(json.csm)
+    if (typeof json.cascades === 'number') component.cascades.set(json.cascades)
     if (typeof json.toneMapping === 'number') component.toneMapping.set(json.toneMapping)
     if (typeof json.toneMappingExposure === 'number') component.toneMappingExposure.set(json.toneMappingExposure)
     if (typeof json.shadowMapType === 'number') component.shadowMapType.set(json.shadowMapType)
@@ -53,6 +54,7 @@ export const RenderSettingsComponent = defineComponent({
   toJSON: (entity, component) => {
     return {
       csm: component.csm.value,
+      cascades: component.cascades.value,
       toneMapping: component.toneMapping.value,
       toneMappingExposure: component.toneMappingExposure.value,
       shadowMapType: component.shadowMapType.value

--- a/packages/engine/src/scene/systems/ShadowSystem.tsx
+++ b/packages/engine/src/scene/systems/ShadowSystem.tsx
@@ -114,6 +114,7 @@ const raycasterPosition = new Vector3()
 
 const EntityCSMReactor = (props: { entity: Entity }) => {
   const activeLightEntity = props.entity
+  const renderSettings = useHookstate(getMutableState(RenderSettingsState))
 
   const directionalLightComponent = useComponent(activeLightEntity, DirectionalLightComponent)
   const shadowMapResolution = useHookstate(getMutableState(RendererState).shadowMapResolution)
@@ -128,14 +129,15 @@ const EntityCSMReactor = (props: { entity: Entity }) => {
         light: directionalLight,
         shadowBias: directionalLightComponent.shadowBias.value,
         maxFar: directionalLightComponent.cameraFar.value,
-        lightIntensity: directionalLightComponent.intensity.value
+        lightIntensity: directionalLightComponent.intensity.value,
+        cascades: renderSettings.cascades.value
       })
     )
     return () => {
       getState(RendererState).csm?.dispose()
       getMutableState(RendererState).csm.set(null)
     }
-  }, [directionalLightComponent.useInCSM])
+  }, [directionalLightComponent.useInCSM, renderSettings.cascades])
 
   /** Must run after scene object system to ensure source light is not lit */
   useExecute(

--- a/packages/spatial/src/renderer/WebGLRendererSystem.ts
+++ b/packages/spatial/src/renderer/WebGLRendererSystem.ts
@@ -287,6 +287,7 @@ export const RenderSettingsState = defineState({
   name: 'RenderSettingsState',
   initial: {
     csm: true,
+    cascades: 5,
     toneMapping: LinearToneMapping as ToneMapping,
     toneMappingExposure: 0.8,
     shadowMapType: PCFSoftShadowMap as ShadowMapType


### PR DESCRIPTION
## Summary
Exposed CSM cascades to render settings as it can be adjusted by scene size. Technically the official paper for CSM calls them splits. Let me know if you think that is better nomenclature

![1 split](https://github.com/EtherealEngine/etherealengine/assets/3631206/4d7ac870-a614-4dba-9c5f-0cc572fa60e0)
![2 split](https://github.com/EtherealEngine/etherealengine/assets/3631206/bc30878b-e1e7-4081-9b69-093f67cf1a67)
![5 split](https://github.com/EtherealEngine/etherealengine/assets/3631206/df047965-834f-4b39-9366-83ce55ce4e52)
[1 split, 2 split, 5 splits]
~~Currently reducing splits also reduces shadow quality. I'm sure we can tweak other settings to fix this.~~
just have to adjust the directional lights far distance.