### PR TITLE
Exlude UVOL from Normal Pass in post processing

### DIFF
--- a/packages/engine/src/scene/components/UVOL2Component.ts
+++ b/packages/engine/src/scene/components/UVOL2Component.ts
@@ -43,6 +43,8 @@ import { AnimationSystemGroup } from '@etherealengine/ecs/src/SystemGroups'
 import { getState } from '@etherealengine/hyperflux'
 import { isIPhone, isMobile } from '@etherealengine/spatial/src/common/functions/isMobile'
 import { addObjectToGroup, removeObjectFromGroup } from '@etherealengine/spatial/src/renderer/components/GroupComponent'
+import { setObjectLayers } from '@etherealengine/spatial/src/renderer/components/ObjectLayerComponent'
+import { ObjectLayers } from '@etherealengine/spatial/src/renderer/constants/ObjectLayers'
 import { isMobileXRHeadset } from '@etherealengine/spatial/src/xr/XRState'
 import { startTransition, useEffect, useMemo, useRef } from 'react'
 import {
@@ -573,6 +575,7 @@ transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
     _group.add(mesh)
     return _group
   }, [])
+  setObjectLayers(group, ObjectLayers.UVOL)
 
   useEffect(() => {
     if (volumetric.useLoadingEffect.value) {

--- a/packages/spatial/src/renderer/constants/ObjectLayers.ts
+++ b/packages/spatial/src/renderer/constants/ObjectLayers.ts
@@ -56,5 +56,7 @@ export const ObjectLayers = {
   // transform gizmo
   HighlightEffect: 11 as const,
 
+  UVOL: 30 as const,
+
   AssetPreview: 31 as const
 } as Record<string, number>

--- a/packages/spatial/src/renderer/functions/configureEffectComposer.ts
+++ b/packages/spatial/src/renderer/functions/configureEffectComposer.ts
@@ -30,7 +30,6 @@ import {
   EdgeDetectionMode,
   EffectComposer,
   EffectPass,
-  NormalPass,
   OutlineEffect,
   RenderPass,
   SMAAEffect,
@@ -39,6 +38,7 @@ import {
 } from 'postprocessing'
 import { VelocityDepthNormalPass } from 'realism-effects'
 import { DepthTexture, NearestFilter, PerspectiveCamera, RGBAFormat, UnsignedIntType, WebGLRenderTarget } from 'three'
+import { CustomNormalPass } from '../passes/CustomNormalPass'
 
 import { getState } from '@etherealengine/hyperflux'
 
@@ -105,7 +105,7 @@ export const configureEffectComposer = (
 
   const effectKeys = Object.keys(EffectMap)
 
-  const normalPass = new NormalPass(scene, camera)
+  const normalPass = new CustomNormalPass(scene, camera)
 
   const depthDownsamplingPass = new DepthDownsamplingPass({
     normalBuffer: normalPass.texture,

--- a/packages/spatial/src/renderer/passes/CustomNormalPass.js
+++ b/packages/spatial/src/renderer/passes/CustomNormalPass.js
@@ -1,3 +1,30 @@
+/*
+Original Source: https://github.com/pmndrs/postprocessing
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+
 import { Color, MeshNormalMaterial, NearestFilter, WebGLRenderTarget } from "three";
 import { Resolution, RenderPass, Pass } from "postprocessing";
 import { defineQuery } from "@etherealengine/ecs";

--- a/packages/spatial/src/renderer/passes/CustomNormalPass.js
+++ b/packages/spatial/src/renderer/passes/CustomNormalPass.js
@@ -1,0 +1,197 @@
+import { Color, MeshNormalMaterial, NearestFilter, WebGLRenderTarget } from "three";
+import { Resolution, RenderPass, Pass } from "postprocessing";
+import { defineQuery } from "@etherealengine/ecs";
+import { ObjectLayers } from "../constants/ObjectLayers";
+/**
+ * A pass that renders the normals of a given scene.
+ */
+
+export class CustomNormalPass extends Pass {
+
+	/**
+	 * Constructs a new normal pass.
+	 *
+	 * @param {Scene} scene - The scene to render.
+	 * @param {Camera} camera - The camera to use to render the scene.
+	 * @param {Object} [options] - The options.
+	 * @param {WebGLRenderTarget} [options.renderTarget] - A custom render target.
+	 * @param {Number} [options.resolutionScale=1.0] - The resolution scale.
+	 * @param {Number} [options.resolutionX=Resolution.AUTO_SIZE] - The horizontal resolution.
+	 * @param {Number} [options.resolutionY=Resolution.AUTO_SIZE] - The vertical resolution.
+	 * @param {Number} [options.width=Resolution.AUTO_SIZE] - Deprecated. Use resolutionX instead.
+	 * @param {Number} [options.height=Resolution.AUTO_SIZE] - Deprecated. Use resolutionY instead.
+	 */
+
+	constructor(scene, camera, {
+		renderTarget,
+		resolutionScale = 1.0,
+		width = Resolution.AUTO_SIZE,
+		height = Resolution.AUTO_SIZE,
+		resolutionX = width,
+		resolutionY = height,
+    ignore = []
+	} = {}) {
+
+		super("NormalPass");
+
+		this.needsSwap = false;
+
+		/**
+		 * A render pass.
+		 *
+		 * @type {RenderPass}
+		 * @private
+		 */
+
+		this.renderPass = new RenderPass(scene, camera, new MeshNormalMaterial());
+
+		const renderPass = this.renderPass;
+		renderPass.ignoreBackground = true;
+		renderPass.skipShadowMapUpdate = true;
+
+		const clearPass = renderPass.getClearPass();
+		clearPass.overrideClearColor = new Color(0x7777ff);
+		clearPass.overrideClearAlpha = 1.0;
+
+		/**
+		 * A render target for the scene normals.
+		 *
+		 * @type {WebGLRenderTarget}
+		 * @readonly
+		 */
+
+		this.renderTarget = renderTarget;
+
+		if(this.renderTarget === undefined) {
+
+			this.renderTarget = new WebGLRenderTarget(1, 1, {
+				minFilter: NearestFilter,
+				magFilter: NearestFilter
+			});
+
+			this.renderTarget.texture.name = "NormalPass.Target";
+
+		}
+
+		/**
+		 * The resolution.
+		 *
+		 * @type {Resolution}
+		 * @readonly
+		 */
+
+		const resolution = this.resolution = new Resolution(this, resolutionX, resolutionY, resolutionScale);
+		resolution.addEventListener("change", (e) => this.setSize(resolution.baseWidth, resolution.baseHeight));
+
+	}
+
+	set mainScene(value) {
+
+		this.renderPass.mainScene = value;
+
+	}
+
+	set mainCamera(value) {
+
+		this.renderPass.mainCamera = value;
+
+	}
+
+	/**
+	 * The normal texture.
+	 *
+	 * @type {Texture}
+	 */
+
+	get texture() {
+
+		return this.renderTarget.texture;
+
+	}
+
+	/**
+	 * The normal texture.
+	 *
+	 * @deprecated Use texture instead.
+	 * @return {Texture} The texture.
+	 */
+
+	getTexture() {
+
+		return this.renderTarget.texture;
+
+	}
+
+	/**
+	 * Returns the resolution settings.
+	 *
+	 * @deprecated Use resolution instead.
+	 * @return {Resolution} The resolution.
+	 */
+
+	getResolution() {
+
+		return this.resolution;
+
+	}
+
+	/**
+	 * Returns the current resolution scale.
+	 *
+	 * @return {Number} The resolution scale.
+	 * @deprecated Use resolution.preferredWidth or resolution.preferredHeight instead.
+	 */
+
+	getResolutionScale() {
+
+		return this.resolution.scale;
+
+	}
+
+	/**
+	 * Sets the resolution scale.
+	 *
+	 * @param {Number} scale - The new resolution scale.
+	 * @deprecated Use resolution.preferredWidth or resolution.preferredHeight instead.
+	 */
+
+	setResolutionScale(scale) {
+
+		this.resolution.scale = scale;
+
+	}
+
+	/**
+	 * Renders the scene normals.
+	 *
+	 * @param {WebGLRenderer} renderer - The renderer.
+	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
+	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
+	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
+	 */
+
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
+
+		const renderTarget = this.renderToScreen ? null : this.renderTarget;
+    this.renderPass.camera.layers.disable(ObjectLayers.UVOL)
+		this.renderPass.render(renderer, renderTarget, renderTarget);
+    this.renderPass.camera.layers.enable(ObjectLayers.UVOL)
+	}
+
+	/**
+	 * Updates the size of this pass.
+	 *
+	 * @param {Number} width - The width.
+	 * @param {Number} height - The height.
+	 */
+
+	setSize(width, height) {
+
+		const resolution = this.resolution;
+		resolution.setBaseSize(width, height);
+		this.renderTarget.setSize(resolution.width, resolution.height);
+
+	}
+
+}

--- a/packages/spatial/src/renderer/passes/CustomNormalPass.js
+++ b/packages/spatial/src/renderer/passes/CustomNormalPass.js
@@ -27,7 +27,6 @@ Ethereal Engine. All Rights Reserved.
 
 import { Color, MeshNormalMaterial, NearestFilter, WebGLRenderTarget } from "three";
 import { Resolution, RenderPass, Pass } from "postprocessing";
-import { defineQuery } from "@etherealengine/ecs";
 import { ObjectLayers } from "../constants/ObjectLayers";
 /**
  * A pass that renders the normals of a given scene.


### PR DESCRIPTION
## Summary
Since Uvol geometry doesn't move it was being caught up in the normal pass used in SSAO in its bind pose and was causing a ghost like artifact with SSAO.

## References
closes #_insert number here_

## QA Steps
