### PR TITLE
Removed/moved some dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "fix-esm": "^1.0.1",
     "minio": "7.1.3",
     "patch-package": "^6.5.1",
-    "react-icons": "^5.0.1",
     "three": "0.158.0",
     "ts-node": "10.9.1",
     "typescript": "5.0.2"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -64,6 +64,7 @@
     "react-file-drop": "3.1.6",
     "react-full-screen": "1.1.1",
     "react-i18next": "11.16.6",
+    "react-icons": "^5.0.1",
     "react-json-tree": "^0.18.0",
     "react-router-dom": "6.9.0",
     "sass": "1.59.3",

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -286,7 +286,6 @@ export default defineConfig(async () => {
     base,
     optimizeDeps: {
       entries: ['./src/main.tsx'],
-      exclude: ['@etherealengine/volumetric'],
       include: ['@reactflow/core', '@reactflow/minimap', '@reactflow/controls', '@reactflow/background'],
       esbuildOptions: {
         target: 'es2020'

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -33,7 +33,6 @@
     "@etherealengine/hyperflux": "^1.6.0",
     "@etherealengine/network": "^1.6.0",
     "@etherealengine/spatial": "^1.6.0",
-    "@etherealengine/volumetric": "^2.0.1",
     "@etherealengine/xrui": "^1.6.0",
     "@gltf-transform/core": "3.4.2",
     "@gltf-transform/extensions": "3.4.2",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -118,6 +118,7 @@
     "semver": "^7.3.8",
     "simple-git": "3.17.0",
     "slugify": "1.6.5",
+    "swagger-ui-dist": "^4.12.0",
     "trace-unhandled": "2.0.1",
     "typescript": "5.0.2",
     "uint8arrays": "^3.0.0",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -118,7 +118,6 @@
     "semver": "^7.3.8",
     "simple-git": "3.17.0",
     "slugify": "1.6.5",
-    "swagger-ui-dist": "^4.12.0",
     "trace-unhandled": "2.0.1",
     "typescript": "5.0.2",
     "uint8arrays": "^3.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
     "@pixiv/types-vrmc-vrm-1.0": "^2.0.6",
     "autoprefixer": "^10.4.14",
     "re-resizable": "^6.9.9",
-    "react-icons": "^4.10.1",
+    "react-icons": "^5.0.1",
     "react-slider": "^2.0.6",
     "tailwind-merge": "^1.13.2",
     "tailwindcss": "^3.3.2",


### PR DESCRIPTION
## Summary

Moved react-icons out of root package.json
Only needed in ui and client packages. Was being unnecessarily installed in api/instanceserver builds as a result.

Removed @etherealengine/volumetric package since all its functionality is now in the engine itself.

## References
closes #_insert number here_

## QA Steps
