### PR TITLE
client settings missing in mocap

### DIFF
--- a/packages/client/src/pages/_app_tw.tsx
+++ b/packages/client/src/pages/_app_tw.tsx
@@ -40,6 +40,10 @@ import { loadWebappInjection } from '@etherealengine/projects/loadWebappInjectio
 import { ThemeProvider } from '@etherealengine/client-core/src/common/services/ThemeService'
 import PublicRouter, { CenteredLoadingCircle } from '../route/public_tw'
 
+import {
+  AdminClientSettingsState,
+  ClientSettingService
+} from '@etherealengine/client-core/src/admin/services/Setting/ClientSettingService'
 import { useTranslation } from 'react-i18next'
 import '../themes/base.css'
 import '../themes/components.css'
@@ -84,10 +88,15 @@ const AppPage = () => {
 const TailwindPage = () => {
   const notistackRef = useRef<SnackbarProvider>()
   const notificationstate = useHookstate(getMutableState(NotificationState))
+  const clientSettingState = useHookstate(getMutableState(AdminClientSettingsState))
 
   useEffect(() => {
     notificationstate.snackbar.set(notistackRef.current)
   }, [notistackRef.current])
+
+  useEffect(() => {
+    if (clientSettingState?.updateNeeded?.value) ClientSettingService.fetchClientSettings()
+  }, [clientSettingState?.updateNeeded?.value])
 
   return (
     <>


### PR DESCRIPTION
## Summary
GetVideoStream was failing as client settings were never populated. Usually this is done with themeProvider/themeContext actually so I just manually put it in our tailwind page for mocap. I can move this into just mocap but I assume we want these settings in most pages rn.

This fixes the issues ubquity have been seeing with video stream failing

## References
closes #_insert number here_

## QA Steps
Open Mocap. Turn on camera
