### PR TITLE
Fix Loading Screen exiting early

### DIFF
--- a/packages/engine/src/scene/components/ColliderComponent.ts
+++ b/packages/engine/src/scene/components/ColliderComponent.ts
@@ -35,7 +35,6 @@ import {
   getComponent,
   getOptionalComponent,
   hasComponent,
-  removeComponent,
   setComponent,
   useComponent,
   useOptionalComponent
@@ -143,7 +142,7 @@ export const ColliderComponent = defineComponent({
       hasComponent(entity, SceneObjectComponent) &&
       !hasComponent(entity, RigidBodyComponent)
     )
-      setComponent(entity, SceneAssetPendingTagComponent)
+      SceneAssetPendingTagComponent.addResource(entity, ColliderComponent.jsonID)
     setComponent(entity, InputComponent)
   },
 
@@ -170,7 +169,7 @@ export const ColliderComponent = defineComponent({
     const modelHierarchy = useHookstate(ModelComponent.entitiesInModelHierarchyState[entity])
 
     useEffect(() => {
-      removeComponent(entity, SceneAssetPendingTagComponent)
+      SceneAssetPendingTagComponent.removeResource(entity, ColliderComponent.jsonID)
 
       const isMeshCollider = [ShapeType.TriMesh, ShapeType.ConvexPolyhedron].includes(colliderComponent.shapeType.value)
       const physicsWorld = getState(PhysicsState).physicsWorld

--- a/packages/engine/src/scene/components/EnvmapComponent.tsx
+++ b/packages/engine/src/scene/components/EnvmapComponent.tsx
@@ -39,12 +39,13 @@ import {
 } from 'three'
 
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
-import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
 
 import { isClient } from '@etherealengine/common/src/utils/getEnvironment'
 import {
   defineComponent,
   getMutableComponent,
+  hasComponent,
   useComponent,
   useOptionalComponent
 } from '@etherealengine/ecs/src/ComponentFunctions'
@@ -60,6 +61,8 @@ import { EnvMapSourceType, EnvMapTextureType } from '../constants/EnvMapEnum'
 import { getRGBArray, loadCubeMapTexture } from '../constants/Util'
 import { addError, removeError } from '../functions/ErrorFunctions'
 import { EnvMapBakeComponent, applyBoxProjection } from './EnvMapBakeComponent'
+import { SceneAssetPendingTagComponent } from './SceneAssetPendingTagComponent'
+import { SceneObjectComponent } from './SceneObjectComponent'
 
 const tempColor = new Color()
 
@@ -88,6 +91,16 @@ export const EnvmapComponent = defineComponent({
     if (typeof json?.envMapSourceEntityUUID === 'string')
       component.envMapSourceEntityUUID.set(json.envMapSourceEntityUUID)
     if (typeof json?.envMapIntensity === 'number') component.envMapIntensity.set(json.envMapIntensity)
+    /**
+     * Add SceneAssetPendingTagComponent to tell scene loading system we should wait for this asset to load
+     */
+    if (
+      isClient &&
+      !getState(SceneState).sceneLoaded &&
+      hasComponent(entity, SceneObjectComponent) &&
+      component.type.value !== EnvMapSourceType.None
+    )
+      SceneAssetPendingTagComponent.addResource(entity, EnvmapComponent.jsonID)
   },
 
   toJSON: (entity, component) => {
@@ -106,7 +119,6 @@ export const EnvmapComponent = defineComponent({
     if (!isClient) return null
 
     const component = useComponent(entity, EnvmapComponent)
-    const group = useComponent(entity, GroupComponent)
     const background = useHookstate(getMutableState(SceneState).background)
     const mesh = useOptionalComponent(entity, MeshComponent)?.value as Mesh<any, any> | null
 
@@ -118,6 +130,7 @@ export const EnvmapComponent = defineComponent({
       if (component.type.value !== EnvMapSourceType.Skybox) return
       component.envmap.set(null)
       updateEnvMap(mesh, background.value as Texture | null)
+      SceneAssetPendingTagComponent.removeResource(entity, EnvmapComponent.jsonID)
     }, [component.type, mesh, background])
 
     useEffect(() => {
@@ -141,38 +154,50 @@ export const EnvmapComponent = defineComponent({
           loadCubeMapTexture(
             component.envMapSourceURL.value,
             (texture: CubeTexture | undefined) => {
-              if (texture) {
-                texture.mapping = CubeReflectionMapping
-                texture.colorSpace = SRGBColorSpace
-                component.envmap.set(texture)
-                removeError(entity, EnvmapComponent, 'MISSING_FILE')
-              }
+              SceneAssetPendingTagComponent.removeResource(entity, EnvmapComponent.jsonID)
+              if (!texture) return
+              texture.mapping = CubeReflectionMapping
+              texture.colorSpace = SRGBColorSpace
+              component.envmap.set(texture)
+              removeError(entity, EnvmapComponent, 'MISSING_FILE')
             },
             undefined,
             (_) => {
               component.envmap.set(null)
               addError(entity, EnvmapComponent, 'MISSING_FILE', 'Skybox texture could not be found!')
+              SceneAssetPendingTagComponent.removeResource(entity, EnvmapComponent.jsonID)
             }
           )
           break
 
         case EnvMapTextureType.Equirectangular:
-          AssetLoader.loadAsync(component.envMapSourceURL.value, {}).then((texture) => {
-            if (texture) {
-              texture.mapping = EquirectangularReflectionMapping
-              component.envmap.set(texture)
-              removeError(entity, EnvmapComponent, 'MISSING_FILE')
-            } else {
+          AssetLoader.loadAsync(component.envMapSourceURL.value, {})
+            .then((texture) => {
+              if (texture) {
+                texture.mapping = EquirectangularReflectionMapping
+                component.envmap.set(texture)
+                removeError(entity, EnvmapComponent, 'MISSING_FILE')
+              } else {
+                component.envmap.set(null)
+                addError(entity, EnvmapComponent, 'MISSING_FILE', 'Skybox texture could not be found!')
+              }
+            })
+            .catch((e) => {
               component.envmap.set(null)
               addError(entity, EnvmapComponent, 'MISSING_FILE', 'Skybox texture could not be found!')
-            }
-          })
+            })
+            .finally(() => {
+              SceneAssetPendingTagComponent.removeResource(entity, EnvmapComponent.jsonID)
+            })
+        default:
+          SceneAssetPendingTagComponent.removeResource(entity, EnvmapComponent.jsonID)
       }
     }, [component.type, component.envMapSourceURL])
 
     useEffect(() => {
       if (!component.envmap.value) return
       updateEnvMap(mesh, component.envmap.value)
+      SceneAssetPendingTagComponent.removeResource(entity, EnvmapComponent.jsonID)
     }, [mesh, component.envmap])
 
     useEffect(() => {
@@ -202,16 +227,23 @@ const EnvBakeComponentReactor = (props: { envmapEntity: Entity; bakeEntity: Enti
 
   /** @todo add an unmount cleanup for applyBoxprojection */
   useEffect(() => {
-    AssetLoader.loadAsync(bakeComponent.envMapOrigin.value, {}).then((texture) => {
-      if (texture) {
-        texture.mapping = EquirectangularReflectionMapping
-        getMutableComponent(envmapEntity, EnvmapComponent).envmap.set(texture)
-        if (bakeComponent.boxProjection.value) applyBoxProjection(bakeEntity, group.value)
-        removeError(envmapEntity, EnvmapComponent, 'MISSING_FILE')
-      } else {
+    AssetLoader.loadAsync(bakeComponent.envMapOrigin.value, {})
+      .then((texture) => {
+        if (texture) {
+          texture.mapping = EquirectangularReflectionMapping
+          getMutableComponent(envmapEntity, EnvmapComponent).envmap.set(texture)
+          if (bakeComponent.boxProjection.value) applyBoxProjection(bakeEntity, group.value)
+          removeError(envmapEntity, EnvmapComponent, 'MISSING_FILE')
+        } else {
+          addError(envmapEntity, EnvmapComponent, 'MISSING_FILE', 'Skybox texture could not be found!')
+        }
+      })
+      .catch((e) => {
         addError(envmapEntity, EnvmapComponent, 'MISSING_FILE', 'Skybox texture could not be found!')
-      }
-    })
+      })
+      .finally(() => {
+        SceneAssetPendingTagComponent.removeResource(props.envmapEntity, EnvmapComponent.jsonID)
+      })
   }, [renderState.forceBasicMaterials, bakeComponent.envMapOrigin])
 
   return null

--- a/packages/engine/src/scene/components/GroundPlaneComponent.ts
+++ b/packages/engine/src/scene/components/GroundPlaneComponent.ts
@@ -29,13 +29,7 @@ import { Color, Mesh, MeshLambertMaterial, PlaneGeometry, ShadowMaterial } from 
 
 import { getState } from '@etherealengine/hyperflux'
 
-import {
-  defineComponent,
-  hasComponent,
-  removeComponent,
-  setComponent,
-  useComponent
-} from '@etherealengine/ecs/src/ComponentFunctions'
+import { defineComponent, hasComponent, setComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { useEntityContext } from '@etherealengine/ecs/src/EntityFunctions'
 import { SceneState } from '@etherealengine/engine/src/scene/Scene'
 import { matches } from '@etherealengine/spatial/src/common/functions/MatchesUtils'
@@ -79,7 +73,7 @@ export const GroundPlaneComponent = defineComponent({
       hasComponent(entity, SceneObjectComponent) &&
       !hasComponent(entity, RigidBodyComponent)
     )
-      setComponent(entity, SceneAssetPendingTagComponent)
+      SceneAssetPendingTagComponent.addResource(entity, GroundPlaneComponent.jsonID)
   },
 
   toJSON(entity, component) {
@@ -121,8 +115,7 @@ export const GroundPlaneComponent = defineComponent({
       const physicsWorld = getState(PhysicsState).physicsWorld
       Physics.createRigidBody(entity, physicsWorld, rigidBodyDesc, [colliderDesc])
 
-      removeComponent(entity, SceneAssetPendingTagComponent)
-
+      SceneAssetPendingTagComponent.removeResource(entity, GroundPlaneComponent.jsonID)
       return () => {
         Physics.removeRigidBody(entity, physicsWorld)
         removeObjectFromGroup(entity, mesh)

--- a/packages/engine/src/scene/components/SceneAssetPendingTagComponent.ts
+++ b/packages/engine/src/scene/components/SceneAssetPendingTagComponent.ts
@@ -23,13 +23,45 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { createState } from '@etherealengine/hyperflux'
-
-import { defineComponent } from '@etherealengine/ecs/src/ComponentFunctions'
-import { Entity } from '@etherealengine/ecs/src/Entity'
+import {
+  Entity,
+  defineComponent,
+  getComponent,
+  getMutableComponent,
+  hasComponent,
+  removeComponent,
+  setComponent
+} from '@etherealengine/ecs'
+import { createState, none } from '@etherealengine/hyperflux'
 
 export const SceneAssetPendingTagComponent = defineComponent({
   name: 'SceneAssetPendingTagComponent',
+
+  onInit(entity) {
+    return [] as string[]
+  },
+
+  onSet(entity, component, json) {
+    if (!json) return
+
+    if (Array.isArray(json)) component.set(json)
+  },
+
+  addResource: (entity: Entity, resource: string) => {
+    if (!hasComponent(entity, SceneAssetPendingTagComponent)) setComponent(entity, SceneAssetPendingTagComponent)
+    if (!getComponent(entity, SceneAssetPendingTagComponent).includes(resource)) {
+      getMutableComponent(entity, SceneAssetPendingTagComponent).merge([resource])
+    }
+  },
+
+  removeResource: (entity: Entity, resource: string) => {
+    if (!hasComponent(entity, SceneAssetPendingTagComponent)) return
+    const index = getComponent(entity, SceneAssetPendingTagComponent).indexOf(resource)
+    if (index < 0) return
+    getMutableComponent(entity, SceneAssetPendingTagComponent)[index].set(none)
+    if (!getComponent(entity, SceneAssetPendingTagComponent).length)
+      removeComponent(entity, SceneAssetPendingTagComponent)
+  },
 
   loadingProgress: createState(
     {} as Record<

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -57,6 +57,7 @@ import { GLTFLoadedComponent } from '../components/GLTFLoadedComponent'
 import { InstancingComponent } from '../components/InstancingComponent'
 import { MeshBVHComponent } from '../components/MeshBVHComponent'
 import { ModelComponent } from '../components/ModelComponent'
+import { SceneAssetPendingTagComponent } from '../components/SceneAssetPendingTagComponent'
 import { SceneObjectComponent } from '../components/SceneObjectComponent'
 
 export const parseECSData = (data: [string, any][]): ComponentJsonType[] => {
@@ -234,6 +235,9 @@ export const generateEntityJsonFromObject = (rootEntity: Entity, obj: Object3D, 
     parentEntity,
     uuid
   })
+
+  if (hasComponent(rootEntity, SceneAssetPendingTagComponent))
+    SceneAssetPendingTagComponent.addResource(objEntity, `${rootEntity}`)
 
   setComponent(objEntity, NameComponent, name)
   setComponent(objEntity, TransformComponent, {

--- a/packages/engine/src/scene/functions/loaders/VariantFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VariantFunctions.ts
@@ -19,6 +19,7 @@ import { AssetLoader } from '../../../assets/classes/AssetLoader'
 import { pathResolver } from '../../../assets/functions/pathResolver'
 import { InstancingComponent } from '../../components/InstancingComponent'
 import { ModelComponent } from '../../components/ModelComponent'
+import { SceneAssetPendingTagComponent } from '../../components/SceneAssetPendingTagComponent'
 import { VariantComponent, VariantLevel } from '../../components/VariantComponent'
 import getFirstMesh from '../../util/meshUtils'
 
@@ -61,7 +62,10 @@ export function setModelVariant(entity: Entity) {
     const deviceVariant = variantComponent.levels.find((level) => level.value.metadata['device'] === targetDevice)
     const modelRelativePath = pathResolver().exec(modelComponent.src.value)?.[2]
     const deviceRelativePath = deviceVariant ? pathResolver().exec(deviceVariant.src.value)?.[2] : ''
-    deviceVariant && modelRelativePath !== deviceRelativePath && modelComponent.src.set(deviceVariant.src.value)
+    if (deviceVariant && modelRelativePath !== deviceRelativePath) {
+      SceneAssetPendingTagComponent.removeResource(entity, modelComponent.src.value)
+      modelComponent.src.set(deviceVariant.src.value)
+    }
   } else if (variantComponent.heuristic.value === 'DISTANCE') {
     const distance = DistanceFromCameraComponent.squaredDistance[entity]
     for (let i = 0; i < variantComponent.levels.length; i++) {
@@ -70,7 +74,10 @@ export function setModelVariant(entity: Entity) {
       const minDistance = Math.pow(level.metadata['minDistance'], 2)
       const maxDistance = Math.pow(level.metadata['maxDistance'], 2)
       const useLevel = minDistance <= distance && distance <= maxDistance
-      useLevel && modelComponent.src.value !== level.src && modelComponent.src.set(level.src)
+      if (useLevel && modelComponent.src.value !== level.src) {
+        SceneAssetPendingTagComponent.removeResource(entity, modelComponent.src.value)
+        modelComponent.src.set(level.src)
+      }
       if (useLevel) break
     }
   }


### PR DESCRIPTION
Co-authored-by: HexaField <joshfield999@gmail.com>

## Summary
Original Work: https://github.com/EtherealEngine/etherealengine/pull/9545/files#diff-c3b5fd77b5cfb8085e215c2bafd90a2727de2d03ad82fe74db17b47605762c7e

We were seeing the loading screen exit very early. I originally thought it was just because of a race condition. However, It was also because we weren't properly adding SceneAssetPendingTag to everything. Josh recommended I fix up his branch that for him fixed the issue a couple weeks ago. I've made some tweaks here and there. It definitly fixes the issue though the race condition definitly still does exist. We will have to refactor scene loading during GLTF to fix the race condition since we have Scenes loading Scenes.

Final Note: I've left out the granular Scene loaded changes as they're still not perfect. Also lets wait to merge this post @MichaelEstes resourceManagement because he'll have a tough time with the merge conflicts if his goes in after.

## References
closes #_insert number here_

## QA Steps
