### PR TITLE
updateAppConfig now auto-patches mismatched redis credentials

### DIFF
--- a/packages/server-core/src/updateAppConfig.ts
+++ b/packages/server-core/src/updateAppConfig.ts
@@ -232,7 +232,21 @@ export const updateAppConfig = async (): Promise<void> => {
   const redisSettingPromise = knexClient
     .select()
     .from<RedisSettingType>(redisSettingPath)
-    .then(([dbRedis]) => {
+    .then(async ([dbRedis]) => {
+      const { address, port, password } = dbRedis
+      if (
+        address !== process.env.REDIS_ADDRESS ||
+        port !== process.env.REDIS_PORT ||
+        password !== process.env.REDIS_PASSWORD
+      ) {
+        await knexClient(redisSettingPath).update({
+          address: process.env.REDIS_ADDRESS,
+          port: process.env.REDIS_PORT,
+          password: process.env.REDIS_PASSWORD
+        })
+        ;[dbRedis] = await knexClient.select().from<RedisSettingType>(redisSettingPath)
+      }
+
       const dbRedisConfig = dbRedis && {
         enabled: dbRedis.enabled,
         address: dbRedis.address,


### PR DESCRIPTION
## Summary

Ran into a situation where redis pods turned over and had new credentials, and the API and instance servers also turned over and were failing because redis-settings in the database still had the old credentials. redis credentials were only being updated in check-db-exists, which is only run by the builder.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
