### PR TITLE
revert event change in client input system

### DIFF
--- a/packages/spatial/src/input/systems/ClientInputSystem.tsx
+++ b/packages/spatial/src/input/systems/ClientInputSystem.tsx
@@ -260,7 +260,7 @@ export const addClientInputListeners = (canvas = EngineRenderer.instance.rendere
     axes[index] = value.x
     axes[index + 1] = value.y
   }
-  canvas.addEventListener('touchstickmove', handleTouchDirectionalPad)
+  document.addEventListener('touchstickmove', handleTouchDirectionalPad)
 
   /**
    * AR uses the `select` event as taps on the screen for mobile AR sessions
@@ -356,7 +356,7 @@ export const addClientInputListeners = (canvas = EngineRenderer.instance.rendere
     canvas.removeEventListener('touchstart', handleMouseClick)
     canvas.removeEventListener('touchend', handleMouseClick)
 
-    canvas.removeEventListener('touchstickmove', handleTouchDirectionalPad)
+    document.removeEventListener('touchstickmove', handleTouchDirectionalPad)
 
     session?.removeEventListener('selectstart', onXRSelectStart)
     session?.removeEventListener('selectend', onXRSelectEnd)


### PR DESCRIPTION
## Summary
our touchstickmove event is custom on the document so had to revert a change that made it's listener source from the canvas.

## QA Steps
Mobile thumbstick