### PR TITLE
remove `version` in docker-compse

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   taskserver:
     image: ${LABEL}-taskserver

--- a/scripts/docker-compose-minio.yml
+++ b/scripts/docker-compose-minio.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   minio:
     image: docker.io/bitnami/minio:latest

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,5 +1,4 @@
 
-version: '2.3'
 services:
   db:
     image: mariadb:10.7


### PR DESCRIPTION
## Summary

`version` can be dropped in docker-compose. it prints the following warning when used:
![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/315ae591-716e-4b7b-8211-d2939b788b74)

[compose-spec](https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md#version-top-level-element) says that the latest version is used by the system irrespective of the version specified.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
