### PR TITLE
Create script for tailscale certs, ignore tailscale certs, automate .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ feathers/*
 packages/ui/tests/jest-test-results.json
 
 /.temp
+
+# tailscale cert/key
+certs/tailscale

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dev-docker-windows": "cd scripts && docker-compose up -d && docker-compose up -d -f docker-compose-minio.yml",
     "dev-tabs": "npm run dev-docker && cd scripts && ./dev-tabs.sh",
     "fetch-projects": "lerna exec 'git fetch -p && git rebase' --parallel --ignore @etherealengine/* --no-bail",
-    "dev-reinit": "npm run dev-docker && cd packages/server && npm run dev-reinit-db && cd ../../scripts && ./generate-certs.sh",
+    "dev-reinit": "./scripts/checkenv.sh && npm run dev-docker && cd packages/server && npm run dev-reinit-db",
     "dev-server": "cd packages/server && npm run dev",
     "dev-windows": "npm run dev-docker-windows && concurrently -n agones,server,client npm:dev-agones-silent npm:dev-server npm:dev-client",
     "diff": "lerna diff",

--- a/scripts/checkenv.sh
+++ b/scripts/checkenv.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+test -f .env.local || (printf "\033[0;33mNo .env.local found creating one with default config\033[0m\n" && cp .env.local.default .env.local && sleep 2)

--- a/scripts/tailscalecerts.sh
+++ b/scripts/tailscalecerts.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+if (( $EUID != 0 )); then
+    echo "Please run as root"
+    exit
+fi
+if (( "${PWD##*/}" != "etherealengine")); then
+    echo "Please run in /etherealengine"
+    exit
+fi
+instructions () {
+  printf "Open ${GREEN}/etherealengine/.env.local${NC}\n"
+  printf "Change all '${RED}localhost${NC}' to '${BLUE}$domain${NC}'\n"
+  printf "Change '${RED}CERT=certs/cert.pem${NC}' to '${BLUE}CERT=certs/tailscale/cert.pem${NC}'\n"
+  printf "Change '${RED}KEY=certs/key.pem${NC}' to '${BLUE}CERT=certs/tailscale/key.pem${NC}'\n"
+}
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+# Colors end
+
+case "$(uname -s)" in
+   Darwin)
+    if ! command -v /Applications/Tailscale.app/Contents/MacOS/Tailscale &> /dev/null
+    then
+        echo "tailscale could not be found"
+        echo "Install tailscale cli on your respective distro and login"
+        exit 1
+    fi
+    domain=$(/Applications/Tailscale.app/Contents/MacOS/Tailscale cert 2>&1 | grep -o '".*"' | sed 's/"//g')
+    tailscale cert $domain 2>&1>/dev/null
+    cp ~/Library/Containers/io.tailscale.ipn.macos/Data/$domain.crt certs/tailscale/cert.pem
+    cp ~/Library/Containers/io.tailscale.ipn.macos/Data/$domain.key certs/tailscale/key.pem
+    instructions
+     ;;
+   Linux)
+    if ! command -v tailscale &> /dev/null
+    then
+        echo "tailscale could not be found"
+        echo "Install tailscale cli on your respective distro and login"
+        exit 1
+    fi
+    domain=$(tailscale cert 2>&1 | grep -o '".*"' | sed 's/"//g')
+    tailscale cert --cert-file certs/tailscale/cert.pem --key-file certs/tailscale/key.pem $domain 2>&1>/dev/null
+    chmod 644 ./certs/cert.pem
+    chmod 644 ./certs/key.pem
+    instructions
+     ;;
+   CYGWIN*|MINGW32*|MSYS*|MINGW*)
+     echo 'MS Windows'
+     echo "Tailscale Cert generation not currently supported on windows"
+     ;;
+   *)
+    echo 'Not supported.'
+    echo 'Other OS' 
+     ;;
+esac


### PR DESCRIPTION
## Summary

- Ignore a tailscale folder in certs
- Script that will generate certs for tailscale magicdns
- Nothing fancy just the barebones logic no recoverable error checking
- No windows implementation as it can be run in WSL ubuntu
- Lastly I added a script to check for .env.local and create it if it doesn't exist. Added a sleep to it so users can read it.
