### PR TITLE
remove `save-as` for downloading zip files

### DIFF
--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -73,7 +73,6 @@
     "react-reflex": "^4.0.12",
     "react-router-dom": "6.9.0",
     "recovery": "^0.2.6",
-    "save-as": "^0.1.8",
     "tick-tock": "^1.0.0",
     "typescript": "5.0.2",
     "util": "^0.12.5",

--- a/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
@@ -27,7 +27,6 @@ import { Downgraded } from '@hookstate/core'
 import React, { useEffect, useRef } from 'react'
 import { useDrop } from 'react-dnd'
 import { useTranslation } from 'react-i18next'
-import { saveAs } from 'save-as'
 
 import ConfirmDialog from '@etherealengine/client-core/src/common/components/ConfirmDialog'
 import LoadingView from '@etherealengine/client-core/src/common/components/LoadingView'
@@ -72,7 +71,7 @@ import { useFind } from '@etherealengine/spatial/src/common/functions/FeathersHo
 import Checkbox from '@etherealengine/ui/src/primitives/mui/Checkbox'
 import FormControlLabel from '@etherealengine/ui/src/primitives/mui/FormControlLabel'
 import { SupportedFileTypes } from '../../../constants/AssetTypes'
-import { inputFileWithAddToScene } from '../../../functions/assetFunctions'
+import { downloadBlobAsZip, inputFileWithAddToScene } from '../../../functions/assetFunctions'
 import { bytesToSize, unique } from '../../../functions/utils'
 import StringInput from '../../inputs/StringInput'
 import { ToolButton } from '../../toolbar/ToolButton'
@@ -347,7 +346,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
       fileName = selectedDirectory.value.split('/').at(-1) as string
     }
 
-    saveAs(blob, fileName + '.zip')
+    downloadBlobAsZip(blob, fileName)
   }
 
   const BreadcrumbItems = () => {
@@ -368,9 +367,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
 
     const nestedIndex = breadcrumbDirectoryFiles.indexOf(nestingDirectory.value)
 
-    breadcrumbDirectoryFiles = breadcrumbDirectoryFiles.filter((file, idx) => {
-      return idx >= nestedIndex
-    })
+    breadcrumbDirectoryFiles = breadcrumbDirectoryFiles.filter((_, idx) => idx >= nestedIndex)
 
     return (
       <Breadcrumbs

--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -203,3 +203,18 @@ export const extractZip = async (path: string): Promise<any> => {
     console.error('error extracting zip: ', err)
   }
 }
+
+export const downloadBlobAsZip = (blob: Blob, fileName: string) => {
+  const anchorElement = document.createElement('a')
+  anchorElement.href = URL.createObjectURL(blob)
+  anchorElement.download = fileName + '.zip'
+  document.body.appendChild(anchorElement)
+  anchorElement.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      view: window
+    })
+  )
+  document.body.removeChild(anchorElement)
+}


### PR DESCRIPTION
## Summary

- removes `save-as` as dependency in client-core
- adds new `downloadBlobAsZip` function to download blobs as zip file (used in the file browser)

## References
closes #9816

## QA Steps
