### PR TITLE
feat(auth): sign up via email address and trigger magic link [IR-42]

### DIFF
--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -525,9 +525,17 @@ export const AuthService = {
 
     try {
       await Engine.instance.api.service(magicLinkPath).create({ type, [paramName]: emailPhone })
-      NotificationService.dispatchNotify(i18n.t('user:auth.magiklink.success-msg'), { variant: 'success' })
+      const message = {
+        email: 'email-sent-msg',
+        sms: 'sms-sent-msg',
+        default: 'success-msg'
+      }
+      NotificationService.dispatchNotify(i18n.t(`user:auth.magiklink.${message[type ?? 'default']}`), {
+        variant: 'success'
+      })
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
+      throw new Error(err)
     } finally {
       authState.merge({ isProcessing: false, error: '' })
     }

--- a/packages/ui/src/primitives/tailwind/Button/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Button/index.tsx
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import React, { ReactNode } from 'react'
-
 import { twMerge } from 'tailwind-merge'
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {

--- a/packages/ui/src/primitives/tailwind/Button/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Button/index.tsx
@@ -24,6 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import React, { ReactNode } from 'react'
+
 import { twMerge } from 'tailwind-merge'
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {


### PR DESCRIPTION
## Summary

- Display the correct message after sending the magic link for SMS or email
- Support buttons without border-radius

## Subtasks Checklist

## Breaking Changes

## References
[IR-42](https://tsu.atlassian.net/browse/IR-42)

## QA Steps

## Evidence
![magic-link](https://github.com/EtherealEngine/etherealengine/assets/113119956/5399dd9d-713e-4b6b-ade1-d6cea32ae9be)



[IR-42]: https://tsu.atlassian.net/browse/IR-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ