### PR TITLE
Fixed issue in build_and_publish_package.sh

### DIFF
--- a/scripts/build_and_publish_package.sh
+++ b/scripts/build_and_publish_package.sh
@@ -23,8 +23,8 @@ fi
 #echo "PRUNED"
 #docker buildx version
 #
-docker context create etherealengine-$PACKAGE
-docker buildx create --driver=docker-container etherealengine-$PACKAGE --name etherealengine-$PACKAGE --driver-opt "image=moby/buildkit:v0.12.0"
+docker context create etherealengine-$PACKAGE-context
+docker buildx create --driver=docker-container etherealengine-$PACKAGE-context --name etherealengine-$PACKAGE --driver-opt "image=moby/buildkit:v0.13.0"
 
 BUILD_START_TIME=`date +"%d-%m-%yT%H-%M-%S"`
 echo "Starting ${PACKAGE} build at ${BUILD_START_TIME}"


### PR DESCRIPTION
## Summary

For some reason, having a builder name be the same as the context name is now disallowed. Changed the context name so they're not identical.

Updated buildkit to v0.13


## References
closes #_insert number here_

## QA Steps
