### PR TITLE
IR-1614 adding proper debug labels in the SystemDebug rootsystems

### DIFF
--- a/packages/client-core/src/components/Debug/SystemDebug.tsx
+++ b/packages/client-core/src/components/Debug/SystemDebug.tsx
@@ -85,7 +85,7 @@ export const SystemDagView = (props: { uuid: SystemUUID }) => {
     <JSONTree
       data={expandSystemToTree(SystemDefinitions.get(props.uuid)!)}
       labelRenderer={(raw, ...keyPath) => {
-        const uuidName = props.uuid! as String
+        const uuidName = props.uuid! as string
         const label = raw[0]
         if (label === 'preSystems' || label === 'subSystems' || label === 'postSystems') {
           return <span style={{ color: 'green' }}>{t(`common:debug.${label}`)}</span>

--- a/packages/client-core/src/components/Debug/SystemDebug.tsx
+++ b/packages/client-core/src/components/Debug/SystemDebug.tsx
@@ -85,10 +85,12 @@ export const SystemDagView = (props: { uuid: SystemUUID }) => {
     <JSONTree
       data={expandSystemToTree(SystemDefinitions.get(props.uuid)!)}
       labelRenderer={(raw, ...keyPath) => {
+        const uuidName = props.uuid! as String
         const label = raw[0]
-        if (label === 'preSystems' || label === 'subSystems' || label === 'postSystems')
+        if (label === 'preSystems' || label === 'subSystems' || label === 'postSystems') {
           return <span style={{ color: 'green' }}>{t(`common:debug.${label}`)}</span>
-        return <span style={{ color: 'black' }}>{label}</span>
+        }
+        return <span style={{ color: 'black' }}>{label === 'root' ? uuidName : label}</span>
       }}
       valueRenderer={(raw, value, ...keyPath) => {
         const system = SystemDefinitions.get(keyPath[0] as SystemUUID)!


### PR DESCRIPTION

## Summary
adding proper debug labels in the SystemDebug menu for the 4 root systems

## QA Steps
open debug menu (with ~) and click the systems button, note that the root objects now display their system names rather than "root"