### PR TITLE
Fixed bug with user disconnect on world instanceserver.

### DIFF
--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -340,6 +340,21 @@ export async function handleDisconnect(network: SocketWebRTCServerNetwork, peerI
             } as any
           )
         })
+        .catch((err) => {
+          app.service(messagePath).create(
+            {
+              instanceId: instanceServerState.instance.id,
+              text: `A user left`,
+              isNotification: true,
+              senderId: null
+            },
+            {
+              [identityProviderPath]: {
+                userId: userId
+              }
+            } as any
+          )
+        })
     }
     NetworkPeerFunctions.destroyPeer(network, peerID)
     updatePeers(network)


### PR DESCRIPTION
## Summary

If a user disconnected because they had signed in from being a guest, and the guest user was then destroyed because the logged-in user already existed, the instanceserver's attempt to create a 'user left' message was throwing an error because looking up that user by ID returned nothing. Now catching that and creating a generic user left message since their name is now impossible to find, with a null senderId because messages can't have a senderId of a non-existent user.

## References
closes #_insert number here_

## QA Steps
