### PR TITLE
Add SceneKillHeightSystem to handle killing entities below a certain height

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -294,7 +294,13 @@
       "description": "An invisible box that objects will bounce off of or rest on top of.\nWithout colliders, objects will fall through floors and go through walls.",
       "lbl-isTrigger": "Trigger",
       "lbl-shape": "Shape",
-      "lbl-type": "Body Type"
+      "lbl-type": "Body Type",
+      "lbl-mass": "Mass",
+      "lbl-massCenter":"Mass Center",
+      "lbl-friction":"Friction",
+      "lbl-restitution":"Restitution",
+      "lbl-collisionLayer":"Collision Layer",
+      "lbl-collisionMask":"Collision Mask"
     },
     "camera": {
       "name": "Camera",

--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -722,7 +722,8 @@
       "save": "Save",
       "lbl-loading": "Loading Screen",
       "info-loading": "Change the loading screen",
-      "lbl-colors": "Colors"
+      "lbl-colors": "Colors",
+      "lbl-killHeight": "Kill Height"
     },
     "scene": {
       "name": "Scene",

--- a/packages/editor/src/components/properties/SceneSettingsEditor.tsx
+++ b/packages/editor/src/components/properties/SceneSettingsEditor.tsx
@@ -47,6 +47,7 @@ import { PropertiesPanelButton } from '../inputs/Button'
 import ColorInput from '../inputs/ColorInput'
 import ImagePreviewInput from '../inputs/ImagePreviewInput'
 import InputGroup from '../inputs/InputGroup'
+import NumericInputGroup from '../inputs/NumericInputGroup'
 import PropertyGroup from './PropertyGroup'
 import { EditorComponentType, commitProperties, commitProperty, updateProperty } from './Util'
 
@@ -161,61 +162,75 @@ export const SceneSettingsEditor: EditorComponentType = (props) => {
         label={t('editor:properties.sceneSettings.lbl-thumbnail')}
         info={t('editor:properties.sceneSettings.info-thumbnail')}
       >
-        <PropertiesPanelButton onClick={createThumbnail}>
-          {t('editor:properties.sceneSettings.generate')}
-        </PropertiesPanelButton>
-        {state.uploadingThumbnail.value ? (
-          <LoadingCircle />
-        ) : (
-          <PropertiesPanelButton onClick={uploadThumbnail} disabled={!state.thumbnail.value}>
-            {t('editor:properties.sceneSettings.save')}
+        <div>
+          <ImagePreviewInput value={state.thumbnailURL.value ?? sceneSettingsComponent.thumbnailURL.value} />
+
+          <PropertiesPanelButton onClick={createThumbnail}>
+            {t('editor:properties.sceneSettings.generate')}
           </PropertiesPanelButton>
-        )}
-        <ImagePreviewInput value={state.thumbnailURL.value ?? sceneSettingsComponent.thumbnailURL.value} />
+          {state.uploadingThumbnail.value ? (
+            <LoadingCircle />
+          ) : (
+            <PropertiesPanelButton onClick={uploadThumbnail} disabled={!state.thumbnail.value}>
+              {t('editor:properties.sceneSettings.save')}
+            </PropertiesPanelButton>
+          )}
+        </div>
       </InputGroup>
       <InputGroup
         name="Loading Screen"
         label={t('editor:properties.sceneSettings.lbl-loading')}
         info={t('editor:properties.sceneSettings.info-loading')}
       >
-        <PropertiesPanelButton onClick={createLoadingScreen}>
-          {t('editor:properties.sceneSettings.generate')}
-        </PropertiesPanelButton>
-        {state.uploadingLoadingScreen.value ? (
-          <LoadingCircle />
-        ) : (
-          <PropertiesPanelButton onClick={uploadLoadingScreen} disabled={!state.loadingScreenImageData.value}>
-            {t('editor:properties.sceneSettings.save')}
+        <div>
+          <ImagePreviewInput value={state.loadingScreenURL.value ?? sceneSettingsComponent.loadingScreenURL.value} />
+          <PropertiesPanelButton onClick={createLoadingScreen}>
+            {t('editor:properties.sceneSettings.generate')}
           </PropertiesPanelButton>
-        )}
-        <ImagePreviewInput value={state.loadingScreenURL.value ?? sceneSettingsComponent.loadingScreenURL.value} />
+          {state.uploadingLoadingScreen.value ? (
+            <LoadingCircle />
+          ) : (
+            <PropertiesPanelButton onClick={uploadLoadingScreen} disabled={!state.loadingScreenImageData.value}>
+              {t('editor:properties.sceneSettings.save')}
+            </PropertiesPanelButton>
+          )}
+        </div>
       </InputGroup>
       <InputGroup name="Primary Color" label={t('editor:properties.sceneSettings.lbl-colors')}>
-        <PropertiesPanelButton onClick={generateColors}>
-          {t('editor:properties.sceneSettings.generate')}
-        </PropertiesPanelButton>
-        <ColorInput
-          disabled={!state.thumbnailURL.value && !sceneSettingsComponent.thumbnailURL.value}
-          value={new Color(sceneSettingsComponent.primaryColor.value)}
-          onSelect={(val) => updateProperty(SceneSettingsComponent, 'primaryColor')('#' + val.getHexString())}
-          onChange={(val) => updateProperty(SceneSettingsComponent, 'primaryColor')('#' + val.getHexString())}
-          onRelease={(val) => commitProperty(SceneSettingsComponent, 'primaryColor')('#' + val.getHexString())}
-        />
-        <ColorInput
-          disabled={!state.thumbnailURL.value && !sceneSettingsComponent.thumbnailURL.value}
-          value={new Color(sceneSettingsComponent.backgroundColor.value)}
-          onSelect={(val) => updateProperty(SceneSettingsComponent, 'backgroundColor')('#' + val.getHexString())}
-          onChange={(val) => updateProperty(SceneSettingsComponent, 'backgroundColor')('#' + val.getHexString())}
-          onRelease={(val) => commitProperty(SceneSettingsComponent, 'backgroundColor')('#' + val.getHexString())}
-        />
-        <ColorInput
-          disabled={!state.thumbnailURL.value && !sceneSettingsComponent.thumbnailURL.value}
-          value={new Color(sceneSettingsComponent.alternativeColor.value)}
-          onSelect={(val) => updateProperty(SceneSettingsComponent, 'alternativeColor')('#' + val.getHexString())}
-          onChange={(val) => updateProperty(SceneSettingsComponent, 'alternativeColor')('#' + val.getHexString())}
-          onRelease={(val) => commitProperty(SceneSettingsComponent, 'alternativeColor')('#' + val.getHexString())}
-        />
+        <div>
+          <ColorInput
+            disabled={!state.thumbnailURL.value && !sceneSettingsComponent.thumbnailURL.value}
+            value={new Color(sceneSettingsComponent.primaryColor.value)}
+            onSelect={(val) => updateProperty(SceneSettingsComponent, 'primaryColor')('#' + val.getHexString())}
+            onChange={(val) => updateProperty(SceneSettingsComponent, 'primaryColor')('#' + val.getHexString())}
+            onRelease={(val) => commitProperty(SceneSettingsComponent, 'primaryColor')('#' + val.getHexString())}
+          />
+          <ColorInput
+            disabled={!state.thumbnailURL.value && !sceneSettingsComponent.thumbnailURL.value}
+            value={new Color(sceneSettingsComponent.backgroundColor.value)}
+            onSelect={(val) => updateProperty(SceneSettingsComponent, 'backgroundColor')('#' + val.getHexString())}
+            onChange={(val) => updateProperty(SceneSettingsComponent, 'backgroundColor')('#' + val.getHexString())}
+            onRelease={(val) => commitProperty(SceneSettingsComponent, 'backgroundColor')('#' + val.getHexString())}
+          />
+          <ColorInput
+            disabled={!state.thumbnailURL.value && !sceneSettingsComponent.thumbnailURL.value}
+            value={new Color(sceneSettingsComponent.alternativeColor.value)}
+            onSelect={(val) => updateProperty(SceneSettingsComponent, 'alternativeColor')('#' + val.getHexString())}
+            onChange={(val) => updateProperty(SceneSettingsComponent, 'alternativeColor')('#' + val.getHexString())}
+            onRelease={(val) => commitProperty(SceneSettingsComponent, 'alternativeColor')('#' + val.getHexString())}
+          />
+          <PropertiesPanelButton onClick={generateColors}>
+            {t('editor:properties.sceneSettings.generate')}
+          </PropertiesPanelButton>
+        </div>
       </InputGroup>
+      <NumericInputGroup
+        name="Kill Height"
+        label={t('editor:properties.sceneSettings.lbl-killHeight')}
+        value={sceneSettingsComponent.sceneKillHeight.value}
+        onChange={updateProperty(SceneSettingsComponent, 'sceneKillHeight')}
+        onRelease={commitProperty(SceneSettingsComponent, 'sceneKillHeight')}
+      />
     </PropertyGroup>
   )
 }

--- a/packages/editor/src/functions/SceneSnapshot.test.tsx
+++ b/packages/editor/src/functions/SceneSnapshot.test.tsx
@@ -342,7 +342,7 @@ describe('Snapshots', () => {
     assert.equal(
       UUIDComponent.getEntityByUUID('child_2_1' as EntityUUID),
       UndefinedEntity,
-      'snapshot unchanged,  entity was not deleted'
+      'snapshot unchanged, entity child_2_1 was not deleted'
     )
 
     dispatchAction(SceneSnapshotAction.undo({ count: 1, sceneID: sceneID }))

--- a/packages/engine/src/avatar/systems/AvatarControllerSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarControllerSystem.ts
@@ -39,7 +39,6 @@ import { NetworkObjectAuthorityTag, NetworkState, WorldNetworkAction } from '@et
 import { TransformComponent, TransformSystem } from '@etherealengine/spatial'
 import { FollowCameraComponent } from '@etherealengine/spatial/src/camera/components/FollowCameraComponent'
 import { TargetCameraRotationComponent } from '@etherealengine/spatial/src/camera/components/TargetCameraRotationComponent'
-import { RigidBodyComponent } from '@etherealengine/spatial/src/physics/components/RigidBodyComponent'
 import { DistanceFromLocalClientComponent } from '@etherealengine/spatial/src/transform/components/DistanceComponents'
 import { getDistanceSquaredFromTarget } from '@etherealengine/spatial/src/transform/systems/TransformSystem'
 import { XRControlsState } from '@etherealengine/spatial/src/xr/XRState'
@@ -47,7 +46,6 @@ import { Vector3 } from 'three'
 import { AvatarComponent } from '../components/AvatarComponent'
 import { AvatarControllerComponent } from '../components/AvatarControllerComponent'
 import { AvatarHeadDecapComponent } from '../components/AvatarIKComponents'
-import { respawnAvatar } from '../functions/respawnAvatar'
 import { AvatarInputSystem } from './AvatarInputSystem'
 
 const controllerQuery = defineQuery([AvatarControllerComponent, NetworkObjectAuthorityTag])
@@ -97,9 +95,6 @@ const execute = () => {
         setComponent(entity, NetworkObjectAuthorityTag)
       }
     }
-
-    const rigidbody = getComponent(entity, RigidBodyComponent)
-    if (rigidbody.position.y < -10) respawnAvatar(entity)
   }
 }
 

--- a/packages/engine/src/scene/SceneModule.ts
+++ b/packages/engine/src/scene/SceneModule.ts
@@ -64,6 +64,7 @@ import { MeshBVHSystem } from './systems/MeshBVHSystem'
 import { ParticleSystem } from './systems/ParticleSystemSystem'
 import { PortalSystem } from './systems/PortalSystem'
 import { SDFSystem } from './systems/SDFSystem'
+import { SceneKillHeightSystem } from './systems/SceneKillHeightSystem'
 import { SceneLoadingSystem } from './systems/SceneLoadingSystem'
 import { SceneObjectDynamicLoadSystem } from './systems/SceneObjectDynamicLoadSystem'
 import { SceneObjectSystem } from './systems/SceneObjectSystem'
@@ -122,6 +123,7 @@ export {
   ParticleSystem,
   PortalSystem,
   SceneLoadingSystem,
+  SceneKillHeightSystem,
   SceneObjectDynamicLoadSystem,
   SceneObjectSystem,
   SDFSystem,

--- a/packages/engine/src/scene/components/SceneSettingsComponent.ts
+++ b/packages/engine/src/scene/components/SceneSettingsComponent.ts
@@ -35,7 +35,8 @@ export const SceneSettingsComponent = defineComponent({
       loadingScreenURL: '',
       primaryColor: '#000000',
       backgroundColor: '#FFFFFF',
-      alternativeColor: '#000000'
+      alternativeColor: '#000000',
+      sceneKillHeight: -10
     }
   },
 
@@ -47,6 +48,7 @@ export const SceneSettingsComponent = defineComponent({
     if (typeof json.primaryColor === 'string') component.primaryColor.set(json.primaryColor)
     if (typeof json.backgroundColor === 'string') component.backgroundColor.set(json.backgroundColor)
     if (typeof json.alternativeColor === 'string') component.alternativeColor.set(json.alternativeColor)
+    if (typeof json.sceneKillHeight === 'number') component.sceneKillHeight.set(json.sceneKillHeight)
   },
 
   toJSON: (entity, component) => {
@@ -55,7 +57,8 @@ export const SceneSettingsComponent = defineComponent({
       loadingScreenURL: component.loadingScreenURL.value,
       primaryColor: component.primaryColor.value,
       backgroundColor: component.backgroundColor.value,
-      alternativeColor: component.alternativeColor.value
+      alternativeColor: component.alternativeColor.value,
+      sceneKillHeight: component.sceneKillHeight.value
     }
   }
 })

--- a/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
@@ -60,7 +60,6 @@ const execute = () => {
       // reset entity
       const uuid = getComponent(entity, UUIDComponent)
       const spawnState = getState(SpawnPoseState)[uuid]
-      console.log('reseting ', entity, spawnState?.spawnPosition)
       setComponent(entity, TransformComponent, {
         position: spawnState?.spawnPosition,
         rotation: spawnState?.spawnRotation

--- a/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
@@ -53,6 +53,7 @@ const heightKillApplicableQuery = defineQuery([
 
 const settingsQuery = defineQuery([SceneSettingsComponent])
 const tempVector = new Vector3()
+
 const execute = () => {
   const settingsEntities = settingsQuery()
   const sceneKillHeight = settingsEntities.reduce((min, entity) => {
@@ -63,11 +64,10 @@ const execute = () => {
   for (const entity of killableEntities) {
     const rigidBodyPosition = getComponent(entity, RigidBodyComponent).position
     if (rigidBodyPosition.y < sceneKillHeight) {
-      // reset entity
-
       const uuid = getComponent(entity, UUIDComponent)
       const spawnState = getState(SpawnPoseState)[uuid]
 
+      // reset entity to it's spawn position
       setComponent(entity, TransformComponent, {
         position: spawnState?.spawnPosition,
         rotation: spawnState?.spawnRotation
@@ -75,14 +75,16 @@ const execute = () => {
       TransformComponent.dirtyTransforms[entity] = true
 
       const { cameraAttachedRigidbodyEntity } = getState(PhysicsState)
-      if (entity !== cameraAttachedRigidbodyEntity) return
+      if (entity !== cameraAttachedRigidbodyEntity) continue
+
       const { isCameraAttachedToAvatar } = getState(XRControlsState)
-      if (!isCameraAttachedToAvatar) return
+      if (!isCameraAttachedToAvatar) continue
+
+      //@TODO see if we can implicitly update the reference space when the avatar teleports
       updateReferenceSpaceFromAvatarMovement(
         entity,
         tempVector.subVectors(spawnState?.spawnPosition, rigidBodyPosition)
       )
-      //@TODO see if we can implicitly update the reference space when the avatar teleports
     }
   }
 }

--- a/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
@@ -1,0 +1,77 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import {
+  SimulationSystemGroup,
+  UUIDComponent,
+  defineQuery,
+  defineSystem,
+  getComponent,
+  setComponent
+} from '@etherealengine/ecs'
+import { getState } from '@etherealengine/hyperflux'
+import { NetworkObjectAuthorityTag } from '@etherealengine/network'
+import { SpawnPoseState, TransformComponent } from '@etherealengine/spatial'
+import {
+  RigidBodyComponent,
+  RigidBodyFixedTagComponent
+} from '@etherealengine/spatial/src/physics/components/RigidBodyComponent'
+import { Not } from 'bitecs'
+import { SceneSettingsComponent } from '../components/SceneSettingsComponent'
+
+const heightKillApplicableQuery = defineQuery([
+  RigidBodyComponent,
+  NetworkObjectAuthorityTag,
+  Not(RigidBodyFixedTagComponent)
+])
+const settingsQuery = defineQuery([SceneSettingsComponent])
+
+const execute = () => {
+  const settingsEntities = settingsQuery()
+  const sceneKillHeight = settingsEntities.reduce((min, entity) => {
+    return Math.min(min, getComponent(entity, SceneSettingsComponent).sceneKillHeight)
+  }, Number.MAX_VALUE)
+  const killableEntities = heightKillApplicableQuery()
+  for (const entity of killableEntities) {
+    const rigidBodyTransform = getComponent(entity, RigidBodyComponent).position
+    if (rigidBodyTransform.y < sceneKillHeight) {
+      // reset entity
+      const uuid = getComponent(entity, UUIDComponent)
+      const spawnState = getState(SpawnPoseState)[uuid]
+      console.log('reseting ', entity, spawnState?.spawnPosition)
+      setComponent(entity, TransformComponent, {
+        position: spawnState?.spawnPosition,
+        rotation: spawnState?.spawnRotation
+      })
+      TransformComponent.dirtyTransforms[entity] = true
+    }
+  }
+}
+
+export const SceneKillHeightSystem = defineSystem({
+  uuid: 'ee.engine.SceneKillHeightSystem',
+  insert: { before: SimulationSystemGroup },
+  execute
+})

--- a/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneKillHeightSystem.tsx
@@ -52,8 +52,7 @@ const heightKillApplicableQuery = defineQuery([
 ])
 
 const settingsQuery = defineQuery([SceneSettingsComponent])
-const userAvatarQuery = defineQuery([SceneSettingsComponent])
-
+const tempVector = new Vector3()
 const execute = () => {
   const settingsEntities = settingsQuery()
   const sceneKillHeight = settingsEntities.reduce((min, entity) => {
@@ -81,7 +80,7 @@ const execute = () => {
       if (!isCameraAttachedToAvatar) return
       updateReferenceSpaceFromAvatarMovement(
         entity,
-        new Vector3().subVectors(spawnState?.spawnPosition, rigidBodyPosition)
+        tempVector.subVectors(spawnState?.spawnPosition, rigidBodyPosition)
       )
       //@TODO see if we can implicitly update the reference space when the avatar teleports
     }

--- a/packages/engine/src/scene/systems/SceneLoadingSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneLoadingSystem.tsx
@@ -97,12 +97,10 @@ export const SceneLoadingReactor = () => {
   )
 }
 
-/** @todo - this needs to be rework according to #9105 # */
 const NetworkedSceneObjectReactor = () => {
   const entity = useEntityContext()
 
   useEffect(() => {
-    if (!entityExists(entity)) return
     const uuid = getComponent(entity, UUIDComponent)
     const transform = getComponent(entity, TransformComponent)
     const isHostingWorldNetwork = !!NetworkState.worldNetwork?.isHosting

--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -30,7 +30,7 @@ import { EntityUUID } from '@etherealengine/ecs'
 import { getComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Engine } from '@etherealengine/ecs/src/Engine'
 import { respawnAvatar } from '@etherealengine/engine/src/avatar/functions/respawnAvatar'
-import { getMutableState, getState, PeerID } from '@etherealengine/hyperflux'
+import { Action, getMutableState, getState, PeerID } from '@etherealengine/hyperflux'
 import { NetworkPeerFunctions, updatePeers } from '@etherealengine/network'
 import { Application } from '@etherealengine/server-core/declarations'
 import config from '@etherealengine/server-core/src/appconfig'
@@ -223,11 +223,11 @@ export const handleConnectingPeer = (
 
   logger.info('Connect to world from ' + userId)
 
-  const cachedActions = NetworkPeerFunctions.getCachedActionsForPeer(peerID)
+  const cachedActions = ([updatePeersAction] as Required<Action>[])
+    .concat(NetworkPeerFunctions.getCachedActionsForPeer(peerID))
     .map((action) => {
       return _.cloneDeep(action)
     })
-    .concat([updatePeersAction])
 
   const instanceServerState = getState(InstanceServerState)
   if (inviteCode && !instanceServerState.isMediaInstance) getUserSpawnFromInvite(network, user, inviteCode!)

--- a/packages/network/src/EntityNetworkState.tsx
+++ b/packages/network/src/EntityNetworkState.tsx
@@ -95,7 +95,7 @@ export const EntityNetworkState = defineState({
 const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
   const state = useHookstate(getMutableState(EntityNetworkState)[props.uuid])
   const ownerID = state.ownerId.value
-  const isOwner = ownerID === Engine.instance.userID
+  const isOwner = ownerID === SceneUser || ownerID === Engine.instance.userID
   const userConnected = !!useHookstate(getMutableState(NetworkWorldUserState)[ownerID]).value || isOwner
   const isWorldNetworkConnected = !!useHookstate(NetworkState.worldNetworkState).value
 
@@ -111,13 +111,10 @@ const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
     if (!userConnected) return
     const entity = UUIDComponent.getEntityByUUID(props.uuid)
     const worldNetwork = NetworkState.worldNetwork
+
     setComponent(entity, NetworkObjectComponent, {
       ownerId:
-        ownerID === SceneUser
-          ? isWorldNetworkConnected
-            ? worldNetwork.peers[worldNetwork.hostPeerID].userId
-            : Engine.instance.userID
-          : ownerID,
+        ownerID === SceneUser ? (isWorldNetworkConnected ? worldNetwork.hostUserID : Engine.instance.userID) : ownerID,
       ownerPeer: state.ownerPeer.value,
       authorityPeerID: state.authorityPeerId.value,
       networkId: state.networkId.value

--- a/packages/network/src/EntityNetworkState.tsx
+++ b/packages/network/src/EntityNetworkState.tsx
@@ -101,7 +101,10 @@ const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
 
   useLayoutEffect(() => {
     if (!userConnected) return
-    const entity = UUIDComponent.getOrCreateEntityByUUID(props.uuid)
+    const entity =
+      ownerID === SceneUser
+        ? UUIDComponent.getEntityByUUID(props.uuid)
+        : UUIDComponent.getOrCreateEntityByUUID(props.uuid)
     return () => {
       removeEntity(entity)
     }
@@ -110,6 +113,7 @@ const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
   useLayoutEffect(() => {
     if (!userConnected) return
     const entity = UUIDComponent.getEntityByUUID(props.uuid)
+    if (!entity) return
     const worldNetwork = NetworkState.worldNetwork
 
     setComponent(entity, NetworkObjectComponent, {
@@ -126,6 +130,7 @@ const EntityNetworkReactor = (props: { uuid: EntityUUID }) => {
     // Authority request can only be processed by owner
 
     const entity = UUIDComponent.getEntityByUUID(props.uuid)
+    if (!entity) return
     const ownerID = getOptionalComponent(entity, NetworkObjectComponent)?.ownerId
     if (!ownerID || ownerID !== Engine.instance.userID) return
     console.log('Requesting authority over object', props.uuid, state.requestingPeerId.value)


### PR DESCRIPTION
## Summary
Add SceneKillHeightSystem to handle killing entities below a certain height

closes #9910

## QA Steps
add dynamic rigid body to default scene in editor with collider.
use visual script to add network authority tag.
confirm that rigid body rests under the scene kill height. 
