### PR TITLE
IR-1790 Add Component menu - search field auto-focus

### DIFF
--- a/packages/editor/src/components/element/ElementList.tsx
+++ b/packages/editor/src/components/element/ElementList.tsx
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { startCase } from 'lodash'
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Component } from '@etherealengine/ecs/src/ComponentFunctions'
@@ -245,6 +245,7 @@ export function ElementList() {
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const shelves = useComponentShelfCategories(search.query.value)
+  const inputReference = useRef<HTMLInputElement>(null)
 
   const onSearch = (text: string) => {
     search.local.set(text)
@@ -253,6 +254,10 @@ export function ElementList() {
       search.query.set(text)
     }, 50)
   }
+
+  useEffect(() => {
+    inputReference.current?.focus()
+  }, [])
 
   return (
     <List
@@ -267,6 +272,7 @@ export function ElementList() {
             value={search.local.value}
             sx={{ mt: 1 }}
             onChange={(e) => onSearch(e.target.value)}
+            inputRef={inputReference}
           />
         </div>
       }


### PR DESCRIPTION
## Summary
making the Add Component search box gain focus automatically when opening the addComponent popup
![image](https://github.com/EtherealEngine/etherealengine/assets/162159423/931d8447-bdb0-4a79-82e8-6d3029d9d63d)

## Subtasks Checklist

## Breaking Changes

## References
[IR-1790](https://tsu.atlassian.net/browse/IR-1790)

## QA Steps
select an entity, click the Add Component button, notice that the search for component text box now automatically gains cursor input focus

[IR-1790]: https://tsu.atlassian.net/browse/IR-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ