### PR TITLE
change tailwind select options prop `name` to `label`

### DIFF
--- a/packages/client-core/src/admin2/components/instance/PatchServerModal.tsx
+++ b/packages/client-core/src/admin2/components/instance/PatchServerModal.tsx
@@ -58,7 +58,7 @@ export default function PatchServerModal() {
 
   const locationsMenu = adminLocations.data.map((el) => {
     return {
-      name: el.name,
+      label: el.name,
       value: el.id
     }
   })

--- a/packages/client-core/src/admin2/components/invites/AddEditInviteModal.tsx
+++ b/packages/client-core/src/admin2/components/invites/AddEditInviteModal.tsx
@@ -105,15 +105,15 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
         const position = transform.props.position
         return {
           value: id,
-          name: `${id} (x: ${position.x}, y: ${position.y}, z: ${position.z})`
+          label: `${id} (x: ${position.x}, y: ${position.y}, z: ${position.z})`
         }
       }
       return {
         value: id,
-        name: id
+        label: id
       }
     }),
-    { value: '', name: t('admin:components.invite.selectSpawnPoint'), disabled: true }
+    { value: '', label: t('admin:components.invite.selectSpawnPoint'), disabled: true }
   ]
 
   const handleSubmit = async () => {
@@ -227,7 +227,7 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
         )}
         <Select
           label={t('admin:components.invite.type')}
-          options={inviteTypeOptions.map((type) => ({ name: t(`admin:components.invite.${type}`), value: type }))}
+          options={inviteTypeOptions.map((type) => ({ label: t(`admin:components.invite.${type}`), value: type }))}
           currentValue={inviteType.value}
           onChange={(value) => inviteType.set(value)}
         />
@@ -235,11 +235,11 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
           <Select
             label={t('admin:components.invite.location')}
             options={[
+              { value: '', label: t('admin:components.invite.selectLocation'), disabled: true },
               ...adminLocations.map((location) => ({
                 value: location.id,
-                name: `${location.name} (${location.sceneId})`
-              })),
-              { value: '', name: t('admin:components.invite.selectLocation'), disabled: true }
+                label: `${location.name} (${location.sceneId})`
+              }))
             ]}
             currentValue={inviteLocation.value}
             onChange={(value) => inviteLocation.set(value)}
@@ -250,11 +250,11 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
           <Select
             label={t('admin:components.invite.instance')}
             options={[
+              { value: '', label: t('admin:components.invite.selectInstance'), disabled: true },
               ...adminInstances.map((instance) => ({
-                name: `${instance.id} (${instance.location.name})`,
+                label: `${instance.id} (${instance.location.name})`,
                 value: instance.id
-              })),
-              { value: '', name: t('admin:components.invite.selectInstance'), disabled: true }
+              }))
             ]}
             currentValue={inviteInstance.value}
             onChange={(value) => inviteInstance.set(value)}
@@ -292,11 +292,13 @@ export default function AddEditInviteModal({ invite }: { invite?: InviteType }) 
                   <Select
                     label={t('admin:components.invite.userPosition')}
                     options={[
-                      ...adminUsers.map((user) => ({
-                        value: user.inviteCode,
-                        name: `${user.name} (${user.inviteCode})`
-                      })),
-                      { name: t('admin:components.invite.selectUserPosition'), value: '', disabled: true }
+                      { label: t('admin:components.invite.selectUserPosition'), value: '', disabled: true },
+                      ...adminUsers
+                        .filter((user) => user.inviteCode)
+                        .map((user) => ({
+                          value: user.inviteCode!,
+                          label: `${user.name} (${user.inviteCode})`
+                        }))
                     ]}
                     currentValue={userPosition.value}
                     onChange={(value) => userPosition.set(value)}

--- a/packages/client-core/src/admin2/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin2/components/locations/AddEditLocationModal.tsx
@@ -137,15 +137,15 @@ export default function AddEditLocationModal({ location }: { location?: Location
         <Select
           label={t('admin:components.location.lbl-scene')}
           currentValue={scene.value}
-          onChange={scene.set}
+          onChange={(value) => scene.set(value)}
           disabled={adminSceneState.retrieving.value}
           options={
             adminSceneState.retrieving.value
-              ? [{ value: '', name: t('common:select.fetching') }]
+              ? [{ value: '', label: t('common:select.fetching') }]
               : [
-                  { value: '', name: t('admin:components.location.selectScene'), disabled: true },
+                  { value: '', label: t('admin:components.location.selectScene'), disabled: true },
                   ...adminSceneState.scenes.value.map((scene) => ({
-                    name: `${scene.name} (${scene.project})`,
+                    label: `${scene.name} (${scene.project})`,
                     value: `${scene.project}/${scene.name}`
                   }))
                 ]

--- a/packages/client-core/src/admin2/components/project/AddEditProjectModal.tsx
+++ b/packages/client-core/src/admin2/components/project/AddEditProjectModal.tsx
@@ -44,9 +44,41 @@ import Select from '@etherealengine/ui/src/primitives/tailwind/Select'
 import Text from '@etherealengine/ui/src/primitives/tailwind/Text'
 import Toggle from '@etherealengine/ui/src/primitives/tailwind/Toggle'
 import { useHookstate } from '@hookstate/core'
+import { t } from 'i18next'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { CiCircleCheck, CiCircleRemove, CiWarning } from 'react-icons/ci'
+
+const autoUpdateIntervalOptions = [
+  {
+    value: '*/5 * * * *',
+    label: `5 ${t('admin:components.project.minutes')}`
+  },
+  {
+    value: '*/30 * * * *',
+    label: `30 ${t('admin:components.project.minutes')}`
+  },
+  {
+    value: '0 * * * *',
+    label: `1 ${t('admin:components.project.hour')}`
+  },
+  {
+    value: '0 */3 * * *',
+    label: `3 ${t('admin:components.project.hours')}`
+  },
+  {
+    value: '0 */6 * * *',
+    label: `6 ${t('admin:components.project.hours')}`
+  },
+  {
+    value: '0 */12 * * *',
+    label: `12 ${t('admin:components.project.hours')}`
+  },
+  {
+    value: '0 0 * * *',
+    label: `1 ${t('admin:components.project.day')}`
+  }
+]
 
 export default function AddEditProjectModal({
   update,
@@ -493,36 +525,7 @@ export default function AddEditProjectModal({
                   <div className="w-1/2">
                     <Select
                       label={t('admin:components.project.autoUpdateInterval')}
-                      options={[
-                        {
-                          value: '*/5 * * * *',
-                          name: `5 ${t('admin:components.project.minutes')}`
-                        },
-                        {
-                          value: '*/30 * * * *',
-                          name: `30 ${t('admin:components.project.minutes')}`
-                        },
-                        {
-                          value: '0 * * * *',
-                          name: `1 ${t('admin:components.project.hour')}`
-                        },
-                        {
-                          value: '0 */3 * * *',
-                          name: `3 ${t('admin:components.project.hours')}`
-                        },
-                        {
-                          value: '0 */6 * * *',
-                          name: `6 ${t('admin:components.project.hours')}`
-                        },
-                        {
-                          value: '0 */12 * * *',
-                          name: `12 ${t('admin:components.project.hours')}`
-                        },
-                        {
-                          value: '0 0 * * *',
-                          name: `1 ${t('admin:components.project.day')}`
-                        }
-                      ]}
+                      options={autoUpdateIntervalOptions}
                       currentValue={projectUpdateStatus.value?.updateSchedule || DefaultUpdateSchedule}
                       onChange={(value) => ProjectUpdateService.setUpdateSchedule(project.name, value)}
                     />

--- a/packages/client-core/src/admin2/components/project/UpdateEngineModal.tsx
+++ b/packages/client-core/src/admin2/components/project/UpdateEngineModal.tsx
@@ -65,7 +65,7 @@ export default function UpdateEngineModal() {
     })
     return {
       value: builderTag.tag,
-      name: `Commit ${builderTag.commitSHA?.slice(0, 8)} -- ${
+      label: `Commit ${builderTag.commitSHA?.slice(0, 8)} -- ${
         builderTag.tag === engineCommit ? '(Current) ' : ''
       }Version ${builderTag.engineVersion} -- Pushed ${pushedDate}`
     }

--- a/packages/client-core/src/admin2/components/user/AddEditUserModal.tsx
+++ b/packages/client-core/src/admin2/components/user/AddEditUserModal.tsx
@@ -36,7 +36,7 @@ import Input from '@etherealengine/ui/src/primitives/tailwind/Input'
 import Label from '@etherealengine/ui/src/primitives/tailwind/Label'
 import Modal from '@etherealengine/ui/src/primitives/tailwind/Modal'
 import MultiSelect from '@etherealengine/ui/src/primitives/tailwind/MultiSelect'
-import Select, { SelectProps } from '@etherealengine/ui/src/primitives/tailwind/Select'
+import Select, { SelectOptionsType } from '@etherealengine/ui/src/primitives/tailwind/Select'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import AccountIdentifiers from './AccountIdentifiers'
@@ -56,37 +56,37 @@ export default function AddEditUserModal({ user }: { user?: UserType }) {
       action: 'admin'
     }
   })
-  const avatarOptions =
+  const avatarOptions: SelectOptionsType =
     avatarsQuery.status === 'success'
       ? [
-          { name: t('admin:components.user.selectAvatar'), value: '', disabled: true },
-          ...avatarsQuery.data.map((av) => ({ name: av.name, value: av.id }))
+          { label: t('admin:components.user.selectAvatar'), value: '', disabled: true },
+          ...avatarsQuery.data.map((av) => ({ label: av.name, value: av.id }))
         ]
-      : [{ name: t('common:select.fetching'), value: '', disabled: true }]
+      : [{ label: t('common:select.fetching'), value: '', disabled: true }]
 
   const scopeTypesQuery = useFind(scopeTypePath, {
     query: {
       paginate: false
     }
   })
-  const scopeTypeOptions: SelectProps['options'] =
+  const scopeTypeOptions: SelectOptionsType =
     scopeTypesQuery.status === 'success'
       ? [
-          { name: t('admin:components.user.selectScopes'), value: '', disabled: true },
-          ...scopeTypesQuery.data.map((st) => ({ name: st.type, value: st.type }))
+          { label: t('admin:components.user.selectScopes'), value: '', disabled: true },
+          ...scopeTypesQuery.data.map((st) => ({ label: st.type, value: st.type }))
         ]
-      : [{ name: t('common:select.fetching'), value: '', disabled: true }]
+      : [{ label: t('common:select.fetching'), value: '', disabled: true }]
 
   if (user) {
     for (const scope of user.scopes || []) {
       const scopeExists = scopeTypeOptions.find((st) => st.value === scope.type)
       if (!scopeExists) {
-        scopeTypeOptions.push({ name: scope.type, value: scope.type })
+        scopeTypeOptions.push({ label: scope.type, value: scope.type })
       }
     }
 
     if (!avatarOptions.find((av) => av.value === user.avatarId)) {
-      avatarOptions.push({ name: user.avatar.name || user.avatarId, value: user.avatarId })
+      avatarOptions.push({ label: user.avatar.name || user.avatarId, value: user.avatarId })
     }
   }
 

--- a/packages/client-core/src/admin2/components/user/AddEditUserModal.tsx
+++ b/packages/client-core/src/admin2/components/user/AddEditUserModal.tsx
@@ -149,7 +149,7 @@ export default function AddEditUserModal({ user }: { user?: UserType }) {
       className="w-[50vw]"
       onSubmit={handleSubmit}
       onClose={() => PopoverState.hidePopupover()}
-      submitLoading={true}
+      submitLoading={submitLoading.value}
     >
       <div className="relative grid w-full gap-6">
         {errors.serviceError.value ? <p className="mt-2 text-rose-700">{errors.serviceError.value}</p> : null}

--- a/packages/ui/src/primitives/tailwind/MultiSelect/index.tsx
+++ b/packages/ui/src/primitives/tailwind/MultiSelect/index.tsx
@@ -35,19 +35,19 @@ import Input from '../Input'
 import Label from '../Label'
 import Text from '../Text'
 
-export interface MultiSelectProps {
+export interface MultiSelectProps<T extends string | number> {
   label?: string
   className?: string
   error?: string
   description?: string
-  options: { name: string; value: any; disabled?: boolean }[]
-  selectedOptions: any[]
-  onChange: (values: any[]) => void
+  options: { label: string; value: T; disabled?: boolean }[]
+  selectedOptions: T[]
+  onChange: (values: T[]) => void
   placeholder?: string
   menuClassName?: string
 }
 
-const MultiSelect = ({
+const MultiSelect = <T extends string | number>({
   className,
   label,
   error,
@@ -57,7 +57,7 @@ const MultiSelect = ({
   onChange,
   placeholder,
   menuClassName
-}: MultiSelectProps) => {
+}: MultiSelectProps<T>) => {
   const { t } = useTranslation()
   const twClassName = twMerge('bg-theme-primary relative', className)
   const ref = useRef<HTMLDivElement>(null)
@@ -72,12 +72,9 @@ const MultiSelect = ({
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     searchInput.set(e.target.value)
-    const newOptions: {
-      name: string
-      value: any
-    }[] = []
+    const newOptions: MultiSelectProps<T>['options'] = []
     for (let i = 0; i < options.length; i++) {
-      if (options[i].name.toLowerCase().startsWith(e.target.value.toLowerCase())) {
+      if (options[i].label.toLowerCase().startsWith(e.target.value.toLowerCase())) {
         newOptions.push(options[i])
       }
     }
@@ -109,7 +106,7 @@ const MultiSelect = ({
             key={selectedOption}
             className="border-theme-primary m-1 flex h-7 items-center justify-center gap-1 rounded border bg-neutral-300 p-1 font-medium text-black"
           >
-            <Text className="text-black">{options.find((opt) => opt.value === selectedOption)?.name}</Text>
+            <Text className="text-black">{options.find((opt) => opt.value === selectedOption)?.label}</Text>
             <HiXCircle onClick={() => onChange(selectedOptions.filter((opt) => opt !== selectedOption))} />
           </div>
         ))}
@@ -148,7 +145,7 @@ const MultiSelect = ({
               }}
             >
               {option.disabled ? (
-                <Label>{option.name}</Label>
+                <Label>{option.label}</Label>
               ) : (
                 <Checkbox
                   onChange={(selected) => {
@@ -159,7 +156,7 @@ const MultiSelect = ({
                     }
                   }}
                   value={selectedOptions.some((opt) => opt && opt === option.value)}
-                  label={option.name}
+                  label={option.label}
                 />
               )}
             </li>

--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -31,20 +31,24 @@ import { MdOutlineKeyboardArrowDown } from 'react-icons/md'
 import { twMerge } from 'tailwind-merge'
 import Input from '../Input'
 
-export interface SelectProps {
+type OptionValueType = string | number
+
+export type SelectOptionsType = { label: string; value: any; disabled?: boolean }[]
+
+export interface SelectProps<T extends OptionValueType> {
   label?: string
   className?: string
   error?: string
   description?: string
-  options: { name: string; value: any; disabled?: boolean }[]
-  currentValue: any
-  onChange: (value: any) => void
+  options: { label: string; value: T; disabled?: boolean }[]
+  currentValue: T
+  onChange: (value: T) => void
   placeholder?: string
   disabled?: boolean
   menuClassname?: string
 }
 
-const Select = ({
+const Select = <T extends OptionValueType>({
   className,
   label,
   error,
@@ -55,7 +59,7 @@ const Select = ({
   placeholder,
   disabled,
   menuClassname
-}: SelectProps) => {
+}: SelectProps<T>) => {
   const ref = useRef<HTMLDivElement>(null)
   const { t } = useTranslation()
 
@@ -67,12 +71,9 @@ const Select = ({
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     selectLabel.set(e.target.value)
-    const newOptions: {
-      name: string
-      value: any
-    }[] = []
+    const newOptions: SelectOptionsType = []
     for (let i = 0; i < options.length; i++) {
-      if (options[i].name.toLowerCase().startsWith(e.target.value.toLowerCase())) {
+      if (options[i].label.toLowerCase().startsWith(e.target.value.toLowerCase())) {
         newOptions.push(options[i])
       }
     }
@@ -81,7 +82,7 @@ const Select = ({
 
   const selectLabel = useHookstate('')
   useEffect(() => {
-    const labelName = options.find((option) => option.value === currentValue)?.name
+    const labelName = options.find((option) => option.value === currentValue)?.label
     if (labelName) selectLabel.set(labelName)
   }, [currentValue, options])
 
@@ -129,7 +130,7 @@ const Select = ({
                 onChange(option.value)
               }}
             >
-              {option.name}
+              {option.label}
             </li>
           ))}
         </ul>

--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -71,7 +71,7 @@ const Select = <T extends OptionValueType>({
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     selectLabel.set(e.target.value)
-    const newOptions: SelectOptionsType = []
+    const newOptions: SelectProps<T>['options'] = []
     for (let i = 0; i < options.length; i++) {
       if (options[i].label.toLowerCase().startsWith(e.target.value.toLowerCase())) {
         newOptions.push(options[i])


### PR DESCRIPTION
## Summary

- change tailwind select options prop `name` to `label`
- also add generic typing to props
- also implement `label` prop in tailwind multiselect

## References
closes #_insert number here_

## QA Steps
