### PR TITLE
Collider Conversion + Export Fixes

### DIFF
--- a/packages/editor/src/components/properties/ConvertOldCollider.tsx
+++ b/packages/editor/src/components/properties/ConvertOldCollider.tsx
@@ -80,14 +80,16 @@ const convert = (entity: Entity, hierarchy: boolean) => {
     delete mesh.userData['type']
     delete mesh.userData['shapeType']
 
-    mesh.userData[`xrengine.${ColliderComponent.jsonID}.shape`] = shape
+    //mesh.userData[`xrengine.${ColliderComponent.jsonID}.shape`] = shape
     setComponent(child, ColliderComponent, { shape })
 
     const isTrigger = mesh.userData['isTrigger'] ?? mesh.userData['xrengine.collider.isTrigger'] ?? false
-    if (isTrigger === true || isTrigger === 'true') setComponent(child, TriggerComponent)
-    delete mesh.userData['isTrigger']
-    delete mesh.userData['xrengine.collider.isTrigger']
-    mesh.userData[`xrengine.${TriggerComponent.jsonID}`] = true
+    if (isTrigger === true || isTrigger === 'true') {
+      setComponent(child, TriggerComponent)
+      delete mesh.userData['isTrigger']
+      delete mesh.userData['xrengine.collider.isTrigger']
+      //mesh.userData[`xrengine.${TriggerComponent.jsonID}`] = true
+    }
   })
 }
 

--- a/packages/editor/src/functions/exportGLTF.ts
+++ b/packages/editor/src/functions/exportGLTF.ts
@@ -41,7 +41,8 @@ export async function exportRelativeGLTF(entity: Entity, projectName: string, re
     relativePath,
     binary: !isGLTF,
     embedImages: !isGLTF,
-    includeCustomExtensions: true
+    includeCustomExtensions: true,
+    onlyVisible: false
   })
   const blob = isGLTF ? [JSON.stringify(gltf)] : [gltf]
   const file = new File(blob, relativePath)

--- a/packages/engine/src/assets/functions/exportModelGLTF.ts
+++ b/packages/engine/src/assets/functions/exportModelGLTF.ts
@@ -36,7 +36,8 @@ export default async function exportModelGLTF(
     relativePath: '',
     binary: true,
     includeCustomExtensions: true,
-    embedImages: true
+    embedImages: true,
+    onlyVisible: false
   }
 ) {
   const scene = getComponent(entity, ModelComponent).scene ?? getComponent(entity, GroupComponent)[0]


### PR DESCRIPTION
Adjusts collider conversion scripts and gltf export to correctly handle saving colliders in the new physics API into glTFs
