### PR TITLE
IR-1780 Interactables serializing and mounting cleanup

### DIFF
--- a/packages/editor/src/components/properties/GrabbableComponentNodeEditor.tsx
+++ b/packages/editor/src/components/properties/GrabbableComponentNodeEditor.tsx
@@ -23,17 +23,35 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { useComponent } from '@etherealengine/ecs'
+import { isClient } from '@etherealengine/common/src/utils/getEnvironment'
+import { getComponent, hasComponent, UUIDComponent } from '@etherealengine/ecs'
 import NodeEditor from '@etherealengine/editor/src/components/properties/NodeEditor'
 import { EditorComponentType } from '@etherealengine/editor/src/components/properties/Util'
 import { GrabbableComponent } from '@etherealengine/engine/src/interaction/components/GrabbableComponent'
-import React from 'react'
+import { InteractableComponent } from '@etherealengine/engine/src/interaction/components/InteractableComponent'
+import { grabbableInteractMessage } from '@etherealengine/engine/src/interaction/functions/grabbableFunctions'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 
 export const GrabbableComponentNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
 
-  const grabbableComponent = useComponent(props.entity, GrabbableComponent)
+  useEffect(() => {
+    if (isClient) {
+      if (!hasComponent(props.entity, InteractableComponent)) {
+        EditorControlFunctions.addOrRemoveComponent([props.entity], InteractableComponent, true, {
+          label: grabbableInteractMessage,
+          callbacks: [
+            {
+              callbackID: GrabbableComponent.grabbableCallbackName,
+              target: getComponent(props.entity, UUIDComponent)
+            }
+          ]
+        })
+      }
+    }
+  }, [])
 
   return (
     <NodeEditor

--- a/packages/editor/src/components/properties/LinkNodeEditor.tsx
+++ b/packages/editor/src/components/properties/LinkNodeEditor.tsx
@@ -23,15 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import { getComponent, hasComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 
 import LinkIcon from '@mui/icons-material/Link'
 
+import { UUIDComponent } from '@etherealengine/ecs'
+import {
+  InteractableComponent,
+  XRUIActivationType
+} from '@etherealengine/engine/src/interaction/components/InteractableComponent'
 import { getEntityErrors } from '@etherealengine/engine/src/scene/components/ErrorComponent'
 import { LinkComponent } from '@etherealengine/engine/src/scene/components/LinkComponent'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import BooleanInput from '../inputs/BooleanInput'
 import InputGroup from '../inputs/InputGroup'
 import { ControlledStringInput } from '../inputs/StringInput'
@@ -48,6 +54,23 @@ export const LinkNodeEditor: EditorComponentType = (props) => {
 
   const linkComponent = useComponent(props.entity, LinkComponent)
   const errors = getEntityErrors(props.entity, LinkComponent)
+
+  useEffect(() => {
+    if (!hasComponent(props.entity, InteractableComponent)) {
+      EditorControlFunctions.addOrRemoveComponent([props.entity], InteractableComponent, true, {
+        label: LinkComponent.interactMessage,
+        uiInteractable: false,
+        clickInteract: true,
+        uiActivationType: XRUIActivationType.hover,
+        callbacks: [
+          {
+            callbackID: LinkComponent.linkCallbackName,
+            target: getComponent(props.entity, UUIDComponent)
+          }
+        ]
+      })
+    }
+  }, [])
 
   return (
     <NodeEditor

--- a/packages/editor/src/components/properties/MountPointNodeEditor.tsx
+++ b/packages/editor/src/components/properties/MountPointNodeEditor.tsx
@@ -23,13 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { getMutableComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import {
+  getComponent,
+  getMutableComponent,
+  hasComponent,
+  useComponent
+} from '@etherealengine/ecs/src/ComponentFunctions'
 import { MountPoint, MountPointComponent } from '@etherealengine/engine/src/scene/components/MountPointComponent'
 
+import { UUIDComponent } from '@etherealengine/ecs'
+import { InteractableComponent } from '@etherealengine/engine/src/interaction/components/InteractableComponent'
 import { Vector3 } from 'three'
+import { EditorControlFunctions } from '../../functions/EditorControlFunctions'
 import InputGroup from '../inputs/InputGroup'
 import SelectInput from '../inputs/SelectInput'
 import Vector3Input from '../inputs/Vector3Input'
@@ -46,6 +54,20 @@ export const MountPointNodeEditor: React.FC<EditorPropType> = (props) => {
   const onChangeOffset = (value: Vector3) => {
     getMutableComponent(props.entity, MountPointComponent).dismountOffset.set(value)
   }
+  useEffect(() => {
+    if (!hasComponent(props.entity, InteractableComponent)) {
+      const mountPoint = getComponent(props.entity, MountPointComponent)
+      EditorControlFunctions.addOrRemoveComponent([props.entity], InteractableComponent, true, {
+        label: MountPointComponent.mountPointInteractMessages[mountPoint.type],
+        callbacks: [
+          {
+            callbackID: MountPointComponent.mountCallbackName,
+            target: getComponent(props.entity, UUIDComponent)
+          }
+        ]
+      })
+    }
+  }, [])
 
   return (
     <NodeEditor

--- a/packages/editor/src/components/properties/TriggerComponentEditor.tsx
+++ b/packages/editor/src/components/properties/TriggerComponentEditor.tsx
@@ -26,7 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { UUIDComponent } from '@etherealengine/ecs'
+import { getOptionalComponent, UUIDComponent } from '@etherealengine/ecs'
 import { getComponent, hasComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { defineQuery } from '@etherealengine/ecs/src/QueryFunctions'
 import { useState } from '@etherealengine/hyperflux'
@@ -42,7 +42,7 @@ import InputGroup from '../inputs/InputGroup'
 import SelectInput from '../inputs/SelectInput'
 import StringInput from '../inputs/StringInput'
 import NodeEditor from './NodeEditor'
-import { EditorComponentType, commitProperties, commitProperty, updateProperty } from './Util'
+import { commitProperties, commitProperty, EditorComponentType, updateProperty } from './Util'
 
 type OptionsType = Array<{
   callbacks: Array<{
@@ -63,11 +63,24 @@ export const TriggerComponentEditor: EditorComponentType = (props) => {
 
   useEffect(() => {
     const options = [] as OptionsType
-    options.push({
-      label: 'Self',
-      value: 'Self',
-      callbacks: []
-    })
+
+    const entityCallbacks = getOptionalComponent(props.entity, CallbackComponent)
+    if (entityCallbacks) {
+      options.push({
+        label: 'Self',
+        value: getComponent(props.entity, UUIDComponent),
+        callbacks: Object.keys(entityCallbacks).map((cb) => {
+          return { label: cb, value: cb }
+        })
+      })
+    } else {
+      options.push({
+        label: 'Self',
+        value: 'Self',
+        callbacks: []
+      })
+    }
+
     for (const entity of callbackQuery()) {
       if (entity === props.entity || !hasComponent(entity, EntityTreeComponent)) continue
       const callbacks = getComponent(entity, CallbackComponent)

--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -24,7 +24,14 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { getNestedObject } from '@etherealengine/common/src/utils/getNestedProperty'
-import { EntityUUID, UUIDComponent, createEntity, generateEntityUUID, removeEntity } from '@etherealengine/ecs'
+import {
+  EntityUUID,
+  SetComponentType,
+  UUIDComponent,
+  createEntity,
+  generateEntityUUID,
+  removeEntity
+} from '@etherealengine/ecs'
 import {
   Component,
   ComponentJSONIDMap,
@@ -85,7 +92,12 @@ const getParentNodeByUUID = (gltf: GLTF.IGLTF, uuid: string) => {
   return gltf.nodes?.find((n) => n.children?.includes(nodeIndex))
 }
 
-const addOrRemoveComponent = <C extends Component<any, any>>(entities: Entity[], component: C, add: boolean) => {
+const addOrRemoveComponent = <C extends Component<any, any>>(
+  entities: Entity[],
+  component: C,
+  add: boolean,
+  args: SetComponentType<C> | undefined = undefined
+) => {
   const sceneComponentID = component.jsonID
   if (!sceneComponentID) return
 
@@ -99,7 +111,10 @@ const addOrRemoveComponent = <C extends Component<any, any>>(entities: Entity[],
         const node = getGLTFNodeByUUID(gltf.data, entityUUID)
         if (!node) continue
         if (add) {
-          node.extensions![sceneComponentID] = componentJsonDefaults(ComponentJSONIDMap.get(sceneComponentID)!)
+          node.extensions![sceneComponentID] = {
+            ...componentJsonDefaults(ComponentJSONIDMap.get(sceneComponentID)!),
+            ...args
+          }
         } else {
           delete node.extensions?.[sceneComponentID]
         }
@@ -116,7 +131,7 @@ const addOrRemoveComponent = <C extends Component<any, any>>(entities: Entity[],
           componentData = componentData.filter((c) => c.name !== sceneComponentID)
           componentData.push({
             name: sceneComponentID,
-            props: componentJsonDefaults(ComponentJSONIDMap.get(sceneComponentID)!)
+            props: { ...componentJsonDefaults(ComponentJSONIDMap.get(sceneComponentID)!), ...args }
           })
         } else {
           const index = componentData.findIndex((c) => c.name === sceneComponentID)

--- a/packages/engine/src/interaction/components/GrabbableComponent.ts
+++ b/packages/engine/src/interaction/components/GrabbableComponent.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import { isClient } from '@etherealengine/common/src/utils/getEnvironment'
 import { getComponent, hasComponent, useEntityContext } from '@etherealengine/ecs'
-import { defineComponent, setComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import { defineComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity } from '@etherealengine/ecs/src/Entity'
 import { getState } from '@etherealengine/hyperflux'
 import { setCallback } from '@etherealengine/spatial/src/common/CallbackComponent'
@@ -33,8 +33,10 @@ import { InputSourceComponent } from '@etherealengine/spatial/src/input/componen
 import { InputState } from '@etherealengine/spatial/src/input/state/InputState'
 import { useEffect } from 'react'
 import { AvatarComponent } from '../../avatar/components/AvatarComponent'
-import { dropEntity, grabEntity, grabbableInteractMessage } from '../functions/grabbableFunctions'
+import { dropEntity, grabEntity } from '../functions/grabbableFunctions'
 import { InteractableComponent, XRUIVisibilityOverride } from './InteractableComponent'
+
+const grabbableCallbackName = 'grabCallback'
 
 /**
  * GrabbableComponent
@@ -46,20 +48,13 @@ export const GrabbableComponent = defineComponent({
 
   toJSON: () => true,
 
+  grabbableCallbackName,
+
   reactor: function () {
     const entity = useEntityContext()
     useEffect(() => {
       if (isClient) {
-        setCallback(entity, 'grabCallback', () => grabCallback(entity))
-        setComponent(entity, InteractableComponent, {
-          label: grabbableInteractMessage,
-          callbacks: [
-            {
-              callbackID: 'grabCallback',
-              target: null
-            }
-          ]
-        })
+        setCallback(entity, grabbableCallbackName, () => grabCallback(entity))
       }
     }, [])
     return null

--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -101,6 +101,8 @@ export const InteractableComponent = defineComponent({
       component.uiActivationType.set(json.uiActivationType)
     if (typeof json.clickInteract === 'boolean' && component.clickInteract.value !== json.clickInteract)
       component.clickInteract.set(json.clickInteract)
+    if (typeof json.uiInteractable === 'boolean' && component.uiInteractable.value !== json.uiInteractable)
+      component.uiInteractable.set(json.uiInteractable)
     if (json.activationDistance) component.activationDistance.set(json.activationDistance)
     if (
       matches
@@ -133,6 +135,7 @@ export const InteractableComponent = defineComponent({
       clickInteract: component.clickInteract.value,
       activationDistance: component.activationDistance.value,
       uiActivationType: component.uiActivationType.value,
+      uiInteractable: component.uiInteractable.value,
       callbacks: component.callbacks.get(NO_PROXY)
     }
   },

--- a/packages/engine/src/scene/components/LinkComponent.ts
+++ b/packages/engine/src/scene/components/LinkComponent.ts
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { isClient } from '@etherealengine/common/src/utils/getEnvironment'
-import { defineComponent, getComponent, setComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import { defineComponent, getComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity } from '@etherealengine/ecs/src/Entity'
 import { useEntityContext } from '@etherealengine/ecs/src/EntityFunctions'
 import { defineState, getMutableState, getState, matches } from '@etherealengine/hyperflux'
@@ -34,7 +34,6 @@ import { XRStandardGamepadButton } from '@etherealengine/spatial/src/input/state
 import { XRState } from '@etherealengine/spatial/src/xr/XRState'
 import { useEffect } from 'react'
 import { Vector3 } from 'three'
-import { InteractableComponent, XRUIActivationType } from '../../interaction/components/InteractableComponent'
 import { addError, clearErrors } from '../functions/ErrorFunctions'
 
 const linkLogic = (linkComponent, xrState) => {
@@ -60,6 +59,7 @@ const linkCallback = (linkEntity: Entity) => {
 
 const vec3 = new Vector3()
 const interactMessage = 'Click to follow'
+const linkCallbackName = 'linkCallback'
 
 export const LinkState = defineState({
   name: 'LinkState',
@@ -79,6 +79,8 @@ export const LinkComponent = defineComponent({
       location: ''
     }
   },
+  linkCallbackName,
+  linkCallback,
 
   onSet: (entity, component, json) => {
     if (!json) return
@@ -86,6 +88,8 @@ export const LinkComponent = defineComponent({
     matches.boolean.test(json.sceneNav) && component.sceneNav.set(json.sceneNav as boolean)
     matches.string.test(json.location) && component.location.set(json.location as string)
   },
+
+  interactMessage,
 
   toJSON: (entity, component) => {
     return {
@@ -114,19 +118,7 @@ export const LinkComponent = defineComponent({
     }, [link.url, link.sceneNav])
 
     useEffect(() => {
-      setCallback(entity, 'linkCallback', () => linkCallback(entity))
-      setComponent(entity, InteractableComponent, {
-        label: interactMessage,
-        uiInteractable: false,
-        clickInteract: true,
-        uiActivationType: XRUIActivationType.hover,
-        callbacks: [
-          {
-            callbackID: 'linkCallback',
-            target: null
-          }
-        ]
-      })
+      setCallback(entity, linkCallbackName, () => LinkComponent.linkCallback(entity))
     }, [])
 
     return null

--- a/packages/engine/src/scene/components/MountPointComponent.ts
+++ b/packages/engine/src/scene/components/MountPointComponent.ts
@@ -24,21 +24,42 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { useEffect } from 'react'
-import { ArrowHelper, Vector3 } from 'three'
+import { ArrowHelper, Box3, Vector3 } from 'three'
 
-import { getMutableState, matches, none, useHookstate } from '@etherealengine/hyperflux'
+import { dispatchAction, getMutableState, getState, matches, none, useHookstate } from '@etherealengine/hyperflux'
 
-import { defineComponent, hasComponent, setComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import { UUIDComponent } from '@etherealengine/ecs'
+import {
+  defineComponent,
+  getComponent,
+  getOptionalComponent,
+  hasComponent,
+  removeComponent,
+  setComponent,
+  useComponent
+} from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity } from '@etherealengine/ecs/src/Entity'
 import { createEntity, removeEntity, useEntityContext } from '@etherealengine/ecs/src/EntityFunctions'
+import { TransformComponent } from '@etherealengine/spatial'
+import { setCallback } from '@etherealengine/spatial/src/common/CallbackComponent'
 import { NameComponent } from '@etherealengine/spatial/src/common/NameComponent'
 import { matchesVector3 } from '@etherealengine/spatial/src/common/functions/MatchesUtils'
+import { RigidBodyComponent } from '@etherealengine/spatial/src/physics/components/RigidBodyComponent'
 import { RendererState } from '@etherealengine/spatial/src/renderer/RendererState'
 import { addObjectToGroup } from '@etherealengine/spatial/src/renderer/components/GroupComponent'
 import { setObjectLayers } from '@etherealengine/spatial/src/renderer/components/ObjectLayerComponent'
 import { setVisibleComponent } from '@etherealengine/spatial/src/renderer/components/VisibleComponent'
 import { ObjectLayers } from '@etherealengine/spatial/src/renderer/constants/ObjectLayers'
+import { BoundingBoxComponent } from '@etherealengine/spatial/src/transform/components/BoundingBoxComponents'
 import { EntityTreeComponent } from '@etherealengine/spatial/src/transform/components/EntityTree'
+import { emoteAnimations, preloadedAnimations } from '../../avatar/animation/Util'
+import { AvatarComponent } from '../../avatar/components/AvatarComponent'
+import { AvatarControllerComponent } from '../../avatar/components/AvatarControllerComponent'
+import { teleportAvatar } from '../../avatar/functions/moveAvatar'
+import { AvatarNetworkAction } from '../../avatar/state/AvatarNetworkActions'
+import { InteractableComponent, XRUIVisibilityOverride } from '../../interaction/components/InteractableComponent'
+import { MountPointActions, MountPointState } from '../../interaction/functions/MountPointActions'
+import { SittingComponent } from './SittingComponent'
 import { SpawnPointComponent } from './SpawnPointComponent'
 
 export const MountPoint = {
@@ -46,6 +67,82 @@ export const MountPoint = {
 }
 
 export type MountPointTypes = (typeof MountPoint)[keyof typeof MountPoint]
+
+/**
+ * @todo refactor this into i18n and configurable
+ */
+const mountPointInteractMessages = {
+  [MountPoint.seat]: 'Press E to Sit'
+}
+
+const mountCallbackName = 'mountEntity'
+
+const mountEntity = (avatarEntity: Entity, mountEntity: Entity) => {
+  const mountedEntities = getState(MountPointState)
+  if (mountedEntities[getComponent(mountEntity, UUIDComponent)]) return //already sitting, exiting
+
+  const avatarUUID = getComponent(avatarEntity, UUIDComponent)
+  const mountPoint = getOptionalComponent(mountEntity, MountPointComponent)
+  if (!mountPoint || mountPoint.type !== MountPoint.seat) return
+  const mountPointUUID = getComponent(mountEntity, UUIDComponent)
+
+  //check if we're already sitting or if the seat is occupied
+  if (getState(MountPointState)[mountPointUUID] || hasComponent(avatarEntity, SittingComponent)) return
+
+  setComponent(avatarEntity, SittingComponent, {
+    mountPointEntity: mountEntity!
+  })
+
+  AvatarControllerComponent.captureMovement(avatarEntity, mountEntity)
+  dispatchAction(
+    AvatarNetworkAction.setAnimationState({
+      animationAsset: preloadedAnimations.emotes,
+      clipName: emoteAnimations.seated,
+      loop: true,
+      layer: 1,
+      entityUUID: avatarUUID
+    })
+  )
+  dispatchAction(
+    MountPointActions.mountInteraction({
+      mounted: true,
+      mountedEntity: getComponent(avatarEntity, UUIDComponent),
+      targetMount: getComponent(mountEntity, UUIDComponent)
+    })
+  )
+}
+
+const unmountEntity = (entity: Entity) => {
+  if (!hasComponent(entity, SittingComponent)) return
+  const rigidBody = getComponent(entity, RigidBodyComponent)
+
+  dispatchAction(
+    AvatarNetworkAction.setAnimationState({
+      animationAsset: preloadedAnimations.emotes,
+      clipName: emoteAnimations.seated,
+      needsSkip: true,
+      entityUUID: getComponent(entity, UUIDComponent)
+    })
+  )
+
+  const sittingComponent = getComponent(entity, SittingComponent)
+
+  AvatarControllerComponent.releaseMovement(entity, sittingComponent.mountPointEntity)
+  dispatchAction(
+    MountPointActions.mountInteraction({
+      mounted: false,
+      mountedEntity: getComponent(entity, UUIDComponent),
+      targetMount: getComponent(sittingComponent.mountPointEntity, UUIDComponent)
+    })
+  )
+  const mountTransform = getComponent(sittingComponent.mountPointEntity, TransformComponent)
+  const mountComponent = getComponent(sittingComponent.mountPointEntity, MountPointComponent)
+  //we use teleport avatar only when rigidbody is not enabled, otherwise translation is called on rigidbody
+  const dismountPoint = new Vector3().copy(mountComponent.dismountOffset).applyMatrix4(mountTransform.matrixWorld)
+  teleportAvatar(entity, dismountPoint)
+  rigidBody.body.setEnabled(true)
+  removeComponent(entity, SittingComponent)
+}
 
 export const MountPointComponent = defineComponent({
   name: 'MountPointComponent',
@@ -71,11 +168,36 @@ export const MountPointComponent = defineComponent({
       dismountOffset: component.dismountOffset.value
     }
   },
+  mountEntity,
+  unmountEntity,
+  mountCallbackName,
+  mountPointInteractMessages,
 
   reactor: function () {
     const entity = useEntityContext()
     const debugEnabled = useHookstate(getMutableState(RendererState).nodeHelperVisibility)
     const mountPoint = useComponent(entity, MountPointComponent)
+    const mountedEntities = useHookstate(getMutableState(MountPointState))
+
+    useEffect(() => {
+      setCallback(entity, mountCallbackName, () => mountEntity(AvatarComponent.getSelfAvatarEntity(), entity))
+      setComponent(entity, BoundingBoxComponent, {
+        box: new Box3().setFromCenterAndSize(
+          getComponent(entity, TransformComponent).position,
+          new Vector3(0.1, 0.1, 0.1)
+        )
+      })
+    }, [])
+
+    useEffect(() => {
+      // manually hide interactable's XRUI when mounted through visibleComponent - (as interactable uses opacity to toggle visibility)
+      const interactableComponent = getComponent(entity, InteractableComponent)
+      if (interactableComponent) {
+        interactableComponent.uiVisibilityOverride = mountedEntities[getComponent(entity, UUIDComponent)].value
+          ? XRUIVisibilityOverride.off
+          : XRUIVisibilityOverride.none
+      }
+    }, [mountedEntities])
 
     useEffect(() => {
       if (!debugEnabled.value) return


### PR DESCRIPTION
## Summary
MountPoint/Grabbable/Link Components now add Interactables to the authoring layer, optimized useEffects to Systems/Components/Editors

proper serialization of InteractableComponents added by other components proper serialization of all remaining elements of Interactables proper editor callback selection on self for Interactables and Triggers

## Subtasks Checklist

## References
[IR-1780](https://tsu.atlassian.net/browse/IR-1780)

## QA Steps

1. Add a new entity to a scene, add a component of one of the following: MountPoint, Link, Grabbable.
2. Observe that it will have also added an InteractableComponent
- note that the default callback is now properly selecting "Self" and the corresponding callback option from your chosen component is chosen as a dropdown option rather than a string (this is now also true for TriggerComponent if there are callbacks on the same entity you add it to) 
- ![image](https://github.com/EtherealEngine/etherealengine/assets/162159423/0ce7ff8e-3e42-4ea9-bba6-6d17f0d4d427)
4. Modify any properties of the InteractableComponent and save the scene
5. either view the scene source or publish and play the scene, your changes to the InteractableComponent should now be reflected properly
- ![image](https://github.com/EtherealEngine/etherealengine/assets/162159423/c2103652-bb47-450a-9e1f-288d81870138)




[IR-1780]: https://tsu.atlassian.net/browse/IR-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ