### PR TITLE
Fix Camera colliding with invisible collider, Reset Zoom level

### DIFF
--- a/packages/engine/src/scene/components/MeshBVHComponent.ts
+++ b/packages/engine/src/scene/components/MeshBVHComponent.ts
@@ -104,7 +104,7 @@ export const MeshBVHComponent = defineComponent({
                 if (toGenerate == 0) {
                   component.generated.set(true)
                 }
-                if (model.cameraOcclusion) {
+                if (model.cameraOcclusion && mesh?.visible) {
                   ObjectLayerMaskComponent.enableLayers(currEntity, ObjectLayers.Camera)
                 }
               }

--- a/packages/engine/src/scene/components/MeshBVHComponent.ts
+++ b/packages/engine/src/scene/components/MeshBVHComponent.ts
@@ -104,7 +104,7 @@ export const MeshBVHComponent = defineComponent({
                 if (toGenerate == 0) {
                   component.generated.set(true)
                 }
-                if (model.cameraOcclusion && mesh?.visible) {
+                if (model.cameraOcclusion) {
                   ObjectLayerMaskComponent.enableLayers(currEntity, ObjectLayers.Camera)
                 }
               }

--- a/packages/spatial/src/camera/systems/CameraSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraSystem.tsx
@@ -148,9 +148,7 @@ export const getMaxCamDistance = (cameraEntity: Entity, target: Vector3) => {
   raycaster.firstHitOnly = true // three-mesh-bvh setting
   raycaster.far = followCamera.maxDistance
   raycaster.set(target, targetToCamVec.normalize())
-  const hits = raycaster
-    .intersectObjects(sceneObjects, false)
-    .filter((item) => getOptionalComponent(item.object.entity, VisibleComponent) === true)
+  const hits = raycaster.intersectObjects(sceneObjects, false)
 
   if (hits[0] && hits[0].distance < maxDistance) {
     maxDistance = hits[0].distance
@@ -159,9 +157,7 @@ export const getMaxCamDistance = (cameraEntity: Entity, target: Vector3) => {
   //Check the cone for minimum distance
   cameraRays.forEach((rayDir, i) => {
     raycaster.set(target, rayDir)
-    const hits = raycaster
-      .intersectObjects(sceneObjects, false)
-      .filter((item) => getOptionalComponent(item.object.entity, VisibleComponent) === true)
+    const hits = raycaster.intersectObjects(sceneObjects, false)
     if (hits[0] && hits[0].distance < maxDistance) {
       maxDistance = hits[0].distance
     }

--- a/packages/spatial/src/camera/systems/CameraSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraSystem.tsx
@@ -118,7 +118,7 @@ export const updateCameraTargetRotation = (cameraEntity: Entity) => {
   followCamera.theta = smoothDamp(followCamera.theta, target.theta, target.thetaVelocity, target.time, delta)
 }
 
-const cameraLayerQuery = defineQuery([ObjectLayerComponents[ObjectLayers.Camera], MeshComponent])
+const cameraLayerQuery = defineQuery([VisibleComponent, ObjectLayerComponents[ObjectLayers.Camera], MeshComponent])
 
 export const getMaxCamDistance = (cameraEntity: Entity, target: Vector3) => {
   const followCamera = getComponent(cameraEntity, FollowCameraComponent)

--- a/packages/spatial/src/camera/systems/CameraSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraSystem.tsx
@@ -158,6 +158,7 @@ export const getMaxCamDistance = (cameraEntity: Entity, target: Vector3) => {
   cameraRays.forEach((rayDir, i) => {
     raycaster.set(target, rayDir)
     const hits = raycaster.intersectObjects(sceneObjects, false)
+
     if (hits[0] && hits[0].distance < maxDistance) {
       maxDistance = hits[0].distance
     }

--- a/packages/spatial/src/camera/systems/CameraSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraSystem.tsx
@@ -49,6 +49,7 @@ import { NetworkObjectComponent, NetworkObjectOwnedTag } from '../../networking/
 import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { MeshComponent } from '../../renderer/components/MeshComponent'
 import { ObjectLayerComponents } from '../../renderer/components/ObjectLayerComponent'
+import { VisibleComponent } from '../../renderer/components/VisibleComponent'
 import { ObjectLayers } from '../../renderer/constants/ObjectLayers'
 import {
   ComputedTransformComponent,
@@ -147,7 +148,9 @@ export const getMaxCamDistance = (cameraEntity: Entity, target: Vector3) => {
   raycaster.firstHitOnly = true // three-mesh-bvh setting
   raycaster.far = followCamera.maxDistance
   raycaster.set(target, targetToCamVec.normalize())
-  const hits = raycaster.intersectObjects(sceneObjects, false)
+  const hits = raycaster
+    .intersectObjects(sceneObjects, false)
+    .filter((item) => getOptionalComponent(item.object.entity, VisibleComponent) === true)
 
   if (hits[0] && hits[0].distance < maxDistance) {
     maxDistance = hits[0].distance
@@ -156,8 +159,9 @@ export const getMaxCamDistance = (cameraEntity: Entity, target: Vector3) => {
   //Check the cone for minimum distance
   cameraRays.forEach((rayDir, i) => {
     raycaster.set(target, rayDir)
-    const hits = raycaster.intersectObjects(sceneObjects, false)
-
+    const hits = raycaster
+      .intersectObjects(sceneObjects, false)
+      .filter((item) => getOptionalComponent(item.object.entity, VisibleComponent) === true)
     if (hits[0] && hits[0].distance < maxDistance) {
       maxDistance = hits[0].distance
     }

--- a/packages/spatial/src/camera/systems/CameraSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraSystem.tsx
@@ -194,9 +194,10 @@ const computeCameraFollow = (cameraEntity: Entity, referenceEntity: Entity) => {
   }
 
   const newZoomDistance = Math.min(followCamera.zoomLevel, maxDistance)
+  followCamera.zoomLevel = newZoomDistance //reset zoom level
 
   // Zoom smoothing
-  let smoothingSpeed = isInsideWall ? 0.1 : 0.3
+  const smoothingSpeed = isInsideWall ? 0.1 : 0.3
   const deltaSeconds = getState(ECSState).deltaSeconds
 
   followCamera.distance = smoothDamp(

--- a/packages/spatial/src/camera/systems/CameraSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraSystem.tsx
@@ -195,7 +195,6 @@ const computeCameraFollow = (cameraEntity: Entity, referenceEntity: Entity) => {
   }
 
   const newZoomDistance = Math.min(followCamera.zoomLevel, maxDistance)
-  followCamera.zoomLevel = newZoomDistance //reset zoom level
 
   // Zoom smoothing
   const smoothingSpeed = isInsideWall ? 0.1 : 0.3


### PR DESCRIPTION
## Summary
Was seeing issues on sky station with the camera beeing very zoomed in.  I also noticed when maxDistance was smaller than zoom the zoom value wasn't being reset.

**Note:**
I did try some improvements to the camera raycasting to improve how it clips into walls and I did see improvements but there were some edge cases when the avatar got too close to a wall. I can still work on that for this PR i'm sure there is some check I can do for the radius off the normal offset I was applying.

## References
closes #_insert number here_

## QA Steps
