### PR TITLE
Fix interactable cursor style reactor

### DIFF
--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -149,14 +149,13 @@ export const InteractableComponent = defineComponent({
     useEffect(() => {
       if (getState(EngineState).isEditor || !input) return
       const canvas = getComponent(Engine.instance.viewerEntity, RendererComponent).canvas
-      console.log('setting cursor type!')
       if (input.inputSources.length > 0) {
         canvas.style.cursor = 'pointer'
       }
       return () => {
         canvas.style.cursor = 'auto'
       }
-    }, [input?.inputSources])
+    }, [input?.inputSources.length])
 
     //handle highlighting when state is set
     useEffect(() => {

--- a/packages/engine/src/interaction/systems/InteractableSystem.ts
+++ b/packages/engine/src/interaction/systems/InteractableSystem.ts
@@ -101,8 +101,10 @@ export const onInteractableUpdate = (entity: Entity) => {
   if (!selfAvatarEntity) return
 
   const interactable = getComponent(entity, InteractableComponent)
-  const xrui = getComponent(interactable.uiEntity, XRUIComponent)
-  const xruiTransform = getComponent(interactable.uiEntity, TransformComponent)
+  const xrui = getOptionalComponent(interactable.uiEntity, XRUIComponent)
+  const xruiTransform = getOptionalComponent(interactable.uiEntity, TransformComponent)
+  if (!xrui || !xruiTransform) return
+
   const boundingBox = getOptionalComponent(entity, BoundingBoxComponent)
 
   updateXrDistVec3(selfAvatarEntity)


### PR DESCRIPTION
## Summary
The interactable cursor styles reactor was updating every frame, causing cursor styles not to work. Also, the interactable system throws an error repeatedly every frame, when an interactable does not have an associated uiEntity assigned. 

This PR fixes both of these issues. 

## Subtasks Checklist

## Breaking Changes

## References

## QA Steps

Try hovering over an interactable w/ a mouse cursor. The cursor should change to a pointer. 
