### PR TITLE
fmt: Replace `v4` from 'uuid' with builtin `self.crypto.randomUUID()`

### DIFF
--- a/packages/client-core/src/common/components/AvatarPreview/index.tsx
+++ b/packages/client-core/src/common/components/AvatarPreview/index.tsx
@@ -37,7 +37,7 @@ import { SxProps, Theme } from '@mui/material/styles'
 
 import styles from './index.module.scss'
 
-import { createEntity, generateEntityUUID, setComponent, UndefinedEntity, UUIDComponent } from '@etherealengine/ecs'
+import { createEntity, setComponent, UndefinedEntity, UUIDComponent } from '@etherealengine/ecs'
 import { defaultAnimationPath, preloadedAnimations } from '@etherealengine/engine/src/avatar/animation/Util'
 import { LoopAnimationComponent } from '@etherealengine/engine/src/avatar/components/LoopAnimationComponent'
 import { AssetPreviewCameraComponent } from '@etherealengine/engine/src/camera/components/AssetPreviewCameraComponent'
@@ -66,7 +66,7 @@ const AvatarPreview = ({ fill, avatarUrl, sx, onAvatarError, onAvatarLoaded }: P
     if (!avatarUrl) return
 
     const { sceneEntity, cameraEntity } = renderPanel
-    const uuid = generateEntityUUID()
+    const uuid = UUIDComponent.generateUUID()
     setComponent(sceneEntity, UUIDComponent, uuid)
     setComponent(sceneEntity, NameComponent, '3D Preview Entity')
     setComponent(sceneEntity, LoopAnimationComponent, {

--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 import { fileBrowserUploadPath, staticResourcePath } from '@etherealengine/common/src/schema.type.module'
 import {
   Engine,
-  EntityUUID,
   UUIDComponent,
   UndefinedEntity,
   createEntity,
@@ -55,7 +54,7 @@ import {
 } from '@etherealengine/spatial/src/transform/components/BoundingBoxComponents'
 import { computeTransformMatrix } from '@etherealengine/spatial/src/transform/systems/TransformSystem'
 import React, { useEffect } from 'react'
-import { MathUtils, Scene, Vector3 } from 'three'
+import { Scene, Vector3 } from 'three'
 import { uploadToFeathersService } from '../../util/upload'
 import { getCanvasBlob } from '../utils'
 
@@ -216,7 +215,7 @@ const ThumbnailJobReactor = (props: { src: string }) => {
 
     const entity = createEntity()
     setComponent(entity, NameComponent, 'thumbnail job asset ' + props.src)
-    const uuid = MathUtils.generateUUID() as EntityUUID
+    const uuid = UUIDComponent.generateUUID()
     setComponent(entity, UUIDComponent, uuid)
     setComponent(entity, ModelComponent, { src: props.src, cameraOcclusion: false })
     setComponent(entity, VisibleComponent)

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -517,7 +517,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
       callback: () => void,
       errback: (error: Error) => void
     ) => {
-      const requestID = self.crypto.randomUUID()
+      const requestID = crypto.randomUUID()
       dispatchAction(
         MediasoupTransportActions.requestTransportConnect({
           requestID,
@@ -603,7 +603,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
         // up a server-side producer object, and get back a
         // producer.id. call callback() on success or errback() on
         // failure.
-        const requestID = self.crypto.randomUUID()
+        const requestID = crypto.randomUUID()
         dispatchAction(
           MediasoupMediaProducerActions.requestProducer({
             requestID,
@@ -669,7 +669,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
       ) => {
         const { sctpStreamParameters, label, protocol, appData } = parameters
 
-        const requestID = self.crypto.randomUUID()
+        const requestID = crypto.randomUUID()
         dispatchAction(
           MediasoupDataProducerActions.requestProducer({
             requestID,

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -84,7 +84,7 @@ import {
 } from 'mediasoup-client/lib/types'
 import type { EventEmitter } from 'primus'
 import Primus from 'primus-client'
-import { v4 as uuidv4 } from 'uuid'
+
 import { LocationInstanceState } from '../common/services/LocationInstanceConnectionService'
 import { MediaInstanceState } from '../common/services/MediaInstanceConnectionService'
 import {
@@ -517,7 +517,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
       callback: () => void,
       errback: (error: Error) => void
     ) => {
-      const requestID = uuidv4()
+      const requestID = self.crypto.randomUUID()
       dispatchAction(
         MediasoupTransportActions.requestTransportConnect({
           requestID,
@@ -603,7 +603,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
         // up a server-side producer object, and get back a
         // producer.id. call callback() on success or errback() on
         // failure.
-        const requestID = uuidv4()
+        const requestID = self.crypto.randomUUID()
         dispatchAction(
           MediasoupMediaProducerActions.requestProducer({
             requestID,
@@ -669,7 +669,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
       ) => {
         const { sctpStreamParameters, label, protocol, appData } = parameters
 
-        const requestID = uuidv4()
+        const requestID = self.crypto.randomUUID()
         dispatchAction(
           MediasoupDataProducerActions.requestProducer({
             requestID,

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 import i18n from 'i18next'
 import { useEffect } from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import config, { validateEmail, validatePhoneNumber } from '@etherealengine/common/src/config'
 import { AuthUserSeed, resolveAuthUser } from '@etherealengine/common/src/interfaces/AuthUser'
@@ -169,7 +168,7 @@ async function _resetToGuestToken(options = { reset: true }) {
   }
   const newProvider = await Engine.instance.api.service(identityProviderPath).create({
     type: 'guest',
-    token: uuidv4(),
+    token: self.crypto.randomUUID(),
     userId: '' as UserID
   })
   const accessToken = newProvider.accessToken!

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -168,7 +168,7 @@ async function _resetToGuestToken(options = { reset: true }) {
   }
   const newProvider = await Engine.instance.api.service(identityProviderPath).create({
     type: 'guest',
-    token: self.crypto.randomUUID(),
+    token: crypto.randomUUID(),
     userId: '' as UserID
   })
   const accessToken = newProvider.accessToken!

--- a/packages/ecs/src/EntityFunctions.tsx
+++ b/packages/ecs/src/EntityFunctions.tsx
@@ -55,5 +55,5 @@ export const useEntityContext = () => {
 }
 
 export const generateEntityUUID = () => {
-  return self.crypto.randomUUID() as EntityUUID
+  return crypto.randomUUID() as EntityUUID
 }

--- a/packages/ecs/src/EntityFunctions.tsx
+++ b/packages/ecs/src/EntityFunctions.tsx
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import * as bitECS from 'bitecs'
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import { HyperFlux } from '@etherealengine/hyperflux'
 import { removeAllComponents } from './ComponentFunctions'
@@ -56,5 +55,5 @@ export const useEntityContext = () => {
 }
 
 export const generateEntityUUID = () => {
-  return uuidv4() as EntityUUID
+  return self.crypto.randomUUID() as EntityUUID
 }

--- a/packages/ecs/src/EntityFunctions.tsx
+++ b/packages/ecs/src/EntityFunctions.tsx
@@ -28,7 +28,7 @@ import React from 'react'
 
 import { HyperFlux } from '@etherealengine/hyperflux'
 import { removeAllComponents } from './ComponentFunctions'
-import { Entity, EntityUUID, UndefinedEntity } from './Entity'
+import { Entity, UndefinedEntity } from './Entity'
 
 export const createEntity = (): Entity => {
   let entity = bitECS.addEntity(HyperFlux.store)
@@ -52,8 +52,4 @@ export const EntityContext = React.createContext(UndefinedEntity)
 
 export const useEntityContext = () => {
   return React.useContext(EntityContext)
-}
-
-export const generateEntityUUID = () => {
-  return crypto.randomUUID() as EntityUUID
 }

--- a/packages/ecs/src/SystemFunctions.ts
+++ b/packages/ecs/src/SystemFunctions.ts
@@ -31,7 +31,6 @@ import { OpaqueType } from '@etherealengine/common/src/interfaces/OpaqueType'
 import multiLogger from '@etherealengine/common/src/logger'
 import { getMutableState, getState, startReactor } from '@etherealengine/hyperflux'
 
-import { v4 as uuidv4 } from 'uuid'
 import { SystemState } from './SystemState'
 import { nowMilliseconds } from './Timer'
 
@@ -196,7 +195,7 @@ export function defineSystem(systemConfig: SystemArgs) {
 
 export const useExecute = (execute: () => void, insert: InsertSystem) => {
   useEffect(() => {
-    const handle = defineSystem({ uuid: uuidv4(), execute, insert })
+    const handle = defineSystem({ uuid: self.crypto.randomUUID(), execute, insert })
     return () => {
       destroySystem(handle)
     }

--- a/packages/ecs/src/SystemFunctions.ts
+++ b/packages/ecs/src/SystemFunctions.ts
@@ -195,7 +195,7 @@ export function defineSystem(systemConfig: SystemArgs) {
 
 export const useExecute = (execute: () => void, insert: InsertSystem) => {
   useEffect(() => {
-    const handle = defineSystem({ uuid: self.crypto.randomUUID(), execute, insert })
+    const handle = defineSystem({ uuid: crypto.randomUUID(), execute, insert })
     return () => {
       destroySystem(handle)
     }

--- a/packages/ecs/src/UUIDComponent.ts
+++ b/packages/ecs/src/UUIDComponent.ts
@@ -82,6 +82,10 @@ export const UUIDComponent = defineComponent({
       setComponent(entity, UUIDComponent, uuid)
     }
     return state.value
+  },
+
+  generateUUID(): EntityUUID {
+    return crypto.randomUUID() as EntityUUID
   }
 })
 

--- a/packages/editor/src/components/assets/AssetPreviewPanels/MaterialPreviewPanel.tsx
+++ b/packages/editor/src/components/assets/AssetPreviewPanels/MaterialPreviewPanel.tsx
@@ -28,7 +28,7 @@ import React, { useEffect, useRef } from 'react'
 import { useRender3DPanelSystem } from '@etherealengine/client-core/src/user/components/Panel3D/useRender3DPanelSystem'
 import { getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
 
-import { UUIDComponent, generateEntityUUID, getMutableComponent, setComponent } from '@etherealengine/ecs'
+import { UUIDComponent, getMutableComponent, setComponent } from '@etherealengine/ecs'
 import { EnvmapComponent } from '@etherealengine/engine/src/scene/components/EnvmapComponent'
 import { MaterialLibraryState } from '@etherealengine/engine/src/scene/materials/MaterialLibrary'
 import { MaterialSelectionState } from '@etherealengine/engine/src/scene/materials/MaterialLibraryState'
@@ -48,7 +48,7 @@ export const MaterialPreviewCanvas = () => {
 
     const { sceneEntity, cameraEntity } = renderPanel
     setComponent(sceneEntity, NameComponent, 'Material Preview Entity')
-    const uuid = generateEntityUUID()
+    const uuid = UUIDComponent.generateUUID()
     setComponent(sceneEntity, UUIDComponent, uuid)
     setComponent(sceneEntity, VisibleComponent, true)
     const material = getState(MaterialLibraryState).materials[selectedMaterial.value].material

--- a/packages/editor/src/components/assets/AssetPreviewPanels/ModelPreviewPanel.tsx
+++ b/packages/editor/src/components/assets/AssetPreviewPanels/ModelPreviewPanel.tsx
@@ -28,7 +28,7 @@ import React, { useEffect, useRef } from 'react'
 import { useRender3DPanelSystem } from '@etherealengine/client-core/src/user/components/Panel3D/useRender3DPanelSystem'
 import { useHookstate } from '@etherealengine/hyperflux'
 
-import { UUIDComponent, createEntity, generateEntityUUID, setComponent } from '@etherealengine/ecs'
+import { UUIDComponent, createEntity, setComponent } from '@etherealengine/ecs'
 import { AssetPreviewCameraComponent } from '@etherealengine/engine/src/camera/components/AssetPreviewCameraComponent'
 import { EnvmapComponent } from '@etherealengine/engine/src/scene/components/EnvmapComponent'
 import { ModelComponent } from '@etherealengine/engine/src/scene/components/ModelComponent'
@@ -51,7 +51,7 @@ export const ModelPreviewPanel = (props) => {
   useEffect(() => {
     const { sceneEntity, cameraEntity } = renderPanel
     setComponent(sceneEntity, NameComponent, '3D Preview Entity')
-    const uuid = generateEntityUUID()
+    const uuid = UUIDComponent.generateUUID()
     setComponent(sceneEntity, UUIDComponent, uuid)
     setComponent(sceneEntity, ModelComponent, { src: url, cameraOcclusion: false })
     setComponent(sceneEntity, EnvmapComponent, { type: 'Skybox', envMapIntensity: 2 }) // todo remove when lighting works

--- a/packages/editor/src/components/assets/ModelCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ModelCompressionPanel.tsx
@@ -51,7 +51,7 @@ import Icon from '@etherealengine/ui/src/primitives/mui/Icon'
 import IconButton from '@etherealengine/ui/src/primitives/mui/IconButton'
 import exportGLTF from '../../functions/exportGLTF'
 
-import { createEntity, Entity, generateEntityUUID, UndefinedEntity, UUIDComponent } from '@etherealengine/ecs'
+import { createEntity, Entity, UndefinedEntity, UUIDComponent } from '@etherealengine/ecs'
 import { SourceComponent } from '@etherealengine/engine/src/scene/components/SourceComponent'
 import { proxifyParentChildRelationships } from '@etherealengine/engine/src/scene/functions/loadGLTFModel'
 import { TransformComponent } from '@etherealengine/spatial'
@@ -83,7 +83,7 @@ const createTempEntity = (name: string, parentEntity: Entity = UndefinedEntity):
   }
   setComponent(entity, SourceComponent, sceneID)
 
-  const uuid = generateEntityUUID()
+  const uuid = UUIDComponent.generateUUID()
   setComponent(entity, UUIDComponent, uuid)
 
   // These additional properties and relations are required for

--- a/packages/editor/src/components/visualScript/components/SidePanel.tsx
+++ b/packages/editor/src/components/visualScript/components/SidePanel.tsx
@@ -113,7 +113,7 @@ export const SidePanel = ({
                       const viewportCenter = reactFlow.screenToFlowPosition({ x: centerX, y: centerY } as XYPosition)
                       const position = viewportCenter // need a way to get viewport
                       const newNode = {
-                        id: self.crypto.randomUUID(),
+                        id: crypto.randomUUID(),
                         type: nodeName,
                         position,
                         data: { configuration: {}, values: {} } //fill with default values here

--- a/packages/editor/src/components/visualScript/components/SidePanel.tsx
+++ b/packages/editor/src/components/visualScript/components/SidePanel.tsx
@@ -28,7 +28,6 @@ import { AddOutlined, CancelOutlined } from '@mui/icons-material'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { XYPosition, useReactFlow } from 'reactflow'
-import { v4 as uuidv4 } from 'uuid'
 
 import { UndefinedEntity } from '@etherealengine/ecs'
 import { NodetoEnginetype } from '@etherealengine/engine'
@@ -114,7 +113,7 @@ export const SidePanel = ({
                       const viewportCenter = reactFlow.screenToFlowPosition({ x: centerX, y: centerY } as XYPosition)
                       const position = viewportCenter // need a way to get viewport
                       const newNode = {
-                        id: uuidv4(),
+                        id: self.crypto.randomUUID(),
                         type: nodeName,
                         position,
                         data: { configuration: {}, values: {} } //fill with default values here

--- a/packages/editor/src/components/visualScript/hooks/useFlowHandlers.ts
+++ b/packages/editor/src/components/visualScript/hooks/useFlowHandlers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import { MouseEvent as ReactMouseEvent, useCallback, useEffect, useState } from 'react'
 import { Connection, Node, OnConnectStartParams, XYPosition } from 'reactflow'
-import { v4 as uuidv4 } from 'uuid'
 
 import { calculateNewEdge } from '../util/calculateNewEdge'
 import { getNodePickerFilters } from '../util/getPickerFilters'
@@ -71,7 +70,7 @@ export const useFlowHandlers = ({
       if (connection.target === null) return
 
       const newEdge = {
-        id: uuidv4(),
+        id: self.crypto.randomUUID(),
         source: connection.source,
         target: connection.target,
         sourceHandle: connection.sourceHandle,
@@ -97,7 +96,7 @@ export const useFlowHandlers = ({
     (nodeType: string, position: XYPosition) => {
       closeNodePicker()
       const newNode = {
-        id: uuidv4(),
+        id: self.crypto.randomUUID(),
         type: nodeType,
         position,
         data: { configuration: {}, values: {} } //fill with default values here

--- a/packages/editor/src/components/visualScript/hooks/useFlowHandlers.ts
+++ b/packages/editor/src/components/visualScript/hooks/useFlowHandlers.ts
@@ -70,7 +70,7 @@ export const useFlowHandlers = ({
       if (connection.target === null) return
 
       const newEdge = {
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         source: connection.source,
         target: connection.target,
         sourceHandle: connection.sourceHandle,
@@ -96,7 +96,7 @@ export const useFlowHandlers = ({
     (nodeType: string, position: XYPosition) => {
       closeNodePicker()
       const newNode = {
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         type: nodeType,
         position,
         data: { configuration: {}, values: {} } //fill with default values here

--- a/packages/editor/src/components/visualScript/hooks/useSelectionHandler.ts
+++ b/packages/editor/src/components/visualScript/hooks/useSelectionHandler.ts
@@ -69,7 +69,7 @@ export const useSelectionHandler = ({
 
     const nodeIdMap = new Map<string, string>()
     const newNodes = nodes.map((node) => {
-      nodeIdMap[node.id] = self.crypto.randomUUID()
+      nodeIdMap[node.id] = crypto.randomUUID()
       return {
         ...node,
         id: nodeIdMap[node.id],
@@ -85,7 +85,7 @@ export const useSelectionHandler = ({
         type: 'add',
         item: {
           ...edge,
-          id: self.crypto.randomUUID(),
+          id: crypto.randomUUID(),
           source: nodeIdMap[edge.source],
           target: nodeIdMap[edge.target]
         }
@@ -99,7 +99,7 @@ export const useSelectionHandler = ({
 
     if (groupNodes) {
       const newGroup: Node = {
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         type: 'group',
         position: { x: nodeBoundingPositions.right + 10, y: nodeBoundingPositions.top - 20 },
         data: { label: groupName, configuration: {}, values: {} },

--- a/packages/editor/src/components/visualScript/hooks/useSelectionHandler.ts
+++ b/packages/editor/src/components/visualScript/hooks/useSelectionHandler.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 import { useEffect, useMemo, useState } from 'react'
 import { Edge, EdgeChange, Node, NodeChange, useKeyPress } from 'reactflow'
-import { v4 as uuidv4 } from 'uuid'
 
 import { useVisualScriptFlow } from './useVisualScriptFlow'
 
@@ -70,7 +69,7 @@ export const useSelectionHandler = ({
 
     const nodeIdMap = new Map<string, string>()
     const newNodes = nodes.map((node) => {
-      nodeIdMap[node.id] = uuidv4()
+      nodeIdMap[node.id] = self.crypto.randomUUID()
       return {
         ...node,
         id: nodeIdMap[node.id],
@@ -86,7 +85,7 @@ export const useSelectionHandler = ({
         type: 'add',
         item: {
           ...edge,
-          id: uuidv4(),
+          id: self.crypto.randomUUID(),
           source: nodeIdMap[edge.source],
           target: nodeIdMap[edge.target]
         }
@@ -100,7 +99,7 @@ export const useSelectionHandler = ({
 
     if (groupNodes) {
       const newGroup: Node = {
-        id: uuidv4(),
+        id: self.crypto.randomUUID(),
         type: 'group',
         position: { x: nodeBoundingPositions.right + 10, y: nodeBoundingPositions.top - 20 },
         data: { label: groupName, configuration: {}, values: {} },

--- a/packages/editor/src/components/visualScript/hooks/useTemplateHandler.ts
+++ b/packages/editor/src/components/visualScript/hooks/useTemplateHandler.ts
@@ -23,7 +23,6 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 import { Edge, Node } from 'reactflow'
-import { v4 as uuidv4 } from 'uuid'
 
 import { getMutableState } from '@etherealengine/hyperflux'
 import { GraphTemplate, VisualScriptState } from '@etherealengine/visual-script'
@@ -49,7 +48,7 @@ export const useTemplateHandler = ({
   const visualScriptState = useHookstate(getMutableState(VisualScriptState))
 
   const createGraphTemplate = (nodes: Node[], edges: Edge[]): GraphTemplate => ({
-    id: uuidv4(),
+    id: self.crypto.randomUUID(),
     name: uniqueId('New template '),
     nodes,
     edges

--- a/packages/editor/src/components/visualScript/hooks/useTemplateHandler.ts
+++ b/packages/editor/src/components/visualScript/hooks/useTemplateHandler.ts
@@ -48,7 +48,7 @@ export const useTemplateHandler = ({
   const visualScriptState = useHookstate(getMutableState(VisualScriptState))
 
   const createGraphTemplate = (nodes: Node[], edges: Edge[]): GraphTemplate => ({
-    id: self.crypto.randomUUID(),
+    id: crypto.randomUUID(),
     name: uniqueId('New template '),
     nodes,
     edges

--- a/packages/editor/src/components/visualScript/hooks/useVariableHandler.ts
+++ b/packages/editor/src/components/visualScript/hooks/useVariableHandler.ts
@@ -35,7 +35,7 @@ export const useVariableHandler = ({
   setVariables
 }: Pick<visualScriptFlow, 'variables' | 'setVariables'>) => {
   const createVariable = (): VariableJSON => ({
-    id: self.crypto.randomUUID(),
+    id: crypto.randomUUID(),
     name: uniqueId('variable '),
     valueTypeName: 'string',
     initialValue: ''

--- a/packages/editor/src/components/visualScript/hooks/useVariableHandler.ts
+++ b/packages/editor/src/components/visualScript/hooks/useVariableHandler.ts
@@ -22,7 +22,6 @@ Original Code is the Ethereal Engine team.
 All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
 Ethereal Engine. All Rights Reserved.
 */
-import { v4 as uuidv4 } from 'uuid'
 
 import { VariableJSON } from '@etherealengine/visual-script'
 import { uniqueId } from 'lodash'
@@ -36,7 +35,7 @@ export const useVariableHandler = ({
   setVariables
 }: Pick<visualScriptFlow, 'variables' | 'setVariables'>) => {
   const createVariable = (): VariableJSON => ({
-    id: uuidv4(),
+    id: self.crypto.randomUUID(),
     name: uniqueId('variable '),
     valueTypeName: 'string',
     initialValue: ''

--- a/packages/editor/src/components/visualScript/transformers/VisualToFlow.ts
+++ b/packages/editor/src/components/visualScript/transformers/VisualToFlow.ts
@@ -64,7 +64,7 @@ export const visualToFlow = (visualScript: GraphJSON): [Node[], Edge[]] => {
       for (const [inputKey, input] of Object.entries(nodeJSON.parameters)) {
         if ('link' in input && input.link !== undefined) {
           edges.push({
-            id: self.crypto.randomUUID(),
+            id: crypto.randomUUID(),
             source: input.link.nodeId,
             sourceHandle: input.link.socket,
             target: nodeJSON.id,
@@ -80,7 +80,7 @@ export const visualToFlow = (visualScript: GraphJSON): [Node[], Edge[]] => {
     if (nodeJSON.flows) {
       for (const [inputKey, link] of Object.entries(nodeJSON.flows)) {
         edges.push({
-          id: self.crypto.randomUUID(),
+          id: crypto.randomUUID(),
           source: nodeJSON.id,
           sourceHandle: inputKey,
           target: link.nodeId,

--- a/packages/editor/src/components/visualScript/transformers/VisualToFlow.ts
+++ b/packages/editor/src/components/visualScript/transformers/VisualToFlow.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import { GraphJSON, NodeConfigurationJSON } from '@etherealengine/visual-script'
 import { Edge, Node } from 'reactflow'
-import { v4 as uuidv4 } from 'uuid'
 
 export const visualToFlow = (visualScript: GraphJSON): [Node[], Edge[]] => {
   const nodes: Node[] = []
@@ -65,7 +64,7 @@ export const visualToFlow = (visualScript: GraphJSON): [Node[], Edge[]] => {
       for (const [inputKey, input] of Object.entries(nodeJSON.parameters)) {
         if ('link' in input && input.link !== undefined) {
           edges.push({
-            id: uuidv4(),
+            id: self.crypto.randomUUID(),
             source: input.link.nodeId,
             sourceHandle: input.link.socket,
             target: nodeJSON.id,
@@ -81,7 +80,7 @@ export const visualToFlow = (visualScript: GraphJSON): [Node[], Edge[]] => {
     if (nodeJSON.flows) {
       for (const [inputKey, link] of Object.entries(nodeJSON.flows)) {
         edges.push({
-          id: uuidv4(),
+          id: self.crypto.randomUUID(),
           source: nodeJSON.id,
           sourceHandle: inputKey,
           target: link.nodeId,

--- a/packages/editor/src/components/visualScript/util/calculateNewEdge.ts
+++ b/packages/editor/src/components/visualScript/util/calculateNewEdge.ts
@@ -53,7 +53,7 @@ export const calculateNewEdge = (
 
   if (connection.handleType === 'source') {
     return {
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       source: connection.nodeId ?? '',
       sourceHandle: connection.handleId,
       target: destinationNodeId,
@@ -62,7 +62,7 @@ export const calculateNewEdge = (
   }
 
   return {
-    id: self.crypto.randomUUID(),
+    id: crypto.randomUUID(),
     target: connection.nodeId ?? '',
     targetHandle: connection.handleId,
     source: destinationNodeId,

--- a/packages/editor/src/components/visualScript/util/calculateNewEdge.ts
+++ b/packages/editor/src/components/visualScript/util/calculateNewEdge.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Node, OnConnectStartParams } from 'reactflow'
-import { v4 as uuidv4 } from 'uuid'
 
 import { NodeSpecGenerator } from '../hooks/useNodeSpecGenerator'
 import { getSocketsByNodeTypeAndHandleType } from './getSocketsByNodeTypeAndHandleType'
@@ -54,7 +53,7 @@ export const calculateNewEdge = (
 
   if (connection.handleType === 'source') {
     return {
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       source: connection.nodeId ?? '',
       sourceHandle: connection.handleId,
       target: destinationNodeId,
@@ -63,7 +62,7 @@ export const calculateNewEdge = (
   }
 
   return {
-    id: uuidv4(),
+    id: self.crypto.randomUUID(),
     target: connection.nodeId ?? '',
     targetHandle: connection.handleId,
     source: destinationNodeId,

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { getNestedObject } from '@etherealengine/common/src/utils/getNestedProperty'
-import { EntityUUID, UUIDComponent, createEntity, generateEntityUUID, removeEntity } from '@etherealengine/ecs'
+import { EntityUUID, UUIDComponent, createEntity, removeEntity } from '@etherealengine/ecs'
 import {
   Component,
   ComponentJSONIDMap,
@@ -276,7 +276,7 @@ const createObjectFromSceneElement = (
 ) => {
   const scenes = getSourcesForEntities([parentEntity])
   const entityUUID =
-    componentJson.find((comp) => comp.name === UUIDComponent.jsonID)?.props.uuid ?? generateEntityUUID()
+    componentJson.find((comp) => comp.name === UUIDComponent.jsonID)?.props.uuid ?? UUIDComponent.generateUUID()
 
   for (const [sceneID, entities] of Object.entries(scenes)) {
     // gltf loader sanitizers names...
@@ -417,7 +417,7 @@ const duplicateObject = (entities: Entity[]) => {
         }
 
         const entityDataClone = JSON.parse(JSON.stringify(node))
-        const newUUID = generateEntityUUID()
+        const newUUID = UUIDComponent.generateUUID()
         copyMap[entityUUID] = newUUID
         entityDataClone.extensions![UUIDComponent.jsonID] = newUUID
         if (newChildren.length) entityDataClone.children = newChildren
@@ -460,7 +460,7 @@ const duplicateObject = (entities: Entity[]) => {
           if (!entityData) return /** @todo entity may be loaded in via GLTF **/
 
           const entityDataClone = JSON.parse(JSON.stringify(entityData))
-          const newUUID = generateEntityUUID()
+          const newUUID = UUIDComponent.generateUUID()
           copyMap[entityUUID] = newUUID
 
           const parentEntity = getComponent(entity, EntityTreeComponent).parentEntity!
@@ -770,7 +770,7 @@ const groupObjects = (entities: Entity[]) => {
       const groupNode = {
         name: 'New Group',
         extensions: {
-          [UUIDComponent.jsonID]: generateEntityUUID(),
+          [UUIDComponent.jsonID]: UUIDComponent.generateUUID(),
           // TODO figure out where the new position should be
           [TransformComponent.jsonID]: componentJsonDefaults(TransformComponent),
           [VisibleComponent.jsonID]: true
@@ -814,7 +814,7 @@ const groupObjects = (entities: Entity[]) => {
       const childIndex = parentEntityTreeComponent.children.length
       const parentEntityUUID = getComponent(parentEntity, UUIDComponent)
 
-      const groupEntityUUID = generateEntityUUID()
+      const groupEntityUUID = UUIDComponent.generateUUID()
       newGroupUUIDs[sceneID] = groupEntityUUID
 
       newSnapshot.data.entities[groupEntityUUID] = {

--- a/packages/engine/src/assets/compression/ModelTransformFunctions.ts
+++ b/packages/engine/src/assets/compression/ModelTransformFunctions.ts
@@ -68,7 +68,7 @@ import ModelTransformLoader from './ModelTransformLoader'
 
 import config from '@etherealengine/common/src/config'
 import { getMutableState, NO_PROXY } from '@etherealengine/hyperflux'
-import { v4 as uuidv4 } from 'uuid'
+
 import { UploadRequestState } from '../state/UploadRequestState'
 
 import { KTX2Encoder } from '@etherealengine/xrui/core/textures/KTX2Encoder'
@@ -804,7 +804,7 @@ export async function transformModel(
       delete resources[image.uri!]
       image.uri = nuURI
     })
-    const defaultBufURI = uuidv4() + '.bin'
+    const defaultBufURI = self.crypto.randomUUID() + '.bin'
     json.buffers?.map((buffer) => {
       buffer.uri = pathJoin(
         args.resourceUri ? args.resourceUri : resourceName + '_resources',

--- a/packages/engine/src/assets/compression/ModelTransformFunctions.ts
+++ b/packages/engine/src/assets/compression/ModelTransformFunctions.ts
@@ -804,7 +804,7 @@ export async function transformModel(
       delete resources[image.uri!]
       image.uri = nuURI
     })
-    const defaultBufURI = self.crypto.randomUUID() + '.bin'
+    const defaultBufURI = crypto.randomUUID() + '.bin'
     json.buffers?.map((buffer) => {
       buffer.uri = pathJoin(
         args.resourceUri ? args.resourceUri : resourceName + '_resources',

--- a/packages/engine/src/assets/exporters/gltf/extensions/BufferHandlerExtension.ts
+++ b/packages/engine/src/assets/exporters/gltf/extensions/BufferHandlerExtension.ts
@@ -32,7 +32,7 @@ import { NO_PROXY, defineAction, dispatchAction, getMutableState } from '@ethere
 import config from '@etherealengine/common/src/config'
 import { pathJoin } from '@etherealengine/common/src/utils/miscUtils'
 import iterateObject3D from '@etherealengine/spatial/src/common/functions/iterateObject3D'
-import { v4 as uuidv4 } from 'uuid'
+
 import { AssetLoader } from '../../../classes/AssetLoader'
 import { modelResourcesPath } from '../../../functions/pathResolver'
 import { UploadRequestState } from '../../../state/UploadRequestState'
@@ -106,7 +106,7 @@ export default class BufferHandlerExtension extends ExporterExtension implements
   writeImage(image: HTMLImageElement | HTMLCanvasElement, imageDef: { [key: string]: any }) {
     //only execute when images are not embedded
     if (this.writer.options.embedImages) return
-    const name = uuidv4()
+    const name = self.crypto.randomUUID()
     const projectName = this.projectName
     const modelName = this.modelName
     let buffer: ArrayBuffer

--- a/packages/engine/src/assets/exporters/gltf/extensions/BufferHandlerExtension.ts
+++ b/packages/engine/src/assets/exporters/gltf/extensions/BufferHandlerExtension.ts
@@ -106,7 +106,7 @@ export default class BufferHandlerExtension extends ExporterExtension implements
   writeImage(image: HTMLImageElement | HTMLCanvasElement, imageDef: { [key: string]: any }) {
     //only execute when images are not embedded
     if (this.writer.options.embedImages) return
-    const name = self.crypto.randomUUID()
+    const name = crypto.randomUUID()
     const projectName = this.projectName
     const modelName = this.modelName
     let buffer: ArrayBuffer

--- a/packages/engine/src/assets/functions/exportMaterialsGLTF.ts
+++ b/packages/engine/src/assets/functions/exportMaterialsGLTF.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import { BufferGeometry, Material, Mesh, Scene } from 'three'
 
-import { v4 as uuidv4 } from 'uuid'
 import { MaterialComponentType } from '../../scene/materials/components/MaterialComponent'
 import { registerMaterial, unregisterMaterial } from '../../scene/materials/functions/MaterialLibraryFunctions'
 import { GLTFExporterOptions } from '../exporters/gltf/GLTFExporter'
@@ -43,7 +42,7 @@ export default async function exportMaterialsGLTF(
   const nuMats: Material[] = []
   for (const material of materials) {
     const nuMat: Material = material.material.clone()
-    nuMat.uuid = uuidv4()
+    nuMat.uuid = self.crypto.randomUUID()
 
     registerMaterial(nuMat, material.src)
     nuMats.push(nuMat)

--- a/packages/engine/src/assets/functions/exportMaterialsGLTF.ts
+++ b/packages/engine/src/assets/functions/exportMaterialsGLTF.ts
@@ -42,7 +42,7 @@ export default async function exportMaterialsGLTF(
   const nuMats: Material[] = []
   for (const material of materials) {
     const nuMat: Material = material.material.clone()
-    nuMat.uuid = self.crypto.randomUUID()
+    nuMat.uuid = crypto.randomUUID()
 
     registerMaterial(nuMat, material.src)
     nuMats.push(nuMat)

--- a/packages/engine/src/assets/functions/resourceHooks.ts
+++ b/packages/engine/src/assets/functions/resourceHooks.ts
@@ -44,7 +44,7 @@ function useLoader<T extends AssetType>(
   const value = useHookstate<T | null>(null)
   const error = useHookstate<ErrorEvent | Error | null>(null)
   const progress = useHookstate<ProgressEvent<EventTarget> | null>(null)
-  const uuid = useHookstate<string>(self.crypto.randomUUID())
+  const uuid = useHookstate<string>(crypto.randomUUID())
 
   const unload = () => {
     if (url) ResourceManager.unload(url, entity, uuid.value)

--- a/packages/engine/src/assets/functions/resourceHooks.ts
+++ b/packages/engine/src/assets/functions/resourceHooks.ts
@@ -27,7 +27,7 @@ import { Entity, UndefinedEntity } from '@etherealengine/ecs'
 import { NO_PROXY, State, useHookstate } from '@etherealengine/hyperflux'
 import { useEffect } from 'react'
 import { Texture } from 'three'
-import { v4 as uuidv4 } from 'uuid'
+
 import { LoadingArgs } from '../classes/AssetLoader'
 import { GLTF } from '../loaders/gltf/GLTFLoader'
 import { AssetType, ResourceManager, ResourceType } from '../state/ResourceState'
@@ -44,7 +44,7 @@ function useLoader<T extends AssetType>(
   const value = useHookstate<T | null>(null)
   const error = useHookstate<ErrorEvent | Error | null>(null)
   const progress = useHookstate<ProgressEvent<EventTarget> | null>(null)
-  const uuid = useHookstate<string>(uuidv4())
+  const uuid = useHookstate<string>(self.crypto.randomUUID())
 
   const unload = () => {
     if (url) ResourceManager.unload(url, entity, uuid.value)

--- a/packages/engine/src/scene/GLTFState.tsx
+++ b/packages/engine/src/scene/GLTFState.tsx
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import {
   Entity,
-  EntityUUID,
   UUIDComponent,
   UndefinedEntity,
   createEntity,
@@ -41,7 +40,6 @@ import { VisibleComponent } from '@etherealengine/spatial/src/renderer/component
 import { EntityTreeComponent } from '@etherealengine/spatial/src/transform/components/EntityTree'
 import { GLTF } from '@gltf-transform/core'
 import React, { useLayoutEffect } from 'react'
-import { MathUtils } from 'three'
 import { GLTFDocumentState, GLTFSnapshotAction } from './GLTFDocumentState'
 import { ModelComponent } from './components/ModelComponent'
 import { SourceComponent } from './components/SourceComponent'
@@ -53,7 +51,7 @@ export const GLTFSourceState = defineState({
 
   load: (source: string, parentEntity = UndefinedEntity) => {
     const entity = createEntity()
-    setComponent(entity, UUIDComponent, MathUtils.generateUUID() as EntityUUID)
+    setComponent(entity, UUIDComponent, UUIDComponent.generateUUID())
     setComponent(entity, NameComponent, source.split('/').pop()!)
     setComponent(entity, VisibleComponent, true)
     setComponent(entity, TransformComponent)

--- a/packages/engine/src/scene/components/ObjectGridSnapComponent.ts
+++ b/packages/engine/src/scene/components/ObjectGridSnapComponent.ts
@@ -34,12 +34,7 @@ import {
   useOptionalComponent
 } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity, UndefinedEntity } from '@etherealengine/ecs/src/Entity'
-import {
-  createEntity,
-  generateEntityUUID,
-  removeEntity,
-  useEntityContext
-} from '@etherealengine/ecs/src/EntityFunctions'
+import { createEntity, removeEntity, useEntityContext } from '@etherealengine/ecs/src/EntityFunctions'
 import { getMutableState, useState } from '@etherealengine/hyperflux'
 import { EngineState } from '@etherealengine/spatial/src/EngineState'
 import { NameComponent } from '@etherealengine/spatial/src/common/NameComponent'
@@ -143,7 +138,7 @@ export const ObjectGridSnapComponent = defineComponent({
       setComponent(helper, NameComponent, 'helper')
       setComponent(helper, VisibleComponent)
       setComponent(helper, TransformComponent)
-      setComponent(helper, UUIDComponent, generateEntityUUID())
+      setComponent(helper, UUIDComponent, UUIDComponent.generateUUID())
       setComponent(helper, EntityTreeComponent, { parentEntity: entity })
       setComponent(helper, ObjectLayerMaskComponent, ObjectLayers.NodeHelper)
 

--- a/packages/engine/src/scene/functions/GLTFConversion.ts
+++ b/packages/engine/src/scene/functions/GLTFConversion.ts
@@ -26,7 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import { Object3D } from 'three'
 
 import config from '@etherealengine/common/src/config'
-import { generateEntityUUID } from '@etherealengine/ecs'
+import { UUIDComponent } from '@etherealengine/ecs'
 
 import { sceneRelativePathIdentifier } from '@etherealengine/common/src/utils/parseSceneJSON'
 import { EntityJsonType, SceneJsonType } from '../types/SceneTypes'
@@ -47,7 +47,7 @@ export const nodeToEntityJson = (node: any): EntityJsonType => {
 export const gltfToSceneJson = (gltf: any): SceneJsonType => {
   handleScenePaths(gltf, 'decode')
   const rootGL = gltf.scenes[gltf.scene]
-  const rootUuid = generateEntityUUID()
+  const rootUuid = UUIDComponent.generateUUID()
   const result: SceneJsonType = {
     entities: {},
     root: rootUuid,

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -156,7 +156,7 @@ export const parseGLTFModel = (entity: Entity, scene: Scene) => {
       const uuid =
         (obj.userData?.gltfExtensions?.EE_uuid as EntityUUID) ||
         (obj.uuid as EntityUUID) ||
-        (crypto.randomUUID() as EntityUUID)
+        UUIDComponent.generateUUID()
       obj.uuid = uuid
       const eJson = generateEntityJsonFromObject(entity, obj, entityJson[uuid])
       entityJson[uuid] = eJson

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -156,7 +156,7 @@ export const parseGLTFModel = (entity: Entity, scene: Scene) => {
       const uuid =
         (obj.userData?.gltfExtensions?.EE_uuid as EntityUUID) ||
         (obj.uuid as EntityUUID) ||
-        (self.crypto.randomUUID() as EntityUUID)
+        (crypto.randomUUID() as EntityUUID)
       obj.uuid = uuid
       const eJson = generateEntityJsonFromObject(entity, obj, entityJson[uuid])
       entityJson[uuid] = eJson

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -47,7 +47,7 @@ import { VisibleComponent } from '@etherealengine/spatial/src/renderer/component
 import { FrustumCullCameraComponent } from '@etherealengine/spatial/src/transform/components/DistanceComponents'
 import { EntityTreeComponent } from '@etherealengine/spatial/src/transform/components/EntityTree'
 import { computeTransformMatrix } from '@etherealengine/spatial/src/transform/systems/TransformSystem'
-import { v4 as uuidv4 } from 'uuid'
+
 import { BoneComponent } from '../../avatar/components/BoneComponent'
 import { SkinnedMeshComponent } from '../../avatar/components/SkinnedMeshComponent'
 import { GLTFLoadedComponent } from '../components/GLTFLoadedComponent'
@@ -154,7 +154,9 @@ export const parseGLTFModel = (entity: Entity, scene: Scene) => {
     child.parent = model.scene
     iterateObject3D(child, (obj: Object3D) => {
       const uuid =
-        (obj.userData?.gltfExtensions?.EE_uuid as EntityUUID) || (obj.uuid as EntityUUID) || (uuidv4() as EntityUUID)
+        (obj.userData?.gltfExtensions?.EE_uuid as EntityUUID) ||
+        (obj.uuid as EntityUUID) ||
+        (self.crypto.randomUUID() as EntityUUID)
       obj.uuid = uuid
       const eJson = generateEntityJsonFromObject(entity, obj, entityJson[uuid])
       entityJson[uuid] = eJson

--- a/packages/engine/src/scene/functions/migrateSceneSettings.ts
+++ b/packages/engine/src/scene/functions/migrateSceneSettings.ts
@@ -50,7 +50,7 @@ export const migrateSceneSettings = (json: SceneJsonType) => {
   // force reordering so our new entity can be at the start
   json.entities = {
     [json.root]: json.entities[json.root],
-    [self.crypto.randomUUID()]: newEntity,
+    [crypto.randomUUID()]: newEntity,
     ...json.entities
   }
 }

--- a/packages/engine/src/scene/functions/migrateSceneSettings.ts
+++ b/packages/engine/src/scene/functions/migrateSceneSettings.ts
@@ -23,7 +23,6 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { v4 as uuidv4 } from 'uuid'
 import { EntityJsonType, SceneJsonType } from '../types/SceneTypes'
 
 // puts the scene settings from the the root entity into a sub entity
@@ -51,7 +50,7 @@ export const migrateSceneSettings = (json: SceneJsonType) => {
   // force reordering so our new entity can be at the start
   json.entities = {
     [json.root]: json.entities[json.root],
-    [uuidv4()]: newEntity,
+    [self.crypto.randomUUID()]: newEntity,
     ...json.entities
   }
 }

--- a/packages/engine/src/visualscript/nodes/profiles/engine/helper/entityHelper.ts
+++ b/packages/engine/src/visualscript/nodes/profiles/engine/helper/entityHelper.ts
@@ -31,7 +31,7 @@ import {
   setComponent
 } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity, UndefinedEntity } from '@etherealengine/ecs/src/Entity'
-import { createEntity, generateEntityUUID } from '@etherealengine/ecs/src/EntityFunctions'
+import { createEntity } from '@etherealengine/ecs/src/EntityFunctions'
 import { ComponentJsonType } from '@etherealengine/engine/src/scene/types/SceneTypes'
 import { VisibleComponent } from '@etherealengine/spatial/src/renderer/components/VisibleComponent'
 import { EntityTreeComponent } from '@etherealengine/spatial/src/transform/components/EntityTree'
@@ -52,7 +52,7 @@ export const addEntityToScene = (
   }
   setComponent(newEntity, EntityTreeComponent, { parentEntity, childIndex })
   setComponent(newEntity, TransformComponent)
-  const uuid = generateEntityUUID()
+  const uuid = UUIDComponent.generateUUID()
   setComponent(newEntity, UUIDComponent, uuid)
   setComponent(newEntity, VisibleComponent)
   for (const component of componentJson) {

--- a/packages/hyperflux/functions/ActionFunctions.ts
+++ b/packages/hyperflux/functions/ActionFunctions.ts
@@ -330,7 +330,7 @@ export const dispatchAction = <A extends Action>(_action: A) => {
   action.$to = action.$to ?? 'all'
   action.$time = action.$time ?? HyperFlux.store.getDispatchTime() + HyperFlux.store.defaultDispatchDelay()
   action.$cache = action.$cache ?? false
-  action.$uuid = action.$uuid ?? self.crypto.randomUUID()
+  action.$uuid = action.$uuid ?? crypto.randomUUID()
   const topic = (action.$topic = action.$topic ?? HyperFlux.store.defaultTopic)
 
   if (process.env.APP_ENV === 'development' && !action.$stack) {

--- a/packages/hyperflux/functions/ActionFunctions.ts
+++ b/packages/hyperflux/functions/ActionFunctions.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { matches, Parser, Validator } from 'ts-matches'
-import { v4 as uuidv4 } from 'uuid'
 
 import { OpaqueType } from '@etherealengine/common/src/interfaces/OpaqueType'
 import multiLogger from '@etherealengine/common/src/logger'
@@ -331,7 +330,7 @@ export const dispatchAction = <A extends Action>(_action: A) => {
   action.$to = action.$to ?? 'all'
   action.$time = action.$time ?? HyperFlux.store.getDispatchTime() + HyperFlux.store.defaultDispatchDelay()
   action.$cache = action.$cache ?? false
-  action.$uuid = action.$uuid ?? uuidv4()
+  action.$uuid = action.$uuid ?? self.crypto.randomUUID()
   const topic = (action.$topic = action.$topic ?? HyperFlux.store.defaultTopic)
 
   if (process.env.APP_ENV === 'development' && !action.$stack) {

--- a/packages/hyperflux/functions/StoreFunctions.ts
+++ b/packages/hyperflux/functions/StoreFunctions.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { State } from '@hookstate/core'
-import { v4 as uuidv4 } from 'uuid'
 
 import { PeerID } from '@etherealengine/hyperflux'
 import { ActionQueueHandle, ActionQueueInstance, ResolvedActionType, Topic } from './ActionFunctions'
@@ -109,7 +108,7 @@ export function createHyperStore(options: {
     getDispatchTime: options.getDispatchTime,
     defaultDispatchDelay: options.defaultDispatchDelay ?? (() => 0),
     getCurrentReactorRoot: options.getCurrentReactorRoot ?? (() => undefined),
-    peerID: uuidv4() as PeerID,
+    peerID: self.crypto.randomUUID() as PeerID,
     stateMap: {},
     stateReactors: {},
     actions: {

--- a/packages/hyperflux/functions/StoreFunctions.ts
+++ b/packages/hyperflux/functions/StoreFunctions.ts
@@ -108,7 +108,7 @@ export function createHyperStore(options: {
     getDispatchTime: options.getDispatchTime,
     defaultDispatchDelay: options.defaultDispatchDelay ?? (() => 0),
     getCurrentReactorRoot: options.getCurrentReactorRoot ?? (() => undefined),
-    peerID: self.crypto.randomUUID() as PeerID,
+    peerID: crypto.randomUUID() as PeerID,
     stateMap: {},
     stateReactors: {},
     actions: {

--- a/packages/instanceserver/tests/InstanceLoad.test.ts
+++ b/packages/instanceserver/tests/InstanceLoad.test.ts
@@ -33,7 +33,7 @@ import { getState } from '@etherealengine/hyperflux'
 import { Application } from '@etherealengine/server-core/declarations'
 import appRootPath from 'app-root-path'
 import { ChildProcess } from 'child_process'
-import { v4 as uuidv4 } from 'uuid'
+
 import { StartTestFileServer } from '../../server-core/src/createFileServer'
 import { onConnection } from '../src/channels'
 import { start } from '../src/start'
@@ -60,7 +60,7 @@ describe('InstanceLoad', () => {
     const loadLocation = onConnection(app)
 
     const type = 'guest'
-    const token = uuidv4()
+    const token = self.crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,

--- a/packages/instanceserver/tests/InstanceLoad.test.ts
+++ b/packages/instanceserver/tests/InstanceLoad.test.ts
@@ -60,7 +60,7 @@ describe('InstanceLoad', () => {
     const loadLocation = onConnection(app)
 
     const type = 'guest'
-    const token = self.crypto.randomUUID()
+    const token = crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,

--- a/packages/network/src/EntityNetworkState.test.tsx
+++ b/packages/network/src/EntityNetworkState.test.tsx
@@ -27,11 +27,10 @@ import assert from 'assert'
 
 import { NetworkId } from '@etherealengine/common/src/interfaces/NetworkId'
 import { UserID } from '@etherealengine/common/src/schema.type.module'
-import { EntityUUID, generateEntityUUID } from '@etherealengine/ecs'
+import { EntityUUID, UUIDComponent } from '@etherealengine/ecs'
 import { PeerID, ReactorReconciler } from '@etherealengine/hyperflux'
 import { applyIncomingActions, dispatchAction } from '@etherealengine/hyperflux/functions/ActionFunctions'
 
-import { UUIDComponent } from '@etherealengine/ecs'
 import { getComponent, hasComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Engine, destroyEngine } from '@etherealengine/ecs/src/Engine'
 import { defineQuery } from '@etherealengine/ecs/src/QueryFunctions'
@@ -406,7 +405,7 @@ describe('EntityNetworkState', () => {
           networkId: objNetId,
           $topic: NetworkTopics.world,
           $peer: Engine.instance.store.peerID,
-          entityUUID: generateEntityUUID()
+          entityUUID: UUIDComponent.generateUUID()
         })
       )
     }
@@ -431,7 +430,7 @@ describe('EntityNetworkState', () => {
         networkId: objNetId,
         $topic: NetworkTopics.world,
         $peer: Engine.instance.store.peerID,
-        entityUUID: generateEntityUUID()
+        entityUUID: UUIDComponent.generateUUID()
       })
     )
 

--- a/packages/projects/createLocations.ts
+++ b/packages/projects/createLocations.ts
@@ -39,9 +39,9 @@ export const createLocations = async (app: Application, projectName: string, sce
   return Promise.all(
     sceneFiles.map(async (fileName) => {
       const assetURL = `projects/${projectName}/${fileName}`
-      const locationId = self.crypto.randomUUID() as LocationID
-      const sceneId = self.crypto.randomUUID()
-      const settingsId = self.crypto.randomUUID()
+      const locationId = crypto.randomUUID() as LocationID
+      const sceneId = crypto.randomUUID()
+      const settingsId = crypto.randomUUID()
       const sceneName = fileName.split('/').pop()!.replace('.scene.json', '').replace('.gltf', '')
 
       /** @todo use .gltf instead */

--- a/packages/projects/createLocations.ts
+++ b/packages/projects/createLocations.ts
@@ -34,15 +34,14 @@ import { assetPath } from '@etherealengine/common/src/schemas/assets/asset.schem
 import { toCapitalCase } from '@etherealengine/common/src/utils/miscUtils'
 import { Application } from '@etherealengine/server-core/declarations'
 import { Paginated } from '@feathersjs/feathers/lib'
-import { v4 as uuidv4 } from 'uuid'
 
 export const createLocations = async (app: Application, projectName: string, sceneFiles: string[] = []) => {
   return Promise.all(
     sceneFiles.map(async (fileName) => {
       const assetURL = `projects/${projectName}/${fileName}`
-      const locationId = uuidv4() as LocationID
-      const sceneId = uuidv4()
-      const settingsId = uuidv4()
+      const locationId = self.crypto.randomUUID() as LocationID
+      const sceneId = self.crypto.randomUUID()
+      const settingsId = self.crypto.randomUUID()
       const sceneName = fileName.split('/').pop()!.replace('.scene.json', '').replace('.gltf', '')
 
       /** @todo use .gltf instead */

--- a/packages/projects/makeSceneUUIDsUnique.ts
+++ b/packages/projects/makeSceneUUIDsUnique.ts
@@ -27,7 +27,7 @@ import appRootPath from 'app-root-path'
 import fs from 'fs'
 import path from 'path'
 
-import { EntityUUID, generateEntityUUID } from '@etherealengine/ecs'
+import { EntityUUID, UUIDComponent } from '@etherealengine/ecs'
 import { SceneJsonType } from '@etherealengine/engine/src/scene/types/SceneTypes'
 
 for (const project of fs.readdirSync(path.resolve(appRootPath.path, 'packages/projects/projects/'))) {
@@ -39,7 +39,7 @@ for (const project of fs.readdirSync(path.resolve(appRootPath.path, 'packages/pr
       fs.readFileSync(path.resolve(appRootPath.path, 'packages/projects/projects/', project, scene)).toString()
     ) as SceneJsonType
     for (const uuid of Object.keys(sceneJson.entities)) {
-      uuidMapping[uuid] = generateEntityUUID()
+      uuidMapping[uuid] = UUIDComponent.generateUUID()
     }
     sceneJson.root = uuidMapping[Object.keys(sceneJson.entities)[0]]
     for (const uuid of Object.keys(sceneJson.entities)) {

--- a/packages/server-core/src/analytics/analytics/analytics.resolvers.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { AnalyticsQuery, AnalyticsType } from '@etherealengine/common/src/schemas/analytics/analytics.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const analyticsExternalResolver = resolve<AnalyticsType, HookContext>({})
 
 export const analyticsDataResolver = resolve<AnalyticsType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/analytics/analytics/analytics.resolvers.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.resolvers.ts
@@ -40,7 +40,7 @@ export const analyticsExternalResolver = resolve<AnalyticsType, HookContext>({})
 
 export const analyticsDataResolver = resolve<AnalyticsType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/analytics/analytics/analytics.seed.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { analyticsPath, AnalyticsType } from '@etherealengine/common/src/schemas/analytics/analytics.schema'
 import appConfig from '@etherealengine/server-core/src/appconfig'
@@ -63,7 +62,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/analytics/analytics/analytics.seed.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.seed.ts
@@ -62,7 +62,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/assets/asset/asset-helper.ts
+++ b/packages/server-core/src/assets/asset/asset-helper.ts
@@ -44,7 +44,7 @@ export const syncAllSceneJSONAssets = async (projects: ProjectType[], app: Appli
         )
         if (!sceneJSONAssets.length) return
         return sceneJSONAssets.map((asset) => ({
-          id: self.crypto.randomUUID(),
+          id: crypto.randomUUID(),
           assetURL: asset,
           projectId: project.id,
           thumbnailURL: asset.replace('.scene.json', '.thumbnail.jpg'),

--- a/packages/server-core/src/assets/asset/asset-helper.ts
+++ b/packages/server-core/src/assets/asset/asset-helper.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import { AssetType, ProjectType, assetPath } from '@etherealengine/common/src/schema.type.module'
 import { getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
-import { v4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 
@@ -44,7 +44,7 @@ export const syncAllSceneJSONAssets = async (projects: ProjectType[], app: Appli
         )
         if (!sceneJSONAssets.length) return
         return sceneJSONAssets.map((asset) => ({
-          id: v4(),
+          id: self.crypto.randomUUID(),
           assetURL: asset,
           projectId: project.id,
           thumbnailURL: asset.replace('.scene.json', '.thumbnail.jpg'),

--- a/packages/server-core/src/assets/asset/asset.resolvers.ts
+++ b/packages/server-core/src/assets/asset/asset.resolvers.ts
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 } from 'uuid'
 
 import type { HookContext } from '@etherealengine/server-core/declarations'
 
@@ -42,7 +41,7 @@ export const assetExternalResolver = resolve<AssetType, HookContext>({})
 
 export const assetDataResolver = resolve<AssetType, HookContext>({
   id: async () => {
-    return v4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/assets/asset/asset.resolvers.ts
+++ b/packages/server-core/src/assets/asset/asset.resolvers.ts
@@ -41,7 +41,7 @@ export const assetExternalResolver = resolve<AssetType, HookContext>({})
 
 export const assetDataResolver = resolve<AssetType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/assets/asset/asset.test.ts
+++ b/packages/server-core/src/assets/asset/asset.test.ts
@@ -41,7 +41,7 @@ describe('asset.test', () => {
   })
 
   before(async () => {
-    projectName = `test-scene-project-${self.crypto.randomUUID()}`
+    projectName = `test-scene-project-${crypto.randomUUID()}`
     project = await app.service(projectPath).create({ name: projectName })
   })
 

--- a/packages/server-core/src/assets/asset/asset.test.ts
+++ b/packages/server-core/src/assets/asset/asset.test.ts
@@ -24,7 +24,7 @@ import { ProjectType, projectPath } from '@etherealengine/common/src/schemas/pro
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import fs from 'fs'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 import { getStorageProvider } from '../../media/storageprovider/storageprovider'
@@ -41,7 +41,7 @@ describe('asset.test', () => {
   })
 
   before(async () => {
-    projectName = `test-scene-project-${uuidv4()}`
+    projectName = `test-scene-project-${self.crypto.randomUUID()}`
     project = await app.service(projectPath).create({ name: projectName })
   })
 

--- a/packages/server-core/src/assets/asset/migrations/20240407001221_assets.ts
+++ b/packages/server-core/src/assets/asset/migrations/20240407001221_assets.ts
@@ -58,7 +58,7 @@ export async function up(knex: Knex): Promise<void> {
         locations
           .filter((item) => item.sceneId)
           .map(async (location: LocationType) => {
-            const id = self.crypto.randomUUID()
+            const id = crypto.randomUUID()
             await trx.from(locationPath).where({ sceneId: location.sceneId }).update({ sceneId: id })
             const [, projectName] = location.sceneId.split('/')
             const projects = await trx.select().from(projectPath).where('name', projectName)

--- a/packages/server-core/src/assets/asset/migrations/20240407001221_assets.ts
+++ b/packages/server-core/src/assets/asset/migrations/20240407001221_assets.ts
@@ -28,7 +28,6 @@ import { projectPath } from '@etherealengine/common/src/schemas/projects/project
 import { LocationType, locationPath } from '@etherealengine/common/src/schemas/social/location.schema'
 import { getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import type { Knex } from 'knex'
-import { v4 } from 'uuid'
 
 /**
  * @param { import("knex").Knex } knex
@@ -59,7 +58,7 @@ export async function up(knex: Knex): Promise<void> {
         locations
           .filter((item) => item.sceneId)
           .map(async (location: LocationType) => {
-            const id = v4()
+            const id = self.crypto.randomUUID()
             await trx.from(locationPath).where({ sceneId: location.sceneId }).update({ sceneId: id })
             const [, projectName] = location.sceneId.split('/')
             const projects = await trx.select().from(projectPath).where('name', projectName)

--- a/packages/server-core/src/bot/bot-command/bot-command.resolvers.ts
+++ b/packages/server-core/src/bot/bot-command/bot-command.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { BotCommandQuery, BotCommandType } from '@etherealengine/common/src/schemas/bot/bot-command.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const botCommandExternalResolver = resolve<BotCommandType, HookContext>({
 
 export const botCommandDataResolver = resolve<BotCommandType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/bot/bot-command/bot-command.resolvers.ts
+++ b/packages/server-core/src/bot/bot-command/bot-command.resolvers.ts
@@ -40,7 +40,7 @@ export const botCommandExternalResolver = resolve<BotCommandType, HookContext>({
 
 export const botCommandDataResolver = resolve<BotCommandType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/bot/bot/bot.resolvers.ts
+++ b/packages/server-core/src/bot/bot/bot.resolvers.ts
@@ -65,7 +65,7 @@ export const botExternalResolver = resolve<BotType, HookContext>({
 
 export const botDataResolver = resolve<BotType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   instanceId: async (instanceId) => {
     return instanceId ?? ('' as InstanceID)

--- a/packages/server-core/src/bot/bot/bot.resolvers.ts
+++ b/packages/server-core/src/bot/bot/bot.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { BotQuery, BotType } from '@etherealengine/common/src/schemas/bot/bot.schema'
 import { locationPath } from '@etherealengine/common/src/schemas/social/location.schema'
@@ -66,7 +65,7 @@ export const botExternalResolver = resolve<BotType, HookContext>({
 
 export const botDataResolver = resolve<BotType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   instanceId: async (instanceId) => {
     return instanceId ?? ('' as InstanceID)

--- a/packages/server-core/src/bot/bot/bot.test.ts
+++ b/packages/server-core/src/bot/bot/bot.test.ts
@@ -62,8 +62,8 @@ describe('bot.service', () => {
   })
 
   before(async () => {
-    const name = ('test-bot-user-name-' + self.crypto.randomUUID()) as UserName
-    const avatarName = 'test-bot-avatar-name-' + self.crypto.randomUUID()
+    const name = ('test-bot-user-name-' + crypto.randomUUID()) as UserName
+    const avatarName = 'test-bot-avatar-name-' + crypto.randomUUID()
 
     const avatar = await app.service(avatarPath).create({
       name: avatarName
@@ -78,8 +78,8 @@ describe('bot.service', () => {
   })
 
   it('should create bot', async () => {
-    const name = 'test-bot-' + self.crypto.randomUUID()
-    const description = self.crypto.randomUUID() + '-' + self.crypto.randomUUID()
+    const name = 'test-bot-' + crypto.randomUUID()
+    const description = crypto.randomUUID() + '-' + crypto.randomUUID()
     testBot = await app.service(botPath).create({
       name,
       instanceId: testInstance.id,
@@ -98,17 +98,17 @@ describe('bot.service', () => {
   })
 
   it('should create bot with botCommands', async () => {
-    const name = 'test-bot-' + self.crypto.randomUUID()
-    const description = self.crypto.randomUUID() + '-' + self.crypto.randomUUID()
+    const name = 'test-bot-' + crypto.randomUUID()
+    const description = crypto.randomUUID() + '-' + crypto.randomUUID()
 
     const botCommands = [
       {
-        name: 'test-bot-command-' + self.crypto.randomUUID(),
-        description: 'bot-command-description-' + self.crypto.randomUUID()
+        name: 'test-bot-command-' + crypto.randomUUID(),
+        description: 'bot-command-description-' + crypto.randomUUID()
       },
       {
-        name: 'test-bot-command-' + self.crypto.randomUUID(),
-        description: 'bot-command-description-' + self.crypto.randomUUID()
+        name: 'test-bot-command-' + crypto.randomUUID(),
+        description: 'bot-command-description-' + crypto.randomUUID()
       }
     ]
 
@@ -135,7 +135,7 @@ describe('bot.service', () => {
   })
 
   it('should patch the bot', async () => {
-    const name = 'test-bot-' + self.crypto.randomUUID()
+    const name = 'test-bot-' + crypto.randomUUID()
     const patchedBot = await app.service(botPath).patch(testBot.id, { name }, { isInternal: true })
     assert.equal(patchedBot.name, name)
     testBot = patchedBot

--- a/packages/server-core/src/bot/bot/bot.test.ts
+++ b/packages/server-core/src/bot/bot/bot.test.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import assert from 'assert'
-import { v4 as uuidv4 } from 'uuid'
 
 import { avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
@@ -63,8 +62,8 @@ describe('bot.service', () => {
   })
 
   before(async () => {
-    const name = ('test-bot-user-name-' + uuidv4()) as UserName
-    const avatarName = 'test-bot-avatar-name-' + uuidv4()
+    const name = ('test-bot-user-name-' + self.crypto.randomUUID()) as UserName
+    const avatarName = 'test-bot-avatar-name-' + self.crypto.randomUUID()
 
     const avatar = await app.service(avatarPath).create({
       name: avatarName
@@ -79,8 +78,8 @@ describe('bot.service', () => {
   })
 
   it('should create bot', async () => {
-    const name = 'test-bot-' + uuidv4()
-    const description = uuidv4() + '-' + uuidv4()
+    const name = 'test-bot-' + self.crypto.randomUUID()
+    const description = self.crypto.randomUUID() + '-' + self.crypto.randomUUID()
     testBot = await app.service(botPath).create({
       name,
       instanceId: testInstance.id,
@@ -99,12 +98,18 @@ describe('bot.service', () => {
   })
 
   it('should create bot with botCommands', async () => {
-    const name = 'test-bot-' + uuidv4()
-    const description = uuidv4() + '-' + uuidv4()
+    const name = 'test-bot-' + self.crypto.randomUUID()
+    const description = self.crypto.randomUUID() + '-' + self.crypto.randomUUID()
 
     const botCommands = [
-      { name: 'test-bot-command-' + uuidv4(), description: 'bot-command-description-' + uuidv4() },
-      { name: 'test-bot-command-' + uuidv4(), description: 'bot-command-description-' + uuidv4() }
+      {
+        name: 'test-bot-command-' + self.crypto.randomUUID(),
+        description: 'bot-command-description-' + self.crypto.randomUUID()
+      },
+      {
+        name: 'test-bot-command-' + self.crypto.randomUUID(),
+        description: 'bot-command-description-' + self.crypto.randomUUID()
+      }
     ]
 
     const createdBot = await app.service(botPath).create({
@@ -130,7 +135,7 @@ describe('bot.service', () => {
   })
 
   it('should patch the bot', async () => {
-    const name = 'test-bot-' + uuidv4()
+    const name = 'test-bot-' + self.crypto.randomUUID()
     const patchedBot = await app.service(botPath).patch(testBot.id, { name }, { isInternal: true })
     assert.equal(patchedBot.name, name)
     testBot = patchedBot

--- a/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
@@ -30,7 +30,6 @@ import { ApiJobQuery, ApiJobType } from '@etherealengine/common/src/schemas/clus
 import type { HookContext } from '@etherealengine/server-core/declarations'
 
 import { fromDateTimeSql, getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
-import { v4 as uuidv4 } from 'uuid'
 
 export const apiJobResolver = resolve<ApiJobType, HookContext>({
   startTime: virtual(async (apiJob) => fromDateTimeSql(apiJob.startTime)),
@@ -43,7 +42,7 @@ export const apiJobExternalResolver = resolve<ApiJobType, HookContext>({})
 
 export const apiJobDataResolver = resolve<ApiJobType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
@@ -42,7 +42,7 @@ export const apiJobExternalResolver = resolve<ApiJobType, HookContext>({})
 
 export const apiJobDataResolver = resolve<ApiJobType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/matchmaking/match-instance/match-instance.resolvers.ts
+++ b/packages/server-core/src/matchmaking/match-instance/match-instance.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   MatchInstanceQuery,
@@ -44,7 +43,7 @@ export const matchInstanceExternalResolver = resolve<MatchInstanceType, HookCont
 
 export const matchInstanceDataResolver = resolve<MatchInstanceType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/matchmaking/match-instance/match-instance.resolvers.ts
+++ b/packages/server-core/src/matchmaking/match-instance/match-instance.resolvers.ts
@@ -43,7 +43,7 @@ export const matchInstanceExternalResolver = resolve<MatchInstanceType, HookCont
 
 export const matchInstanceDataResolver = resolve<MatchInstanceType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/matchmaking/match-ticket/match-ticket.resolvers.ts
+++ b/packages/server-core/src/matchmaking/match-ticket/match-ticket.resolvers.ts
@@ -40,7 +40,7 @@ export const matchTicketExternalResolver = resolve<MatchTicketType, HookContext>
 
 export const matchTicketDataResolver = resolve<MatchTicketType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/matchmaking/match-ticket/match-ticket.resolvers.ts
+++ b/packages/server-core/src/matchmaking/match-ticket/match-ticket.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { MatchTicketQuery, MatchTicketType } from '@etherealengine/matchmaking/src/match-ticket.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const matchTicketExternalResolver = resolve<MatchTicketType, HookContext>
 
 export const matchTicketDataResolver = resolve<MatchTicketType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/matchmaking/match-user/match-user.resolvers.ts
+++ b/packages/server-core/src/matchmaking/match-user/match-user.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { MatchUserQuery, MatchUserType } from '@etherealengine/common/src/schemas/matchmaking/match-user.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const matchUserExternalResolver = resolve<MatchUserType, HookContext>({})
 
 export const matchUserDataResolver = resolve<MatchUserType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/matchmaking/match-user/match-user.resolvers.ts
+++ b/packages/server-core/src/matchmaking/match-user/match-user.resolvers.ts
@@ -40,7 +40,7 @@ export const matchUserExternalResolver = resolve<MatchUserType, HookContext>({})
 
 export const matchUserDataResolver = resolve<MatchUserType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/media/invalidation/invalidation.resolvers.ts
+++ b/packages/server-core/src/media/invalidation/invalidation.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 } from 'uuid'
 
 import { InvalidationQuery, InvalidationType } from '@etherealengine/common/src/schemas/media/invalidation.schema'
 import { fromDateTimeSql, getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
@@ -40,7 +39,7 @@ export const invalidationExternalResolver = resolve<InvalidationType, HookContex
 
 export const invalidationDataResolver = resolve<InvalidationType, HookContext>({
   id: async () => {
-    return v4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/media/invalidation/invalidation.resolvers.ts
+++ b/packages/server-core/src/media/invalidation/invalidation.resolvers.ts
@@ -39,7 +39,7 @@ export const invalidationExternalResolver = resolve<InvalidationType, HookContex
 
 export const invalidationDataResolver = resolve<InvalidationType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/media/static-resource/static-resource.resolvers.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   StaticResourceDatabaseType,
@@ -87,7 +86,7 @@ export const staticResourceExternalResolver = resolve<StaticResourceType, HookCo
 export const staticResourceDataResolver = resolve<StaticResourceType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     sid: async () => {
       return nanoid(8)

--- a/packages/server-core/src/media/static-resource/static-resource.resolvers.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.resolvers.ts
@@ -86,7 +86,7 @@ export const staticResourceExternalResolver = resolve<StaticResourceType, HookCo
 export const staticResourceDataResolver = resolve<StaticResourceType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     sid: async () => {
       return nanoid(8)

--- a/packages/server-core/src/networking/instance-attendance/instance-attendance.resolvers.ts
+++ b/packages/server-core/src/networking/instance-attendance/instance-attendance.resolvers.ts
@@ -43,7 +43,7 @@ export const instanceAttendanceExternalResolver = resolve<InstanceAttendanceType
 
 export const instanceAttendanceDataResolver = resolve<InstanceAttendanceType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/networking/instance-attendance/instance-attendance.resolvers.ts
+++ b/packages/server-core/src/networking/instance-attendance/instance-attendance.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   InstanceAttendanceQuery,
@@ -44,7 +43,7 @@ export const instanceAttendanceExternalResolver = resolve<InstanceAttendanceType
 
 export const instanceAttendanceDataResolver = resolve<InstanceAttendanceType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/networking/instance-authorized-user/instance-authorized-user.resolvers.ts
+++ b/packages/server-core/src/networking/instance-authorized-user/instance-authorized-user.resolvers.ts
@@ -43,7 +43,7 @@ export const instanceAuthorizedUserExternalResolver = resolve<InstanceAuthorized
 
 export const instanceAuthorizedUserDataResolver = resolve<InstanceAuthorizedUserType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/networking/instance-authorized-user/instance-authorized-user.resolvers.ts
+++ b/packages/server-core/src/networking/instance-authorized-user/instance-authorized-user.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   InstanceAuthorizedUserQuery,
@@ -44,7 +43,7 @@ export const instanceAuthorizedUserExternalResolver = resolve<InstanceAuthorized
 
 export const instanceAuthorizedUserDataResolver = resolve<InstanceAuthorizedUserType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/networking/instance/instance.resolvers.ts
+++ b/packages/server-core/src/networking/instance/instance.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { InstanceID, InstanceQuery, InstanceType } from '@etherealengine/common/src/schemas/networking/instance.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -47,7 +46,7 @@ export const instanceExternalResolver = resolve<InstanceType, HookContext>({})
 
 export const instanceDataResolver = resolve<InstanceType, HookContext>({
   id: async () => {
-    return uuidv4() as InstanceID
+    return self.crypto.randomUUID() as InstanceID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/networking/instance/instance.resolvers.ts
+++ b/packages/server-core/src/networking/instance/instance.resolvers.ts
@@ -46,7 +46,7 @@ export const instanceExternalResolver = resolve<InstanceType, HookContext>({})
 
 export const instanceDataResolver = resolve<InstanceType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as InstanceID
+    return crypto.randomUUID() as InstanceID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/projects/project-branches/project-branches.test.ts
+++ b/packages/server-core/src/projects/project-branches/project-branches.test.ts
@@ -53,10 +53,10 @@ describe('project-branches.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-branches-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-branches-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-branches-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-branches-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-branches/project-branches.test.ts
+++ b/packages/server-core/src/projects/project-branches/project-branches.test.ts
@@ -32,7 +32,7 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -53,10 +53,10 @@ describe('project-branches.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-branches-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-branches-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-branches-avatar-name-' + uuidv4()
+      name: 'test-project-branches-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-builder-tags/project-builder-tags.test.ts
+++ b/packages/server-core/src/projects/project-builder-tags/project-builder-tags.test.ts
@@ -53,10 +53,10 @@ describe('project-builder-tags.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-builder-tags-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-builder-tags-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-builder-tags-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-builder-tags-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-builder-tags/project-builder-tags.test.ts
+++ b/packages/server-core/src/projects/project-builder-tags/project-builder-tags.test.ts
@@ -32,7 +32,7 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -53,10 +53,10 @@ describe('project-builder-tags.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-builder-tags-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-builder-tags-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-builder-tags-avatar-name-' + uuidv4()
+      name: 'test-project-builder-tags-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-check-source-destination-match/project-check-source-destination-match.test.ts
+++ b/packages/server-core/src/projects/project-check-source-destination-match/project-check-source-destination-match.test.ts
@@ -33,7 +33,7 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -64,10 +64,10 @@ describe('project-check-source-destination-match.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-check-source-destination-match-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-check-source-destination-match-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-check-source-destination-match-avatar-name-' + uuidv4()
+      name: 'test-project-check-source-destination-match-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-check-source-destination-match/project-check-source-destination-match.test.ts
+++ b/packages/server-core/src/projects/project-check-source-destination-match/project-check-source-destination-match.test.ts
@@ -64,10 +64,10 @@ describe('project-check-source-destination-match.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-check-source-destination-match-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-check-source-destination-match-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-check-source-destination-match-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-check-source-destination-match-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-check-unfetched-commit/project-check-unfetched-commit.test.ts
+++ b/packages/server-core/src/projects/project-check-unfetched-commit/project-check-unfetched-commit.test.ts
@@ -32,7 +32,7 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -53,10 +53,10 @@ describe('project-check-unfetched-commit.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-check-unfetched-commit-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-check-unfetched-commit-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-check-unfetched-commit-avatar-name-' + uuidv4()
+      name: 'test-project-check-unfetched-commit-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-check-unfetched-commit/project-check-unfetched-commit.test.ts
+++ b/packages/server-core/src/projects/project-check-unfetched-commit/project-check-unfetched-commit.test.ts
@@ -53,10 +53,10 @@ describe('project-check-unfetched-commit.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-check-unfetched-commit-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-check-unfetched-commit-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-check-unfetched-commit-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-check-unfetched-commit-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-commits/project-commits.test.ts
+++ b/packages/server-core/src/projects/project-commits/project-commits.test.ts
@@ -53,10 +53,10 @@ describe('project-commits.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-commits-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-commits-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-commits-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-commits-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-commits/project-commits.test.ts
+++ b/packages/server-core/src/projects/project-commits/project-commits.test.ts
@@ -32,7 +32,7 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -53,10 +53,10 @@ describe('project-commits.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-commits-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-commits-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-commits-avatar-name-' + uuidv4()
+      name: 'test-project-commits-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-destination-check/project-destination-check.test.ts
+++ b/packages/server-core/src/projects/project-destination-check/project-destination-check.test.ts
@@ -53,10 +53,10 @@ describe('project-destination-check.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-destination-check-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-destination-check-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-destination-check-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-destination-check-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-destination-check/project-destination-check.test.ts
+++ b/packages/server-core/src/projects/project-destination-check/project-destination-check.test.ts
@@ -32,7 +32,7 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -53,10 +53,10 @@ describe('project-destination-check.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-destination-check-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-destination-check-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-destination-check-avatar-name-' + uuidv4()
+      name: 'test-project-destination-check-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({

--- a/packages/server-core/src/projects/project-github-push/project-github-push.test.ts
+++ b/packages/server-core/src/projects/project-github-push/project-github-push.test.ts
@@ -34,7 +34,7 @@ import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
 import { createHash } from 'crypto'
 import nock from 'nock'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
@@ -56,10 +56,10 @@ describe('project-github-push.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-destination-check-user-name-' + uuidv4()) as UserName
+    const name = ('test-project-destination-check-user-name-' + self.crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-destination-check-avatar-name-' + uuidv4()
+      name: 'test-project-destination-check-avatar-name-' + self.crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({
@@ -83,7 +83,7 @@ describe('project-github-push.test', () => {
   })
 
   before(async () => {
-    const projectName = `test-project-github-push-${uuidv4()}`
+    const projectName = `test-project-github-push-${self.crypto.randomUUID()}`
     testProject = await app
       .service(projectPath)
       .create({ name: projectName, repositoryPath: `https://github.com/test-user/${projectName}` })
@@ -282,13 +282,13 @@ const getGitRef = () => ({
   url: 'https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA',
   object: {
     type: 'commit',
-    sha: createHash('sha256').update(uuidv4()).digest('hex'),
+    sha: createHash('sha256').update(self.crypto.randomUUID()).digest('hex'),
     url: 'https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd'
   }
 })
 
 const getGitCommitData = () => ({
-  sha: createHash('sha256').update(uuidv4()).digest('hex'),
+  sha: createHash('sha256').update(self.crypto.randomUUID()).digest('hex'),
   node_id: 'MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==',
   url: 'https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd',
   html_url: 'https://github.com/octocat/Hello-World/commit/7638417db6d59f3c431d3e1f261cc637155684cd',
@@ -305,7 +305,7 @@ const getGitCommitData = () => ({
   message: 'added readme, because im a good github citizen',
   tree: {
     url: 'https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb',
-    sha: createHash('sha256').update(uuidv4()).digest('hex')
+    sha: createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
   },
   parents: [
     {
@@ -370,7 +370,7 @@ const getAuthenticatedUser = (username: string) => ({
 })
 
 const getGitBlob = () => {
-  const createdHash = createHash('sha256').update(uuidv4()).digest('hex')
+  const createdHash = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
   return {
     url: `https://api.github.com/repos/test-user/example/git/blobs/${createdHash}`,
     sha: createdHash
@@ -378,10 +378,10 @@ const getGitBlob = () => {
 }
 
 const getGitTree = () => {
-  const sha1 = createHash('sha256').update(uuidv4()).digest('hex')
-  const sha2 = createHash('sha256').update(uuidv4()).digest('hex')
-  const sha3 = createHash('sha256').update(uuidv4()).digest('hex')
-  const sha4 = createHash('sha256').update(uuidv4()).digest('hex')
+  const sha1 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
+  const sha2 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
+  const sha3 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
+  const sha4 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
 
   return {
     sha: sha1,

--- a/packages/server-core/src/projects/project-github-push/project-github-push.test.ts
+++ b/packages/server-core/src/projects/project-github-push/project-github-push.test.ts
@@ -56,10 +56,10 @@ describe('project-github-push.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-destination-check-user-name-' + self.crypto.randomUUID()) as UserName
+    const name = ('test-project-destination-check-user-name-' + crypto.randomUUID()) as UserName
 
     const avatar = await app.service(avatarPath).create({
-      name: 'test-project-destination-check-avatar-name-' + self.crypto.randomUUID()
+      name: 'test-project-destination-check-avatar-name-' + crypto.randomUUID()
     })
 
     const testUser = await app.service(userPath).create({
@@ -83,7 +83,7 @@ describe('project-github-push.test', () => {
   })
 
   before(async () => {
-    const projectName = `test-project-github-push-${self.crypto.randomUUID()}`
+    const projectName = `test-project-github-push-${crypto.randomUUID()}`
     testProject = await app
       .service(projectPath)
       .create({ name: projectName, repositoryPath: `https://github.com/test-user/${projectName}` })
@@ -282,13 +282,13 @@ const getGitRef = () => ({
   url: 'https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA',
   object: {
     type: 'commit',
-    sha: createHash('sha256').update(self.crypto.randomUUID()).digest('hex'),
+    sha: createHash('sha256').update(crypto.randomUUID()).digest('hex'),
     url: 'https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd'
   }
 })
 
 const getGitCommitData = () => ({
-  sha: createHash('sha256').update(self.crypto.randomUUID()).digest('hex'),
+  sha: createHash('sha256').update(crypto.randomUUID()).digest('hex'),
   node_id: 'MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==',
   url: 'https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd',
   html_url: 'https://github.com/octocat/Hello-World/commit/7638417db6d59f3c431d3e1f261cc637155684cd',
@@ -305,7 +305,7 @@ const getGitCommitData = () => ({
   message: 'added readme, because im a good github citizen',
   tree: {
     url: 'https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb',
-    sha: createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
+    sha: createHash('sha256').update(crypto.randomUUID()).digest('hex')
   },
   parents: [
     {
@@ -370,7 +370,7 @@ const getAuthenticatedUser = (username: string) => ({
 })
 
 const getGitBlob = () => {
-  const createdHash = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
+  const createdHash = createHash('sha256').update(crypto.randomUUID()).digest('hex')
   return {
     url: `https://api.github.com/repos/test-user/example/git/blobs/${createdHash}`,
     sha: createdHash
@@ -378,10 +378,10 @@ const getGitBlob = () => {
 }
 
 const getGitTree = () => {
-  const sha1 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
-  const sha2 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
-  const sha3 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
-  const sha4 = createHash('sha256').update(self.crypto.randomUUID()).digest('hex')
+  const sha1 = createHash('sha256').update(crypto.randomUUID()).digest('hex')
+  const sha2 = createHash('sha256').update(crypto.randomUUID()).digest('hex')
+  const sha3 = createHash('sha256').update(crypto.randomUUID()).digest('hex')
+  const sha4 = createHash('sha256').update(crypto.randomUUID()).digest('hex')
 
   return {
     sha: sha1,

--- a/packages/server-core/src/projects/project-permission/project-permission.resolvers.ts
+++ b/packages/server-core/src/projects/project-permission/project-permission.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   ProjectPermissionQuery,
@@ -48,7 +47,7 @@ export const projectPermissionExternalResolver = resolve<ProjectPermissionType, 
 
 export const projectPermissionDataResolver = resolve<ProjectPermissionType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/projects/project-permission/project-permission.resolvers.ts
+++ b/packages/server-core/src/projects/project-permission/project-permission.resolvers.ts
@@ -47,7 +47,7 @@ export const projectPermissionExternalResolver = resolve<ProjectPermissionType, 
 
 export const projectPermissionDataResolver = resolve<ProjectPermissionType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -73,7 +73,7 @@ import { AssetClass } from '@etherealengine/engine/src/assets/enum/AssetClass'
 import { BadRequest, Forbidden } from '@feathersjs/errors'
 import { Paginated } from '@feathersjs/feathers'
 import { RestEndpointMethodTypes } from '@octokit/rest'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import { syncAllSceneJSONAssets } from '../../assets/asset/asset-helper'
@@ -1542,7 +1542,7 @@ export const updateProject = async (
     ? // Add to DB
       await app.service(projectPath).create(
         {
-          id: uuidv4(),
+          id: self.crypto.randomUUID(),
           name: projectName,
           enabled,
           repositoryPath,

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1542,7 +1542,7 @@ export const updateProject = async (
     ? // Add to DB
       await app.service(projectPath).create(
         {
-          id: self.crypto.randomUUID(),
+          id: crypto.randomUUID(),
           name: projectName,
           enabled,
           repositoryPath,

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -41,7 +41,7 @@ import {
 import { getDateTimeSql, toDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import { getState } from '@etherealengine/hyperflux'
 import { KnexAdapterOptions, KnexAdapterParams, KnexService } from '@feathersjs/knex'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import logger from '../../ServerLogger'
 import { ServerMode, ServerState } from '../../ServerState'
@@ -110,7 +110,7 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
     const { commitSHA, commitDate } = await getCommitSHADate(projectName)
 
     await super._create({
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       name: projectName,
       enabled,
       repositoryPath: gitData.repositoryPath,

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -110,7 +110,7 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
     const { commitSHA, commitDate } = await getCommitSHADate(projectName)
 
     await super._create({
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       name: projectName,
       enabled,
       repositoryPath: gitData.repositoryPath,

--- a/packages/server-core/src/projects/project/project.resolvers.ts
+++ b/packages/server-core/src/projects/project/project.resolvers.ts
@@ -97,7 +97,7 @@ export const projectExternalResolver = resolve<ProjectType, HookContext>({})
 export const projectDataResolver = resolve<ProjectDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/projects/project/project.resolvers.ts
+++ b/packages/server-core/src/projects/project/project.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   ProjectPermissionType,
@@ -98,7 +97,7 @@ export const projectExternalResolver = resolve<ProjectType, HookContext>({})
 export const projectDataResolver = resolve<ProjectDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/projects/project/project.test.ts
+++ b/packages/server-core/src/projects/project/project.test.ts
@@ -39,7 +39,7 @@ import { UserApiKeyType, userApiKeyPath } from '@etherealengine/common/src/schem
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { copyFolderRecursiveSync, deleteFolderRecursive } from '@etherealengine/common/src/utils/fsHelperFunctions'
 import { Paginated } from '@feathersjs/feathers'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 import { useGit } from '../../util/gitHelperFunctions'
@@ -69,8 +69,8 @@ describe('project.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-user-name-' + uuidv4()) as UserName
-    const avatarName = 'test-project-avatar-name-' + uuidv4()
+    const name = ('test-project-user-name-' + self.crypto.randomUUID()) as UserName
+    const avatarName = 'test-project-avatar-name-' + self.crypto.randomUUID()
 
     const avatar = await app.service(avatarPath).create({
       name: avatarName
@@ -102,7 +102,7 @@ describe('project.test', () => {
 
   describe('create', () => {
     it('should add new project', async () => {
-      const projectName = `test-project-${uuidv4()}`
+      const projectName = `test-project-${self.crypto.randomUUID()}`
 
       testProject = await app.service(projectPath).create(
         {
@@ -144,7 +144,7 @@ describe('project.test', () => {
       git.add('.')
       git.commit('initial commit')
 
-      testUpdateProjectName = `test-update-project-name-${uuidv4()}`
+      testUpdateProjectName = `test-update-project-name-${self.crypto.randomUUID()}`
     })
 
     after(async () => {

--- a/packages/server-core/src/projects/project/project.test.ts
+++ b/packages/server-core/src/projects/project/project.test.ts
@@ -69,8 +69,8 @@ describe('project.test', () => {
   })
 
   before(async () => {
-    const name = ('test-project-user-name-' + self.crypto.randomUUID()) as UserName
-    const avatarName = 'test-project-avatar-name-' + self.crypto.randomUUID()
+    const name = ('test-project-user-name-' + crypto.randomUUID()) as UserName
+    const avatarName = 'test-project-avatar-name-' + crypto.randomUUID()
 
     const avatar = await app.service(avatarPath).create({
       name: avatarName
@@ -102,7 +102,7 @@ describe('project.test', () => {
 
   describe('create', () => {
     it('should add new project', async () => {
-      const projectName = `test-project-${self.crypto.randomUUID()}`
+      const projectName = `test-project-${crypto.randomUUID()}`
 
       testProject = await app.service(projectPath).create(
         {
@@ -144,7 +144,7 @@ describe('project.test', () => {
       git.add('.')
       git.commit('initial commit')
 
-      testUpdateProjectName = `test-update-project-name-${self.crypto.randomUUID()}`
+      testUpdateProjectName = `test-update-project-name-${crypto.randomUUID()}`
     })
 
     after(async () => {

--- a/packages/server-core/src/recording/recording-resource/recording-resource.resolvers.ts
+++ b/packages/server-core/src/recording/recording-resource/recording-resource.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import type { HookContext } from '@etherealengine/server-core/declarations'
 
@@ -49,7 +48,7 @@ export const recordingResourceExternalResolver = resolve<RecordingResourceType, 
 
 export const recordingResourceDataResolver = resolve<RecordingResourceType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/recording/recording-resource/recording-resource.resolvers.ts
+++ b/packages/server-core/src/recording/recording-resource/recording-resource.resolvers.ts
@@ -48,7 +48,7 @@ export const recordingResourceExternalResolver = resolve<RecordingResourceType, 
 
 export const recordingResourceDataResolver = resolve<RecordingResourceType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/recording/recording/recording.resolvers.ts
+++ b/packages/server-core/src/recording/recording/recording.resolvers.ts
@@ -90,7 +90,7 @@ export const recordingExternalResolver = resolve<RecordingType, HookContext>({})
 export const recordingDataResolver = resolve<RecordingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID() as RecordingID
+      return crypto.randomUUID() as RecordingID
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/recording/recording/recording.resolvers.ts
+++ b/packages/server-core/src/recording/recording/recording.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import type { HookContext } from '@etherealengine/server-core/declarations'
 
@@ -91,7 +90,7 @@ export const recordingExternalResolver = resolve<RecordingType, HookContext>({})
 export const recordingDataResolver = resolve<RecordingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4() as RecordingID
+      return self.crypto.randomUUID() as RecordingID
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/route/route/route.resolvers.ts
+++ b/packages/server-core/src/route/route/route.resolvers.ts
@@ -40,7 +40,7 @@ export const routeExternalResolver = resolve<RouteType, HookContext>({})
 
 export const routeDataResolver = resolve<RouteType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as RouteID
+    return crypto.randomUUID() as RouteID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/route/route/route.resolvers.ts
+++ b/packages/server-core/src/route/route/route.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { RouteID, RouteQuery, RouteType } from '@etherealengine/common/src/schemas/route/route.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const routeExternalResolver = resolve<RouteType, HookContext>({})
 
 export const routeDataResolver = resolve<RouteType, HookContext>({
   id: async () => {
-    return uuidv4() as RouteID
+    return self.crypto.randomUUID() as RouteID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/route/route/route.seed.ts
+++ b/packages/server-core/src/route/route/route.seed.ts
@@ -70,7 +70,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID() as RouteID,
+      id: crypto.randomUUID() as RouteID,
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/route/route/route.seed.ts
+++ b/packages/server-core/src/route/route/route.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { RouteID, routePath, RouteType } from '@etherealengine/common/src/schemas/route/route.schema'
 import appConfig from '@etherealengine/server-core/src/appconfig'
@@ -71,7 +70,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4() as RouteID,
+      id: self.crypto.randomUUID() as RouteID,
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/route/route/route.test.ts
+++ b/packages/server-core/src/route/route/route.test.ts
@@ -27,7 +27,6 @@ import appRootPath from 'app-root-path'
 import assert from 'assert'
 import fs from 'fs'
 import path from 'path'
-import { v4 as uuidv4 } from 'uuid'
 
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
@@ -92,8 +91,8 @@ describe('route.test', () => {
   })
 
   it('should find the installed project routes', async () => {
-    testProject = `test-project-${uuidv4()}`
-    testRoute = `test-route-${uuidv4()}`
+    testProject = `test-project-${self.crypto.randomUUID()}`
+    testRoute = `test-route-${self.crypto.randomUUID()}`
 
     await app.service(projectPath).create({ name: testProject }, params)
     updateXREngineConfigForTest(testProject, testRoute)

--- a/packages/server-core/src/route/route/route.test.ts
+++ b/packages/server-core/src/route/route/route.test.ts
@@ -91,8 +91,8 @@ describe('route.test', () => {
   })
 
   it('should find the installed project routes', async () => {
-    testProject = `test-project-${self.crypto.randomUUID()}`
-    testRoute = `test-route-${self.crypto.randomUUID()}`
+    testProject = `test-project-${crypto.randomUUID()}`
+    testRoute = `test-route-${crypto.randomUUID()}`
 
     await app.service(projectPath).create({ name: testProject }, params)
     updateXREngineConfigForTest(testProject, testRoute)

--- a/packages/server-core/src/scope/scope/scope.resolvers.ts
+++ b/packages/server-core/src/scope/scope/scope.resolvers.ts
@@ -40,7 +40,7 @@ export const scopeExternalResolver = resolve<ScopeTypeInterface, HookContext>({
 
 export const scopeDataResolver = resolve<ScopeTypeInterface, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as ScopeID
+    return crypto.randomUUID() as ScopeID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/scope/scope/scope.resolvers.ts
+++ b/packages/server-core/src/scope/scope/scope.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { ScopeID, ScopeQuery, ScopeTypeInterface } from '@etherealengine/common/src/schemas/scope/scope.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const scopeExternalResolver = resolve<ScopeTypeInterface, HookContext>({
 
 export const scopeDataResolver = resolve<ScopeTypeInterface, HookContext>({
   id: async () => {
-    return uuidv4() as ScopeID
+    return self.crypto.randomUUID() as ScopeID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.resolvers.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   AuthAppCredentialsType,
@@ -177,7 +176,7 @@ export const authenticationSettingExternalResolver = resolve<AuthenticationSetti
 export const authenticationSettingDataResolver = resolve<AuthenticationSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.resolvers.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.resolvers.ts
@@ -176,7 +176,7 @@ export const authenticationSettingExternalResolver = resolve<AuthenticationSetti
 export const authenticationSettingDataResolver = resolve<AuthenticationSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   AuthenticationSettingDatabaseType,
@@ -113,7 +112,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
@@ -112,7 +112,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/aws-setting/aws-setting.resolvers.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   AwsCloudFrontType,
@@ -100,7 +99,7 @@ export const awsSettingExternalResolver = resolve<AwsSettingType, HookContext>({
 export const awsSettingDataResolver = resolve<AwsSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/aws-setting/aws-setting.resolvers.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.resolvers.ts
@@ -99,7 +99,7 @@ export const awsSettingExternalResolver = resolve<AwsSettingType, HookContext>({
 export const awsSettingDataResolver = resolve<AwsSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
@@ -70,7 +70,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { AwsSettingDatabaseType, awsSettingPath } from '@etherealengine/common/src/schemas/setting/aws-setting.schema'
 import appConfig from '@etherealengine/server-core/src/appconfig'
@@ -71,7 +70,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.resolvers.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   ChargebeeSettingQuery,
@@ -44,7 +43,7 @@ export const chargebeeSettingExternalResolver = resolve<ChargebeeSettingType, Ho
 
 export const chargebeeSettingDataResolver = resolve<ChargebeeSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.resolvers.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.resolvers.ts
@@ -43,7 +43,7 @@ export const chargebeeSettingExternalResolver = resolve<ChargebeeSettingType, Ho
 
 export const chargebeeSettingDataResolver = resolve<ChargebeeSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.seed.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.seed.ts
@@ -45,7 +45,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.seed.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   chargebeeSettingPath,
@@ -46,7 +45,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/client-setting/client-setting.resolvers.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   ClientSettingDatabaseType,
@@ -91,7 +90,7 @@ export const clientSettingExternalResolver = resolve<ClientSettingType, HookCont
 export const clientSettingDataResolver = resolve<ClientSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/client-setting/client-setting.resolvers.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.resolvers.ts
@@ -90,7 +90,7 @@ export const clientSettingExternalResolver = resolve<ClientSettingType, HookCont
 export const clientSettingDataResolver = resolve<ClientSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/client-setting/client-setting.seed.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.seed.ts
@@ -79,7 +79,7 @@ export async function seed(knex: Knex): Promise<void> {
   const seedData: ClientSettingDatabaseType[] = await Promise.all(
     [clientSettingSeedData].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/client-setting/client-setting.seed.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { defaultMediaSettings } from '@etherealengine/common/src/constants/DefaultMediaSettings'
 import { defaultThemeModes, defaultThemeSettings } from '@etherealengine/common/src/constants/DefaultThemeSettings'
@@ -80,7 +79,7 @@ export async function seed(knex: Knex): Promise<void> {
   const seedData: ClientSettingDatabaseType[] = await Promise.all(
     [clientSettingSeedData].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/coil-setting/coil-setting.resolvers.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { CoilSettingQuery, CoilSettingType } from '@etherealengine/common/src/schemas/setting/coil-setting.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -53,7 +52,7 @@ export const coilSettingExternalResolver = resolve<CoilSettingType, HookContext>
 
 export const coilSettingDataResolver = resolve<CoilSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/coil-setting/coil-setting.resolvers.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.resolvers.ts
@@ -52,7 +52,7 @@ export const coilSettingExternalResolver = resolve<CoilSettingType, HookContext>
 
 export const coilSettingDataResolver = resolve<CoilSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/coil-setting/coil-setting.seed.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.seed.ts
@@ -43,7 +43,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/coil-setting/coil-setting.seed.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { coilSettingPath, CoilSettingType } from '@etherealengine/common/src/schemas/setting/coil-setting.schema'
 import appConfig from '@etherealengine/server-core/src/appconfig'
@@ -44,7 +43,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/email-setting/email-setting.resolvers.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   EmailAuthType,
@@ -86,7 +85,7 @@ export const emailSettingExternalResolver = resolve<EmailSettingType, HookContex
 export const emailSettingDataResolver = resolve<EmailSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/email-setting/email-setting.resolvers.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.resolvers.ts
@@ -85,7 +85,7 @@ export const emailSettingExternalResolver = resolve<EmailSettingType, HookContex
 export const emailSettingDataResolver = resolve<EmailSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/email-setting/email-setting.seed.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.seed.ts
@@ -64,7 +64,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/email-setting/email-setting.seed.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   EmailSettingDatabaseType,
@@ -65,7 +64,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/helm-setting/helm-setting.resolvers.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.resolvers.ts
@@ -40,7 +40,7 @@ export const helmSettingExternalResolver = resolve<HelmSettingType, HookContext>
 
 export const helmSettingDataResolver = resolve<HelmSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/helm-setting/helm-setting.resolvers.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { HelmSettingQuery, HelmSettingType } from '@etherealengine/common/src/schemas/setting/helm-setting.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const helmSettingExternalResolver = resolve<HelmSettingType, HookContext>
 
 export const helmSettingDataResolver = resolve<HelmSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/helm-setting/helm-setting.seed.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { HelmSettingType, helmSettingPath } from '@etherealengine/common/src/schemas/setting/helm-setting.schema'
 import appConfig from '@etherealengine/server-core/src/appconfig'
@@ -43,7 +42,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/helm-setting/helm-setting.seed.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.seed.ts
@@ -42,7 +42,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   InstanceServerSettingQuery,
@@ -44,7 +43,7 @@ export const instanceServerSettingExternalResolver = resolve<InstanceServerSetti
 
 export const instanceServerSettingDataResolver = resolve<InstanceServerSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.resolvers.ts
@@ -43,7 +43,7 @@ export const instanceServerSettingExternalResolver = resolve<InstanceServerSetti
 
 export const instanceServerSettingDataResolver = resolve<InstanceServerSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.seed.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.seed.ts
@@ -54,7 +54,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.seed.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   instanceServerSettingPath,
@@ -55,7 +54,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/redis-setting/redis-setting.resolvers.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { RedisSettingQuery, RedisSettingType } from '@etherealengine/common/src/schemas/setting/redis-setting.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const redisSettingExternalResolver = resolve<RedisSettingType, HookContex
 
 export const redisSettingDataResolver = resolve<RedisSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/redis-setting/redis-setting.resolvers.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.resolvers.ts
@@ -40,7 +40,7 @@ export const redisSettingExternalResolver = resolve<RedisSettingType, HookContex
 
 export const redisSettingDataResolver = resolve<RedisSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/redis-setting/redis-setting.seed.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.seed.ts
@@ -45,7 +45,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/redis-setting/redis-setting.seed.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import { redisSettingPath, RedisSettingType } from '@etherealengine/common/src/schemas/setting/redis-setting.schema'
 import appConfig from '@etherealengine/server-core/src/appconfig'
@@ -46,7 +45,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/server-setting/server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   ServerHubType,
@@ -70,7 +69,7 @@ export const serverSettingExternalResolver = resolve<ServerSettingType, HookCont
 export const serverSettingDataResolver = resolve<ServerSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/server-setting/server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.resolvers.ts
@@ -69,7 +69,7 @@ export const serverSettingExternalResolver = resolve<ServerSettingType, HookCont
 export const serverSettingDataResolver = resolve<ServerSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/server-setting/server-setting.seed.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.seed.ts
@@ -78,7 +78,7 @@ export async function seed(knex: Knex): Promise<void> {
   const seedData: ServerSettingDatabaseType[] = await Promise.all(
     [server].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/server-setting/server-setting.seed.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.seed.ts
@@ -27,7 +27,6 @@ import appRootPath from 'app-root-path'
 import { Knex } from 'knex'
 import path from 'path'
 import url from 'url'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   ServerSettingDatabaseType,
@@ -79,7 +78,7 @@ export async function seed(knex: Knex): Promise<void> {
   const seedData: ServerSettingDatabaseType[] = await Promise.all(
     [server].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/task-server-setting/task-server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/task-server-setting/task-server-setting.resolvers.ts
@@ -43,7 +43,7 @@ export const taskServerSettingExternalResolver = resolve<TaskServerSettingType, 
 
 export const taskServerSettingDataResolver = resolve<TaskServerSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/task-server-setting/task-server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/task-server-setting/task-server-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   TaskServerSettingQuery,
@@ -44,7 +43,7 @@ export const taskServerSettingExternalResolver = resolve<TaskServerSettingType, 
 
 export const taskServerSettingDataResolver = resolve<TaskServerSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/setting/task-server-setting/task-server-setting.seed.ts
+++ b/packages/server-core/src/setting/task-server-setting/task-server-setting.seed.ts
@@ -45,7 +45,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/setting/task-server-setting/task-server-setting.seed.ts
+++ b/packages/server-core/src/setting/task-server-setting/task-server-setting.seed.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   taskServerSettingPath,
@@ -46,7 +45,7 @@ export async function seed(knex: Knex): Promise<void> {
       }
     ].map(async (item) => ({
       ...item,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       createdAt: await getDateTimeSql(),
       updatedAt: await getDateTimeSql()
     }))

--- a/packages/server-core/src/social/channel-user/channel-user.resolvers.ts
+++ b/packages/server-core/src/social/channel-user/channel-user.resolvers.ts
@@ -43,7 +43,7 @@ export const channelUserExternalResolver = resolve<ChannelUserType, HookContext>
 
 export const channelUserDataResolver = resolve<ChannelUserType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/channel-user/channel-user.resolvers.ts
+++ b/packages/server-core/src/social/channel-user/channel-user.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { ChannelUserQuery, ChannelUserType } from '@etherealengine/common/src/schemas/social/channel-user.schema'
 import { userPath } from '@etherealengine/common/src/schemas/user/user.schema'
@@ -44,7 +43,7 @@ export const channelUserExternalResolver = resolve<ChannelUserType, HookContext>
 
 export const channelUserDataResolver = resolve<ChannelUserType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/channel/channel.resolvers.ts
+++ b/packages/server-core/src/social/channel/channel.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { ChannelUserType, channelUserPath } from '@etherealengine/common/src/schemas/social/channel-user.schema'
 import { ChannelID, ChannelQuery, ChannelType } from '@etherealengine/common/src/schemas/social/channel.schema'
@@ -69,7 +68,7 @@ export const channelExternalResolver = resolve<ChannelType, HookContext>({
 
 export const channelDataResolver = resolve<ChannelType, HookContext>({
   id: async () => {
-    return uuidv4() as ChannelID
+    return self.crypto.randomUUID() as ChannelID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/channel/channel.resolvers.ts
+++ b/packages/server-core/src/social/channel/channel.resolvers.ts
@@ -68,7 +68,7 @@ export const channelExternalResolver = resolve<ChannelType, HookContext>({
 
 export const channelDataResolver = resolve<ChannelType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as ChannelID
+    return crypto.randomUUID() as ChannelID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/invite/invite.resolvers.ts
+++ b/packages/server-core/src/social/invite/invite.resolvers.ts
@@ -105,7 +105,7 @@ export const inviteExternalResolver = resolve<InviteType, HookContext>({
 export const inviteDataResolver = resolve<InviteType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID()
+      return crypto.randomUUID()
     },
     passcode: async () => {
       return crypto.randomBytes(8).toString('hex')

--- a/packages/server-core/src/social/invite/invite.resolvers.ts
+++ b/packages/server-core/src/social/invite/invite.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { ChannelID, channelPath } from '@etherealengine/common/src/schemas/social/channel.schema'
 import {
@@ -106,7 +105,7 @@ export const inviteExternalResolver = resolve<InviteType, HookContext>({
 export const inviteDataResolver = resolve<InviteType, HookContext>(
   {
     id: async () => {
-      return uuidv4()
+      return self.crypto.randomUUID()
     },
     passcode: async () => {
       return crypto.randomBytes(8).toString('hex')

--- a/packages/server-core/src/social/invite/invite.test.ts
+++ b/packages/server-core/src/social/invite/invite.test.ts
@@ -30,7 +30,7 @@ import { avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schem
 import { UserName, UserType, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 import assert from 'assert'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import { createTestLocation } from '../../../tests/util/createTestLocation'
 import { createFeathersKoaApp } from '../../createApp'
@@ -47,8 +47,8 @@ describe('invite.service', () => {
   })
 
   before(async () => {
-    const name = ('test-invite-user-name-' + uuidv4()) as UserName
-    const avatarName = 'test-invite-avatar-name-' + uuidv4()
+    const name = ('test-invite-user-name-' + self.crypto.randomUUID()) as UserName
+    const avatarName = 'test-invite-avatar-name-' + self.crypto.randomUUID()
 
     const avatar = await app.service(avatarPath).create({
       name: avatarName
@@ -72,7 +72,7 @@ describe('invite.service', () => {
   inviteTypes.forEach((inviteType) => {
     it(`should create an invite with type ${inviteType}`, async () => {
       const inviteType = 'friend'
-      const token = `${uuidv4()}@etherealengine.io`
+      const token = `${self.crypto.randomUUID()}@etherealengine.io`
       const identityProviderType = 'email'
 
       const createdInvite = await app.service(invitePath).create(

--- a/packages/server-core/src/social/invite/invite.test.ts
+++ b/packages/server-core/src/social/invite/invite.test.ts
@@ -47,8 +47,8 @@ describe('invite.service', () => {
   })
 
   before(async () => {
-    const name = ('test-invite-user-name-' + self.crypto.randomUUID()) as UserName
-    const avatarName = 'test-invite-avatar-name-' + self.crypto.randomUUID()
+    const name = ('test-invite-user-name-' + crypto.randomUUID()) as UserName
+    const avatarName = 'test-invite-avatar-name-' + crypto.randomUUID()
 
     const avatar = await app.service(avatarPath).create({
       name: avatarName
@@ -72,7 +72,7 @@ describe('invite.service', () => {
   inviteTypes.forEach((inviteType) => {
     it(`should create an invite with type ${inviteType}`, async () => {
       const inviteType = 'friend'
-      const token = `${self.crypto.randomUUID()}@etherealengine.io`
+      const token = `${crypto.randomUUID()}@etherealengine.io`
       const identityProviderType = 'email'
 
       const createdInvite = await app.service(invitePath).create(

--- a/packages/server-core/src/social/location-admin/location-admin.resolvers.ts
+++ b/packages/server-core/src/social/location-admin/location-admin.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { LocationAdminQuery, LocationAdminType } from '@etherealengine/common/src/schemas/social/location-admin.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const locationAdminExternalResolver = resolve<LocationAdminType, HookCont
 
 export const locationAdminDataResolver = resolve<LocationAdminType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-admin/location-admin.resolvers.ts
+++ b/packages/server-core/src/social/location-admin/location-admin.resolvers.ts
@@ -40,7 +40,7 @@ export const locationAdminExternalResolver = resolve<LocationAdminType, HookCont
 
 export const locationAdminDataResolver = resolve<LocationAdminType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-authorized-user/location-authorized-user.resolvers.ts
+++ b/packages/server-core/src/social/location-authorized-user/location-authorized-user.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   LocationAuthorizedUserQuery,
@@ -44,7 +43,7 @@ export const locationAuthorizedUserExternalResolver = resolve<LocationAuthorized
 
 export const locationAuthorizedUserDataResolver = resolve<LocationAuthorizedUserType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-authorized-user/location-authorized-user.resolvers.ts
+++ b/packages/server-core/src/social/location-authorized-user/location-authorized-user.resolvers.ts
@@ -43,7 +43,7 @@ export const locationAuthorizedUserExternalResolver = resolve<LocationAuthorized
 
 export const locationAuthorizedUserDataResolver = resolve<LocationAuthorizedUserType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-ban/location-ban.resolvers.ts
+++ b/packages/server-core/src/social/location-ban/location-ban.resolvers.ts
@@ -40,7 +40,7 @@ export const locationBanExternalResolver = resolve<LocationBanType, HookContext>
 
 export const locationBanDataResolver = resolve<LocationBanType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-ban/location-ban.resolvers.ts
+++ b/packages/server-core/src/social/location-ban/location-ban.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { LocationBanQuery, LocationBanType } from '@etherealengine/common/src/schemas/social/location-ban.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,7 +40,7 @@ export const locationBanExternalResolver = resolve<LocationBanType, HookContext>
 
 export const locationBanDataResolver = resolve<LocationBanType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-setting/location-setting.resolvers.ts
+++ b/packages/server-core/src/social/location-setting/location-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   LocationSettingQuery,
@@ -44,7 +43,7 @@ export const locationSettingExternalResolver = resolve<LocationSettingType, Hook
 
 export const locationSettingDataResolver = resolve<LocationSettingType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location-setting/location-setting.resolvers.ts
+++ b/packages/server-core/src/social/location-setting/location-setting.resolvers.ts
@@ -43,7 +43,7 @@ export const locationSettingExternalResolver = resolve<LocationSettingType, Hook
 
 export const locationSettingDataResolver = resolve<LocationSettingType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/location/location.resolvers.ts
+++ b/packages/server-core/src/social/location/location.resolvers.ts
@@ -76,12 +76,12 @@ export const locationExternalResolver = resolve<LocationType, HookContext>({
 
 export const locationDataResolver = resolve<LocationType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as LocationID
+    return crypto.randomUUID() as LocationID
   },
   locationSetting: async (value, location) => {
     return {
       ...location.locationSetting,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       locationType: location.locationSetting.locationType || 'public',
       locationId: '' as LocationID,
       createdAt: await getDateTimeSql(),
@@ -91,7 +91,7 @@ export const locationDataResolver = resolve<LocationType, HookContext>({
   locationAdmin: async (value, location) => {
     return {
       ...location.locationAdmin,
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       locationId: '' as LocationID,
       userId: '' as UserID,
       createdAt: await getDateTimeSql(),

--- a/packages/server-core/src/social/location/location.resolvers.ts
+++ b/packages/server-core/src/social/location/location.resolvers.ts
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { locationSettingPath } from '@etherealengine/common/src/schemas/social/location-setting.schema'
 import { LocationID, LocationQuery, LocationType } from '@etherealengine/common/src/schemas/social/location.schema'
@@ -77,12 +76,12 @@ export const locationExternalResolver = resolve<LocationType, HookContext>({
 
 export const locationDataResolver = resolve<LocationType, HookContext>({
   id: async () => {
-    return uuidv4() as LocationID
+    return self.crypto.randomUUID() as LocationID
   },
   locationSetting: async (value, location) => {
     return {
       ...location.locationSetting,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       locationType: location.locationSetting.locationType || 'public',
       locationId: '' as LocationID,
       createdAt: await getDateTimeSql(),
@@ -92,7 +91,7 @@ export const locationDataResolver = resolve<LocationType, HookContext>({
   locationAdmin: async (value, location) => {
     return {
       ...location.locationAdmin,
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       locationId: '' as LocationID,
       userId: '' as UserID,
       createdAt: await getDateTimeSql(),

--- a/packages/server-core/src/social/location/location.test.ts
+++ b/packages/server-core/src/social/location/location.test.ts
@@ -50,10 +50,10 @@ describe('location.test', () => {
   })
 
   it('should create a new location', async () => {
-    const name = `Test Location ${self.crypto.randomUUID()}`
+    const name = `Test Location ${crypto.randomUUID()}`
 
     const scene = await app.service(assetPath).create({
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       name,
       assetURL: 'projects/default-project/test.scene.json',
       thumbnailURL: 'projects/default-project/test.thumbnail.jpg',
@@ -98,7 +98,7 @@ describe('location.test', () => {
   })
 
   it('should be able to update the location', async () => {
-    const newName = `Update Test Location ${self.crypto.randomUUID()}`
+    const newName = `Update Test Location ${crypto.randomUUID()}`
     const locationSetting = await app.service(locationSettingPath).create({
       locationType: 'public',
       audioEnabled: true,

--- a/packages/server-core/src/social/location/location.test.ts
+++ b/packages/server-core/src/social/location/location.test.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import assert from 'assert'
-import { v4 as uuidv4 } from 'uuid'
 
 import { locationSettingPath } from '@etherealengine/common/src/schemas/social/location-setting.schema'
 import { LocationID, LocationType, locationPath } from '@etherealengine/common/src/schemas/social/location.schema'
@@ -51,10 +50,10 @@ describe('location.test', () => {
   })
 
   it('should create a new location', async () => {
-    const name = `Test Location ${uuidv4()}`
+    const name = `Test Location ${self.crypto.randomUUID()}`
 
     const scene = await app.service(assetPath).create({
-      id: uuidv4(),
+      id: self.crypto.randomUUID(),
       name,
       assetURL: 'projects/default-project/test.scene.json',
       thumbnailURL: 'projects/default-project/test.thumbnail.jpg',
@@ -99,7 +98,7 @@ describe('location.test', () => {
   })
 
   it('should be able to update the location', async () => {
-    const newName = `Update Test Location ${uuidv4()}`
+    const newName = `Update Test Location ${self.crypto.randomUUID()}`
     const locationSetting = await app.service(locationSettingPath).create({
       locationType: 'public',
       audioEnabled: true,

--- a/packages/server-core/src/social/message/message.resolvers.ts
+++ b/packages/server-core/src/social/message/message.resolvers.ts
@@ -47,7 +47,7 @@ export const messageExternalResolver = resolve<MessageType, HookContext>({
 
 export const messageDataResolver = resolve<MessageType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as MessageID
+    return crypto.randomUUID() as MessageID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/social/message/message.resolvers.ts
+++ b/packages/server-core/src/social/message/message.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { MessageID, MessageQuery, MessageType } from '@etherealengine/common/src/schemas/social/message.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -48,7 +47,7 @@ export const messageExternalResolver = resolve<MessageType, HookContext>({
 
 export const messageDataResolver = resolve<MessageType, HookContext>({
   id: async () => {
-    return uuidv4() as MessageID
+    return self.crypto.randomUUID() as MessageID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/accept-invite/accept-invite.class.ts
+++ b/packages/server-core/src/user/accept-invite/accept-invite.class.ts
@@ -128,7 +128,7 @@ export class AcceptInviteService implements ServiceInterface<AcceptInviteParams>
             {
               type: invite.identityProviderType,
               token: invite.token,
-              userId: self.crypto.randomUUID() as UserID
+              userId: crypto.randomUUID() as UserID
             },
             params as any
           )

--- a/packages/server-core/src/user/accept-invite/accept-invite.class.ts
+++ b/packages/server-core/src/user/accept-invite/accept-invite.class.ts
@@ -41,7 +41,7 @@ import {
 import { userRelationshipPath } from '@etherealengine/common/src/schemas/user/user-relationship.schema'
 import { UserID, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { KnexAdapterParams } from '@feathersjs/knex'
-import { v4 as uuidv4 } from 'uuid'
+
 import { Application } from '../../../declarations'
 import logger from '../../ServerLogger'
 
@@ -128,7 +128,7 @@ export class AcceptInviteService implements ServiceInterface<AcceptInviteParams>
             {
               type: invite.identityProviderType,
               token: invite.token,
-              userId: uuidv4() as UserID
+              userId: self.crypto.randomUUID() as UserID
             },
             params as any
           )

--- a/packages/server-core/src/user/avatar/avatar.resolvers.ts
+++ b/packages/server-core/src/user/avatar/avatar.resolvers.ts
@@ -74,7 +74,7 @@ export const avatarExternalResolver = resolve<AvatarType, HookContext>({
 
 export const avatarDataResolver = resolve<AvatarDatabaseType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as AvatarID
+    return crypto.randomUUID() as AvatarID
   },
   isPublic: async (isPublic) => {
     return isPublic ?? true

--- a/packages/server-core/src/user/avatar/avatar.resolvers.ts
+++ b/packages/server-core/src/user/avatar/avatar.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { staticResourcePath } from '@etherealengine/common/src/schemas/media/static-resource.schema'
 import {
@@ -75,7 +74,7 @@ export const avatarExternalResolver = resolve<AvatarType, HookContext>({
 
 export const avatarDataResolver = resolve<AvatarDatabaseType, HookContext>({
   id: async () => {
-    return uuidv4() as AvatarID
+    return self.crypto.randomUUID() as AvatarID
   },
   isPublic: async (isPublic) => {
     return isPublic ?? true

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.resolvers.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.resolvers.ts
@@ -43,7 +43,7 @@ export const githubRepoAccessExternalResolver = resolve<GithubRepoAccessType, Ho
 
 export const githubRepoAccessDataResolver = resolve<GithubRepoAccessType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.resolvers.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   GithubRepoAccessQuery,
@@ -44,7 +43,7 @@ export const githubRepoAccessExternalResolver = resolve<GithubRepoAccessType, Ho
 
 export const githubRepoAccessDataResolver = resolve<GithubRepoAccessType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/identity-provider/identity-provider.resolvers.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   IdentityProviderQuery,
@@ -46,7 +45,7 @@ export const identityProviderExternalResolver = resolve<IdentityProviderType, Ho
 
 export const identityProviderDataResolver = resolve<IdentityProviderType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/identity-provider/identity-provider.resolvers.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.resolvers.ts
@@ -45,7 +45,7 @@ export const identityProviderExternalResolver = resolve<IdentityProviderType, Ho
 
 export const identityProviderDataResolver = resolve<IdentityProviderType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/identity-provider/identity-provider.test.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.test.ts
@@ -52,7 +52,7 @@ describe('identity-provider.service', () => {
 
   it('should create an identity provider for guest', async () => {
     const type = 'guest'
-    const token = self.crypto.randomUUID()
+    const token = crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,
@@ -72,7 +72,7 @@ describe('identity-provider.service', () => {
 
   it('should create an identity provider for email', async () => {
     const type = 'email'
-    const token = self.crypto.randomUUID()
+    const token = crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,
@@ -90,7 +90,7 @@ describe('identity-provider.service', () => {
 
   it('should create an identity provider for password', async () => {
     const type = 'password'
-    const token = self.crypto.randomUUID()
+    const token = crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,
@@ -146,7 +146,7 @@ describe('identity-provider.service', () => {
 
   it('should be able to remove the only identity provider as a guest', async () => {
     const type = 'guest'
-    const token = self.crypto.randomUUID()
+    const token = crypto.randomUUID()
 
     const foundIdentityProvider = await app.service(identityProviderPath).create(
       {
@@ -162,7 +162,7 @@ describe('identity-provider.service', () => {
 
   it('should not be able to remove the only identity provider as a user', async () => {
     const type = 'user'
-    const token = self.crypto.randomUUID()
+    const token = crypto.randomUUID()
 
     const foundIdentityProvider = await app.service(identityProviderPath).create(
       {

--- a/packages/server-core/src/user/identity-provider/identity-provider.test.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.test.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import assert from 'assert'
-import { v4 as uuidv4 } from 'uuid'
 
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
@@ -53,7 +52,7 @@ describe('identity-provider.service', () => {
 
   it('should create an identity provider for guest', async () => {
     const type = 'guest'
-    const token = uuidv4()
+    const token = self.crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,
@@ -73,7 +72,7 @@ describe('identity-provider.service', () => {
 
   it('should create an identity provider for email', async () => {
     const type = 'email'
-    const token = uuidv4()
+    const token = self.crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,
@@ -91,7 +90,7 @@ describe('identity-provider.service', () => {
 
   it('should create an identity provider for password', async () => {
     const type = 'password'
-    const token = uuidv4()
+    const token = self.crypto.randomUUID()
 
     const createdIdentityProvider = await app.service(identityProviderPath).create({
       type,
@@ -147,7 +146,7 @@ describe('identity-provider.service', () => {
 
   it('should be able to remove the only identity provider as a guest', async () => {
     const type = 'guest'
-    const token = uuidv4()
+    const token = self.crypto.randomUUID()
 
     const foundIdentityProvider = await app.service(identityProviderPath).create(
       {
@@ -163,7 +162,7 @@ describe('identity-provider.service', () => {
 
   it('should not be able to remove the only identity provider as a user', async () => {
     const type = 'user'
-    const token = uuidv4()
+    const token = self.crypto.randomUUID()
 
     const foundIdentityProvider = await app.service(identityProviderPath).create(
       {

--- a/packages/server-core/src/user/login-token/login-token.resolvers.ts
+++ b/packages/server-core/src/user/login-token/login-token.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { LoginTokenQuery, LoginTokenType } from '@etherealengine/common/src/schemas/user/login-token.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -45,7 +44,7 @@ export const loginTokenExternalResolver = resolve<LoginTokenType, HookContext>({
 
 export const loginTokenDataResolver = resolve<LoginTokenType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   token: async () => {
     return crypto.randomBytes(config.authentication.bearerToken.numBytes).toString('hex')

--- a/packages/server-core/src/user/login-token/login-token.resolvers.ts
+++ b/packages/server-core/src/user/login-token/login-token.resolvers.ts
@@ -44,7 +44,7 @@ export const loginTokenExternalResolver = resolve<LoginTokenType, HookContext>({
 
 export const loginTokenDataResolver = resolve<LoginTokenType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   token: async () => {
     return crypto.randomBytes(config.authentication.bearerToken.numBytes).toString('hex')

--- a/packages/server-core/src/user/user-api-key/user-api-key.resolvers.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { UserApiKeyQuery, UserApiKeyType } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -41,10 +40,10 @@ export const userApiKeyExternalResolver = resolve<UserApiKeyType, HookContext>({
 
 export const userApiKeyDataResolver = resolve<UserApiKeyType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   token: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql
@@ -52,10 +51,10 @@ export const userApiKeyDataResolver = resolve<UserApiKeyType, HookContext>({
 
 export const userApiKeyPatchResolver = resolve<UserApiKeyType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   token: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-api-key/user-api-key.resolvers.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.resolvers.ts
@@ -40,10 +40,10 @@ export const userApiKeyExternalResolver = resolve<UserApiKeyType, HookContext>({
 
 export const userApiKeyDataResolver = resolve<UserApiKeyType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   token: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql
@@ -51,10 +51,10 @@ export const userApiKeyDataResolver = resolve<UserApiKeyType, HookContext>({
 
 export const userApiKeyPatchResolver = resolve<UserApiKeyType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   token: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-avatar/user-avatar.resolvers.ts
+++ b/packages/server-core/src/user/user-avatar/user-avatar.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { UserAvatarQuery, UserAvatarType } from '@etherealengine/common/src/schemas/user/user-avatar.schema'
 import { fromDateTimeSql, getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
@@ -40,7 +39,7 @@ export const userAvatarExternalResolver = resolve<UserAvatarType, HookContext>({
 
 export const userAvatarDataResolver = resolve<UserAvatarType, HookContext>({
   id: async () => {
-    return uuidv4()
+    return self.crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-avatar/user-avatar.resolvers.ts
+++ b/packages/server-core/src/user/user-avatar/user-avatar.resolvers.ts
@@ -39,7 +39,7 @@ export const userAvatarExternalResolver = resolve<UserAvatarType, HookContext>({
 
 export const userAvatarDataResolver = resolve<UserAvatarType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID()
+    return crypto.randomUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-kick/user-kick.resolvers.ts
+++ b/packages/server-core/src/user/user-kick/user-kick.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import { UserKickID, UserKickQuery, UserKickType } from '@etherealengine/common/src/schemas/user/user-kick.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
@@ -42,7 +41,7 @@ export const userKickExternalResolver = resolve<UserKickType, HookContext>({})
 
 export const userKickDataResolver = resolve<UserKickType, HookContext>({
   id: async () => {
-    return uuidv4() as UserKickID
+    return self.crypto.randomUUID() as UserKickID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-kick/user-kick.resolvers.ts
+++ b/packages/server-core/src/user/user-kick/user-kick.resolvers.ts
@@ -41,7 +41,7 @@ export const userKickExternalResolver = resolve<UserKickType, HookContext>({})
 
 export const userKickDataResolver = resolve<UserKickType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as UserKickID
+    return crypto.randomUUID() as UserKickID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   UserRelationshipID,
@@ -53,7 +52,7 @@ export const userRelationshipExternalResolver = resolve<UserRelationshipType, Ho
 
 export const userRelationshipDataResolver = resolve<UserRelationshipType, HookContext>({
   id: async () => {
-    return uuidv4() as UserRelationshipID
+    return self.crypto.randomUUID() as UserRelationshipID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
@@ -52,7 +52,7 @@ export const userRelationshipExternalResolver = resolve<UserRelationshipType, Ho
 
 export const userRelationshipDataResolver = resolve<UserRelationshipType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as UserRelationshipID
+    return crypto.randomUUID() as UserRelationshipID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-setting/user-setting.resolvers.ts
+++ b/packages/server-core/src/user/user-setting/user-setting.resolvers.ts
@@ -75,7 +75,7 @@ export const userSettingExternalResolver = resolve<UserSettingType, HookContext>
 export const userSettingDataResolver = resolve<UserSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return self.crypto.randomUUID() as UserSettingID
+      return crypto.randomUUID() as UserSettingID
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user-setting/user-setting.resolvers.ts
+++ b/packages/server-core/src/user/user-setting/user-setting.resolvers.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   UserSettingDatabaseType,
@@ -76,7 +75,7 @@ export const userSettingExternalResolver = resolve<UserSettingType, HookContext>
 export const userSettingDataResolver = resolve<UserSettingDatabaseType, HookContext>(
   {
     id: async () => {
-      return uuidv4() as UserSettingID
+      return self.crypto.randomUUID() as UserSettingID
     },
     createdAt: getDateTimeSql,
     updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/user/migrations/20231115081100_migrate-avatar-id.ts
+++ b/packages/server-core/src/user/user/migrations/20231115081100_migrate-avatar-id.ts
@@ -48,7 +48,7 @@ export async function up(knex: Knex): Promise<void> {
           .map(
             async (user) =>
               ({
-                id: self.crypto.randomUUID(),
+                id: crypto.randomUUID(),
                 userId: user.id,
                 avatarId: user.avatarId,
                 createdAt: await getDateTimeSql(),

--- a/packages/server-core/src/user/user/migrations/20231115081100_migrate-avatar-id.ts
+++ b/packages/server-core/src/user/user/migrations/20231115081100_migrate-avatar-id.ts
@@ -27,7 +27,6 @@ import { UserAvatarType, userAvatarPath } from '@etherealengine/common/src/schem
 import { userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import type { Knex } from 'knex'
-import { v4 as uuidv4 } from 'uuid'
 
 /**
  * @param { import("knex").Knex } knex
@@ -49,7 +48,7 @@ export async function up(knex: Knex): Promise<void> {
           .map(
             async (user) =>
               ({
-                id: uuidv4(),
+                id: self.crypto.randomUUID(),
                 userId: user.id,
                 avatarId: user.avatarId,
                 createdAt: await getDateTimeSql(),

--- a/packages/server-core/src/user/user/user.resolvers.ts
+++ b/packages/server-core/src/user/user/user.resolvers.ts
@@ -166,7 +166,7 @@ export const userExternalResolver = resolve<UserType, HookContext>({
 
 export const userDataResolver = resolve<UserType, HookContext>({
   id: async (id) => {
-    return id || (self.crypto.randomUUID() as UserID)
+    return id || (crypto.randomUUID() as UserID)
   },
   name: async (name) => {
     return name || (('Guest #' + Math.floor(Math.random() * (999 - 100 + 1) + 100)) as UserName)

--- a/packages/server-core/src/user/user/user.resolvers.ts
+++ b/packages/server-core/src/user/user/user.resolvers.ts
@@ -27,7 +27,6 @@ Ethereal Engine. All Rights Reserved.
 import { InviteCode, UserID, UserName, UserQuery, UserType } from '@etherealengine/common/src/schemas/user/user.schema'
 import type { HookContext } from '@etherealengine/server-core/declarations'
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   InstanceAttendanceType,
@@ -167,7 +166,7 @@ export const userExternalResolver = resolve<UserType, HookContext>({
 
 export const userDataResolver = resolve<UserType, HookContext>({
   id: async (id) => {
-    return id || (uuidv4() as UserID)
+    return id || (self.crypto.randomUUID() as UserID)
   },
   name: async (name) => {
     return name || (('Guest #' + Math.floor(Math.random() * (999 - 100 + 1) + 100)) as UserName)

--- a/packages/server-core/src/user/user/user.test.ts
+++ b/packages/server-core/src/user/user/user.test.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import assert from 'assert'
-import { v4 as uuidv4 } from 'uuid'
 
 import { AvatarType, avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
@@ -114,7 +113,7 @@ describe('user.test', () => {
 
   it('should patch users', async () => {
     for (const user of users) {
-      const newName = uuidv4() as UserName
+      const newName = self.crypto.randomUUID() as UserName
       await app.service(userPath).patch(
         user.id,
         {
@@ -130,7 +129,7 @@ describe('user.test', () => {
   })
 
   it('should patch a user with a query without affecting users not part of that query', async () => {
-    const newName = uuidv4() as UserName
+    const newName = self.crypto.randomUUID() as UserName
     const user1 = users[0]
     const user2 = users[1]
     await app.service(userPath).patch(user1.id, {

--- a/packages/server-core/src/user/user/user.test.ts
+++ b/packages/server-core/src/user/user/user.test.ts
@@ -113,7 +113,7 @@ describe('user.test', () => {
 
   it('should patch users', async () => {
     for (const user of users) {
-      const newName = self.crypto.randomUUID() as UserName
+      const newName = crypto.randomUUID() as UserName
       await app.service(userPath).patch(
         user.id,
         {
@@ -129,7 +129,7 @@ describe('user.test', () => {
   })
 
   it('should patch a user with a query without affecting users not part of that query', async () => {
-    const newName = self.crypto.randomUUID() as UserName
+    const newName = crypto.randomUUID() as UserName
     const user1 = users[0]
     const user2 = users[1]
     await app.service(userPath).patch(user1.id, {

--- a/packages/server-core/src/world/spawn-point/spawn-point.resolvers.ts
+++ b/packages/server-core/src/world/spawn-point/spawn-point.resolvers.ts
@@ -31,7 +31,7 @@ import type { HookContext } from '@etherealengine/server-core/declarations'
 
 import { SpawnPointQuery, SpawnPointType } from '@etherealengine/common/src/schema.type.module'
 import { fromDateTimeSql, getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
-import { EntityUUID } from '@etherealengine/ecs'
+import { UUIDComponent } from '@etherealengine/ecs'
 
 export const spawnPointResolver = resolve<SpawnPointType, HookContext>({
   createdAt: virtual(async (spawnPoint) => fromDateTimeSql(spawnPoint.createdAt)),
@@ -42,7 +42,7 @@ export const spawnPointExternalResolver = resolve<SpawnPointType, HookContext>({
 
 export const spawnPointDataResolver = resolve<SpawnPointType, HookContext>({
   id: async () => {
-    return crypto.randomUUID() as EntityUUID
+    return UUIDComponent.generateUUID()
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/world/spawn-point/spawn-point.resolvers.ts
+++ b/packages/server-core/src/world/spawn-point/spawn-point.resolvers.ts
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 
 import { resolve, virtual } from '@feathersjs/schema'
-import { v4 } from 'uuid'
 
 import type { HookContext } from '@etherealengine/server-core/declarations'
 
@@ -43,7 +42,7 @@ export const spawnPointExternalResolver = resolve<SpawnPointType, HookContext>({
 
 export const spawnPointDataResolver = resolve<SpawnPointType, HookContext>({
   id: async () => {
-    return v4() as EntityUUID
+    return self.crypto.randomUUID() as EntityUUID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/world/spawn-point/spawn-point.resolvers.ts
+++ b/packages/server-core/src/world/spawn-point/spawn-point.resolvers.ts
@@ -42,7 +42,7 @@ export const spawnPointExternalResolver = resolve<SpawnPointType, HookContext>({
 
 export const spawnPointDataResolver = resolve<SpawnPointType, HookContext>({
   id: async () => {
-    return self.crypto.randomUUID() as EntityUUID
+    return crypto.randomUUID() as EntityUUID
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/tests/storageprovider/storageprovider.test.ts
+++ b/packages/server-core/tests/storageprovider/storageprovider.test.ts
@@ -39,7 +39,7 @@ import { providerAfterTest, providerBeforeTest } from './storageproviderconfig'
 
 describe('storageprovider', () => {
   const testFileName = 'TestFile.txt'
-  const testFolderName = `TestFolder-${self.crypto.randomUUID()}`
+  const testFolderName = `TestFolder-${crypto.randomUUID()}`
   const testFileContent = 'content'
   const folderKeyTemp = path.join(testFolderName, 'temp')
   const folderKeyTemp2 = path.join(testFolderName, 'temp2')

--- a/packages/server-core/tests/storageprovider/storageprovider.test.ts
+++ b/packages/server-core/tests/storageprovider/storageprovider.test.ts
@@ -31,7 +31,7 @@ import fs from 'fs-extra'
 import https from 'https'
 import fetch from 'node-fetch'
 import path from 'path/posix'
-import { v4 as uuidv4 } from 'uuid'
+
 import LocalStorage from '../../src/media/storageprovider/local.storage'
 import S3Provider from '../../src/media/storageprovider/s3.storage'
 import { getContentType } from '../../src/util/fileUtils'
@@ -39,7 +39,7 @@ import { providerAfterTest, providerBeforeTest } from './storageproviderconfig'
 
 describe('storageprovider', () => {
   const testFileName = 'TestFile.txt'
-  const testFolderName = `TestFolder-${uuidv4()}`
+  const testFolderName = `TestFolder-${self.crypto.randomUUID()}`
   const testFileContent = 'content'
   const folderKeyTemp = path.join(testFolderName, 'temp')
   const folderKeyTemp2 = path.join(testFolderName, 'temp2')

--- a/packages/server-core/tests/util/createTestLocation.ts
+++ b/packages/server-core/tests/util/createTestLocation.ts
@@ -25,13 +25,12 @@ Ethereal Engine. All Rights Reserved.
 
 import { LocationID, assetPath, locationPath } from '@etherealengine/common/src/schema.type.module'
 import { Application } from '@feathersjs/feathers'
-import { v4 as uuidv4 } from 'uuid'
 
 export const createTestLocation = async (app: Application, params = { isInternal: true } as any) => {
-  const name = `Test Location ${uuidv4()}`
+  const name = `Test Location ${self.crypto.randomUUID()}`
 
   const scene = await app.service(assetPath).create({
-    id: uuidv4(),
+    id: self.crypto.randomUUID(),
     assetURL: 'projects/default-project/test.scene.json',
     thumbnailURL: 'projects/default-project/test.thumbnail.jpg',
     project: 'default-project'

--- a/packages/server-core/tests/util/createTestLocation.ts
+++ b/packages/server-core/tests/util/createTestLocation.ts
@@ -27,10 +27,10 @@ import { LocationID, assetPath, locationPath } from '@etherealengine/common/src/
 import { Application } from '@feathersjs/feathers'
 
 export const createTestLocation = async (app: Application, params = { isInternal: true } as any) => {
-  const name = `Test Location ${self.crypto.randomUUID()}`
+  const name = `Test Location ${crypto.randomUUID()}`
 
   const scene = await app.service(assetPath).create({
-    id: self.crypto.randomUUID(),
+    id: crypto.randomUUID(),
     assetURL: 'projects/default-project/test.scene.json',
     thumbnailURL: 'projects/default-project/test.thumbnail.jpg',
     project: 'default-project'

--- a/packages/server/scripts/upload-avatar.ts
+++ b/packages/server/scripts/upload-avatar.ts
@@ -117,7 +117,7 @@ const uploadFile = (Key, Body) => {
 
 const saveToDB = async (name, extension) => {
   await knexClient.from(staticResourcePath).insert({
-    id: self.crypto.randomUUID(),
+    id: crypto.randomUUID(),
     sid: nanoid(8),
     name,
     url: 'https://s3.amazonaws.com/' + BUCKET + '/' + AVATAR_FOLDER + '/' + name + extension,

--- a/packages/server/scripts/upload-avatar.ts
+++ b/packages/server/scripts/upload-avatar.ts
@@ -117,7 +117,7 @@ const uploadFile = (Key, Body) => {
 
 const saveToDB = async (name, extension) => {
   await knexClient.from(staticResourcePath).insert({
-    id: uuidv4(),
+    id: self.crypto.randomUUID(),
     sid: nanoid(8),
     name,
     url: 'https://s3.amazonaws.com/' + BUCKET + '/' + AVATAR_FOLDER + '/' + name + extension,

--- a/scripts/make-user-admin.ts
+++ b/scripts/make-user-admin.ts
@@ -83,7 +83,7 @@ cli.main(async () => {
             .first()
           if (existingScope == null) {
             await knexClient.from<ScopeTypeInterface>(scopePath).insert({
-              id: self.crypto.randomUUID() as ScopeID,
+              id: crypto.randomUUID() as ScopeID,
               userId: options.id,
               type,
               createdAt: new Date().toISOString().slice(0, 19).replace('T', ' '),

--- a/scripts/make-user-admin.ts
+++ b/scripts/make-user-admin.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import appRootPath from 'app-root-path'
 import knex from 'knex'
-import { v4 as uuidv4 } from 'uuid'
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
   ScopeID,
@@ -83,7 +83,7 @@ cli.main(async () => {
             .first()
           if (existingScope == null) {
             await knexClient.from<ScopeTypeInterface>(scopePath).insert({
-              id: uuidv4() as ScopeID,
+              id: self.crypto.randomUUID() as ScopeID,
               userId: options.id,
               type,
               createdAt: new Date().toISOString().slice(0, 19).replace('T', ' '),


### PR DESCRIPTION
## Summary

## Subtasks Checklist
- [x] Replace `v4` with `uuidv4`
- [x] Replace `uuidv4()` with `self.crypto.randomUUID()`
- [x] Remove all `from 'uuid'` imports
- [x] Remove `self.` prefix from `self.crypto`
- [x] Change `generateEntityUUID()` to use `crypto.randomUUID()`
- [x] `UUIDComponent.generateUUID()` return the type `EntityUUID`
- [x] Everywhere else use `crypto.randomUUID()` directly 
- [x] Add `generateEntityUUID()` to `UUIDComponent` as `UUIDComponent.generateUUID()`
- [x] Refactor every `generateEntityUUID()` call to use `UUIDComponent.generateUUID()`
- [x] Remove `generateEntityUUID()`
- [x] Remove leftover calls to `MathUtils.generateUUID()` _(two of them)_
- [x] Find `as EntityUUID` and replace with `UUIDComponent.generateUUID()`
- [ ] Fix `crypto is not defined` crash on `npm run test`
- [ ] Remove the `'uuid'` library/package from the list of installed packages

## Breaking Changes

## References
closes #_insert number here_

## QA Steps