### PR TITLE
Made screenshare button rendering separate from video buttons

### DIFF
--- a/packages/client-core/src/components/MediaIconsBox/index.tsx
+++ b/packages/client-core/src/components/MediaIconsBox/index.tsx
@@ -83,6 +83,9 @@ export const MediaIconsBox = () => {
   const audioEnabled = currentLocation?.locationSetting?.value
     ? currentLocation?.locationSetting?.audioEnabled?.value
     : false
+  const screenshareEnabled = currentLocation?.locationSetting?.value
+    ? currentLocation?.locationSetting?.screenSharingEnabled?.value
+    : false
 
   const mediaStreamState = useHookstate(getMutableState(MediaStreamState))
   const isMotionCaptureEnabled = mediaStreamState.faceTracking.value
@@ -194,6 +197,10 @@ export const MediaIconsBox = () => {
             onPointerEnter={() => AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.ui)}
             icon={<Icon type={'Accessibility'} />}
           />
+        </>
+      ) : null}
+      {screenshareEnabled && mediaNetworkReady && mediaNetworkState?.ready.value ? (
+        <>
           <IconButtonWithTooltip
             id="UserScreenSharing"
             title={t('user:menu.shareScreen')}


### PR DESCRIPTION
## Summary

Screenshare controls were only being rendered if video was enabled and a video device was connected. Moved this to a separate conditional rendering block based on screenshare being enabled.

## References
closes #_insert number here_

## QA Steps
