### PR TITLE
Updated auto-scrolling of instance chat window.

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -237,6 +237,19 @@ export const InstanceChat = ({ styles = defaultStyles }: InstanceChatProps) => {
     )
   }, [chatState.messageCreated.value])
 
+  // When messages change, scroll to most recent message if the previous most-recent message is at least partially visible
+  useEffect(() => {
+    const lastMessage = sortedMessages[sortedMessages.length - 1]
+    if (!sortedMessages.length) return
+    const lastMessageElement = document.getElementById(lastMessage.id)
+    if (!lastMessageElement) return
+    const rect = lastMessageElement.getBoundingClientRect()
+    const elemTop = rect.top
+    const elemBottom = rect.bottom
+    const isVisible = elemTop < window.innerHeight && elemBottom >= 0
+    if (isVisible) messageRef.current.scrollTop = messageRef.current.scrollHeight
+  }, [messages.data])
+
   const messageRef = useRef<any>()
 
   useEffect(() => {
@@ -289,7 +302,7 @@ export const InstanceChat = ({ styles = defaultStyles }: InstanceChatProps) => {
     return (
       <Fragment key={message.id as MessageID}>
         {message.isNotification ? (
-          <div key={message.id as MessageID} className={`${styles.selfEnd} ${styles.noMargin}`}>
+          <div key={message.id as MessageID} id={message.id} className={`${styles.selfEnd} ${styles.noMargin}`}>
             <div className={styles.dFlex}>
               <div className={`${styles.msgNotification} ${styles.mx2}`}>
                 <p className={styles.shadowText}>{message.text}</p>
@@ -297,7 +310,11 @@ export const InstanceChat = ({ styles = defaultStyles }: InstanceChatProps) => {
             </div>
           </div>
         ) : (
-          <div key={message.id as MessageID} className={`${styles.dFlex} ${styles.flexColumn} ${styles.mgSmall}`}>
+          <div
+            key={message.id as MessageID}
+            id={message.id}
+            className={`${styles.dFlex} ${styles.flexColumn} ${styles.mgSmall}`}
+          >
             <div className={`${styles.selfEnd} ${styles.noMargin}`}>
               <div
                 className={`${message.senderId !== user?.id.value ? styles.msgReplyContainer : styles.msgOwner} ${


### PR DESCRIPTION
## Summary

On message array changing, if the most recent message is in view, then scroll to the bottom of the chat window. If not, then don't scroll, as someone is looking at older messages and doesn't want to be moved away from that.

## References
closes #_insert number here_

## QA Steps
