### PR TITLE
fix dir perms

### DIFF
--- a/scripts/tailscalecerts.sh
+++ b/scripts/tailscalecerts.sh
@@ -30,7 +30,7 @@ case "$(uname -s)" in
         exit 1
     fi
     domain=$(/Applications/Tailscale.app/Contents/MacOS/Tailscale cert 2>&1 | grep -o '".*"' | sed 's/"//g')
-    mkdir -p ./certs/tailscale
+    mkdir -p ./certs/tailscale && chmod 644 ./certs/tailscale
     tailscale cert $domain 2>&1>/dev/null
     cp ~/Library/Containers/io.tailscale.ipn.macos/Data/$domain.crt certs/tailscale/cert.pem
     cp ~/Library/Containers/io.tailscale.ipn.macos/Data/$domain.key certs/tailscale/key.pem
@@ -44,7 +44,7 @@ case "$(uname -s)" in
         exit 1
     fi
     domain=$(tailscale cert 2>&1 | grep -o '".*"' | sed 's/"//g')
-    mkdir -p ./certs/tailscale
+    mkdir -p ./certs/tailscale && chmod 644 ./certs/tailscale
     tailscale cert --cert-file certs/tailscale/cert.pem --key-file certs/tailscale/key.pem $domain 2>&1>/dev/null
     chmod 644 ./certs/tailscale/cert.pem
     chmod 600 ./certs/tailscale/key.pem


### PR DESCRIPTION
## Summary
For some reason at least on ubuntu the perms of the dir meant vite couldn't access the certs. Had to change the dir perms to match the cert.

## References
closes #_insert number here_

## QA Steps
