### PR TITLE
Fixed issues with screenshare.

### DIFF
--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -82,7 +82,9 @@ export const useMediaWindows = () => {
         })
 
       const userScreens = consumers
-        .filter(([peerID, { cam, screen }]) => peerIDs.includes(peerID) && screen?.videoStream)
+        .filter(
+          ([peerID, { cam, screen }]) => peerIDs.includes(peerID) && screen?.videoStream && !screen?.videoStream?.closed
+        )
         .map(([peerID]) => {
           return { peerID, type: 'screen' as const }
         })

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -1233,6 +1233,15 @@ export const stopScreenshare = async (network: SocketWebRTCClientNetwork) => {
 
   console.log(mediaStreamState.screenVideoProducer.value, mediaStreamState.screenShareVideoPaused.value)
   if (mediaStreamState.screenVideoProducer.value) {
+    dispatchAction(
+      MediasoupMediaProducerActions.producerPaused({
+        producerID: mediaStreamState.screenVideoProducer.value.id,
+        globalMute: false,
+        paused: true,
+        $network: network.id,
+        $topic: network.topic
+      })
+    )
     await mediaStreamState.screenVideoProducer.value.pause()
     mediaStreamState.screenShareVideoPaused.set(true)
     dispatchAction(
@@ -1247,6 +1256,15 @@ export const stopScreenshare = async (network: SocketWebRTCClientNetwork) => {
   }
 
   if (mediaStreamState.screenAudioProducer.value) {
+    dispatchAction(
+      MediasoupMediaProducerActions.producerPaused({
+        producerID: mediaStreamState.screenAudioProducer.value.id,
+        globalMute: false,
+        paused: true,
+        $network: network.id,
+        $topic: network.topic
+      })
+    )
     dispatchAction(
       MediasoupMediaProducerActions.producerClosed({
         producerID: mediaStreamState.screenAudioProducer.value.id,

--- a/packages/instanceserver/src/MediasoupServerSystem.tsx
+++ b/packages/instanceserver/src/MediasoupServerSystem.tsx
@@ -42,6 +42,8 @@ import {
 import { SocketWebRTCServerNetwork } from './SocketWebRTCServerFunctions'
 import {
   createOutgoingDataProducer,
+  handleCloseConsumer,
+  handleCloseProducer,
   handleConsumeData,
   handleConsumerSetLayers,
   handleProduceData,
@@ -56,6 +58,8 @@ import {
 const requestConsumerActionQueue = defineActionQueue(MediasoupMediaConsumerActions.requestConsumer.matches)
 const consumerLayersActionQueue = defineActionQueue(MediasoupMediaConsumerActions.consumerLayers.matches)
 const requestProducerActionQueue = defineActionQueue(MediasoupMediaProducerActions.requestProducer.matches)
+const closeProducerActionQueue = defineActionQueue(MediasoupMediaProducerActions.producerClosed.matches)
+const closeConsumerActionQueue = defineActionQueue(MediasoupMediaConsumerActions.consumerClosed.matches)
 
 const dataRequestProducerActionQueue = defineActionQueue(MediasoupDataProducerActions.requestProducer.matches)
 const dataRequestConsumerActionQueue = defineActionQueue(MediasoupDataConsumerActions.requestConsumer.matches)
@@ -73,6 +77,12 @@ const execute = () => {
   }
   for (const action of requestProducerActionQueue()) {
     handleRequestProducer(action)
+  }
+  for (const action of closeConsumerActionQueue()) {
+    handleCloseConsumer(action)
+  }
+  for (const action of closeProducerActionQueue()) {
+    handleCloseProducer(action)
   }
 
   for (const action of dataRequestProducerActionQueue()) {

--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -346,7 +346,7 @@ export async function handleDisconnect(network: SocketWebRTCServerNetwork, peerI
               instanceId: instanceServerState.instance.id,
               text: `A user left`,
               isNotification: true,
-              senderId: null
+              senderId: undefined
             },
             {
               [identityProviderPath]: {


### PR DESCRIPTION
## Summary
Backend was not handling closeProducer and closeConsumer messages. WebRTCFunctions.ts was not saving producer objects in MediaSoupMediaProducersConsumersObjectsState. Close messages now attempt to close the object on in the instanceserver.

Fixed a bug where screenshare consumers that are closed were still showing as userScreens.

## References
closes #_insert number here_

## QA Steps
