### PR TITLE
IR-1871 SystemDebug System tree systems without any pre/post/sub systems will no longer start out expanded

### DIFF
--- a/packages/client-core/src/components/Debug/SystemDebug.tsx
+++ b/packages/client-core/src/components/Debug/SystemDebug.tsx
@@ -121,8 +121,19 @@ export const SystemDagView = (props: { uuid: SystemUUID }) => {
           </>
         )
       }}
-      shouldExpandNodeInitially={() => true}
+      shouldExpandNodeInitially={(keyName, data, level) => shouldExpandNode(data)}
     />
+  )
+}
+function shouldExpandNode(nodeData) {
+  const data = nodeData as SystemTree
+
+  // !data.postSystems is a shorthand for whether we're on a system node that contains all 3 (sub/pre/post systems)
+  return (
+    !data.postSystems ||
+    Object.keys(data.postSystems).length > 0 ||
+    Object.keys(data.preSystems).length > 0 ||
+    Object.keys(data.subSystems).length > 0
   )
 }
 


### PR DESCRIPTION
## Summary
SystemDebug System tree systems without any pre/post/sub systems will no longer start out expanded

## Subtasks Checklist

## Breaking Changes

## References
[IR-1871](https://tsu.atlassian.net/browse/IR-1871)

## QA Steps
Go to a scene in studio or a location, hit the ~ key to open the debug menu, and click the systems tab. You should note that not all of the tree items are expanded. Those that are collapsed to start have no elements under any of the 3 pre/post/sub system children


[IR-1871]: https://tsu.atlassian.net/browse/IR-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ