### PR TITLE
Prevent search component from reloading on Enter press

### DIFF
--- a/packages/editor/src/components/Search/Search.tsx
+++ b/packages/editor/src/components/Search/Search.tsx
@@ -49,6 +49,11 @@ const Search = (props: Props) => {
       <InputBase
         className={classes.input}
         onChange={handleChange}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault() // Prevent default behavior of form submission on Enter key press
+          }
+        }}
         placeholder="search..."
         endAdornment={<SearchIcon className={classes.iconButton} />}
       />


### PR DESCRIPTION
This pull request modifies the search component to prevent it from reloading the page when the Enter key is pressed. The `onKeyDown` event handler has been added to the input field, and if the Enter key is detected, the default form submission behavior is prevented. This improves the user experience by allowing them to search without triggering a page reload.