### PR TITLE
URI encoding cache invalidation paths

### DIFF
--- a/scripts/run-batch-invalidation.ts
+++ b/scripts/run-batch-invalidation.ts
@@ -75,7 +75,7 @@ cli.main(async () => {
       let pathArray: string[] = []
       let idArray: string[] = []
       for (let invalidation of invalidations) {
-        pathArray.push(invalidation.path)
+        pathArray.push(encodeURIComponent(invalidation.path))
         idArray.push(invalidation.id)
       }
       pathArray = [...new Set(pathArray)]


### PR DESCRIPTION
## Summary

Certain characters are valid for S3 file names but are invalid for Cloudfront cache invalidation paths.
URI encoding the paths submitted to Cloudfront to fix this.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
