### PR TITLE
prevent multiple rerender due to materialquery array

### DIFF
--- a/packages/editor/src/components/materials/MaterialLibraryPanelContainer.tsx
+++ b/packages/editor/src/components/materials/MaterialLibraryPanelContainer.tsx
@@ -73,7 +73,7 @@ export default function MaterialLibraryPanel() {
       ]
     })
     nodes.set(result)
-  }, [materialQuery, selected])
+  }, [materialQuery.length, selected])
 
   const onClick = (e: MouseEvent, node: MaterialLibraryEntryType) => {
     getMutableState(MaterialSelectionState).selectedMaterial.set(node.uuid)


### PR DESCRIPTION
## Summary

Prevent re-rendering in useeffect due to `materialQuery`'s array being changed (in reference) between renders

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

**earlier**

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/d3329171-a75b-4be5-8163-a4c40daa1c67)

**now**

_no re-render_