### PR TITLE
fix remove all components from erroring itself

### DIFF
--- a/packages/ecs/src/ComponentFunctions.ts
+++ b/packages/ecs/src/ComponentFunctions.ts
@@ -472,10 +472,14 @@ export const getAllComponentData = (entity: Entity): { [name: string]: Component
 export const removeAllComponents = (entity: Entity) => {
   try {
     for (const component of bitECS.getEntityComponents(HyperFlux.store, entity)) {
-      removeComponent(entity, component as Component)
+      try {
+        removeComponent(entity, component as Component)
+      } catch (e) {
+        console.error(e)
+      }
     }
-  } catch (_) {
-    // entity does not exist
+  } catch (e) {
+    console.error(e)
   }
 }
 

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -170,7 +170,8 @@ export const proxifyParentChildRelationships = (obj: Object3D) => {
         return getComponent(objEntity, TransformComponent).matrixWorld
       },
       set(value) {
-        throw new Error('Cannot set matrixWorld of proxified object')
+        if (value != undefined) throw new Error('Cannot set matrixWorld of proxified object')
+        console.warn('Setting to nil value is not supported LoadGLTFModel.ts: proxifyParentChildRelationships')
       }
     },
     parent: {
@@ -185,7 +186,8 @@ export const proxifyParentChildRelationships = (obj: Object3D) => {
         return Engine.instance.scene
       },
       set(value) {
-        throw new Error('Cannot set parent of proxified object')
+        if (value != undefined) throw new Error('Cannot set parent of proxified object')
+        console.warn('Setting to nil value is not supported LoadGLTFModel.ts: proxifyParentChildRelationships')
       }
     },
     children: {
@@ -207,7 +209,8 @@ export const proxifyParentChildRelationships = (obj: Object3D) => {
         }
       },
       set(value) {
-        throw new Error('Cannot set children of proxified object')
+        if (value != undefined) throw new Error('Cannot set children of proxified object')
+        console.warn('Setting to nil value is not supported LoadGLTFModel.ts: proxifyParentChildRelationships')
       }
     },
     isProxified: {


### PR DESCRIPTION
## Summary
Remove all component was failing silentlty. I ensured it would show errors in console. I also made sure that it would continue if it does error. Furthermore, I fixed the original bug in the object3d proxify as internal three code was triggering our throw. Now if a set to nil is attempted it will only print a warning and ignore.

## References
closes #_insert number here_

## QA Steps
