### PR TITLE
Implement non reactive canSleep

### DIFF
--- a/packages/spatial/src/physics/components/RigidBodyComponent.ts
+++ b/packages/spatial/src/physics/components/RigidBodyComponent.ts
@@ -77,7 +77,7 @@ export const RigidBodyComponent = defineComponent({
       angularVelocity: proxifyVector3(this.angularVelocity, entity),
       /** If multiplier is 0, ridigbody moves immediately to target pose, linearly interpolating between substeps */
       targetKinematicLerpMultiplier: 0,
-      canSleep: true
+      canSleep: true /** Not a reactive property. Only on Init*/
     }
   },
 

--- a/packages/spatial/src/physics/components/RigidBodyComponent.ts
+++ b/packages/spatial/src/physics/components/RigidBodyComponent.ts
@@ -76,7 +76,8 @@ export const RigidBodyComponent = defineComponent({
       linearVelocity: proxifyVector3(this.linearVelocity, entity),
       angularVelocity: proxifyVector3(this.angularVelocity, entity),
       /** If multiplier is 0, ridigbody moves immediately to target pose, linearly interpolating between substeps */
-      targetKinematicLerpMultiplier: 0
+      targetKinematicLerpMultiplier: 0,
+      canSleep: true
     }
   },
 
@@ -86,6 +87,7 @@ export const RigidBodyComponent = defineComponent({
     if (typeof json.type === 'string') component.type.set(json.type)
     if (typeof json.ccd === 'boolean') component.ccd.set(json.ccd)
     if (typeof json.allowRolling === 'boolean') component.allowRolling.set(json.allowRolling)
+    if (typeof json.canSleep === 'boolean') component.canSleep.set(json.canSleep)
     if (Array.isArray(json.enabledRotations) && json.enabledRotations.length === 3)
       component.enabledRotations.set(json.enabledRotations)
   },
@@ -95,11 +97,12 @@ export const RigidBodyComponent = defineComponent({
       type: component.type.value as Body,
       ccd: component.ccd.value,
       allowRolling: component.allowRolling.value,
-      enabledRotations: component.enabledRotations.value
+      enabledRotations: component.enabledRotations.value,
+      canSleep: component.canSleep.value
     }
   },
 
-  reactor: function () {
+  reactor: function (props) {
     const entity = useEntityContext()
     const component = useComponent(entity, RigidBodyComponent)
 
@@ -119,6 +122,7 @@ export const RigidBodyComponent = defineComponent({
           rigidBodyDesc = RigidBodyDesc.kinematicPositionBased()
           break
       }
+      if (component.canSleep.value) rigidBodyDesc.setCanSleep(component.canSleep.value)
 
       const world = getState(PhysicsState).physicsWorld
       const rigidBody = Physics.createRigidBody(entity, world, rigidBodyDesc)

--- a/packages/spatial/src/physics/components/RigidBodyComponent.ts
+++ b/packages/spatial/src/physics/components/RigidBodyComponent.ts
@@ -65,7 +65,7 @@ export const RigidBodyComponent = defineComponent({
       ccd: false,
       allowRolling: true,
       enabledRotations: [true, true, true],
-      canSleep: true, /** Not a reactive property. Only on Init*/
+      canSleep: true /** Not a reactive property. Only on Init*/,
       // internal
       body: null! as RigidBody,
       previousPosition: proxifyVector3(this.previousPosition, entity),

--- a/packages/spatial/src/physics/components/RigidBodyComponent.ts
+++ b/packages/spatial/src/physics/components/RigidBodyComponent.ts
@@ -102,7 +102,7 @@ export const RigidBodyComponent = defineComponent({
     }
   },
 
-  reactor: function (props) {
+  reactor: function () {
     const entity = useEntityContext()
     const component = useComponent(entity, RigidBodyComponent)
 

--- a/packages/spatial/src/physics/components/RigidBodyComponent.ts
+++ b/packages/spatial/src/physics/components/RigidBodyComponent.ts
@@ -65,6 +65,7 @@ export const RigidBodyComponent = defineComponent({
       ccd: false,
       allowRolling: true,
       enabledRotations: [true, true, true],
+      canSleep: true, /** Not a reactive property. Only on Init*/
       // internal
       body: null! as RigidBody,
       previousPosition: proxifyVector3(this.previousPosition, entity),
@@ -76,8 +77,7 @@ export const RigidBodyComponent = defineComponent({
       linearVelocity: proxifyVector3(this.linearVelocity, entity),
       angularVelocity: proxifyVector3(this.angularVelocity, entity),
       /** If multiplier is 0, ridigbody moves immediately to target pose, linearly interpolating between substeps */
-      targetKinematicLerpMultiplier: 0,
-      canSleep: true /** Not a reactive property. Only on Init*/
+      targetKinematicLerpMultiplier: 0
     }
   },
 


### PR DESCRIPTION
## Summary
Ubiquity is utilizing the canSleep functionality and we didn't expose it. There's no good way to make it reactive without recreating the rigid body and I wasn't okay with doing so.

My only other idea would be to implement reactor init props that we can pass in so that the canSleep property isn't on the component and therefore no exposed as a reactive property.

## References
closes #_insert number here_

## QA Steps
