### PR TITLE
Fixed bugs with builder commit fetching

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -112,7 +112,7 @@ function handler(event) {
 }
 `
 
-const awsPath = './.aws'
+const awsPath = './.aws/s3'
 const credentialsPath = `${awsPath}/credentials`
 
 export const getACL = (key: string) =>

--- a/packages/server-core/src/projects/builder-info/builder-info.class.ts
+++ b/packages/server-core/src/projects/builder-info/builder-info.class.ts
@@ -84,7 +84,7 @@ export class BuilderInfoService implements ServiceInterface<BuilderInfoType> {
               : publicECRRegexExec
               ? publicECRRegexExec[1]
               : privateECRRegexExec
-              ? privateECRRegexExec[0]
+              ? privateECRRegexExec[2]
               : ''
         }
       }

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -23,8 +23,9 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { ECRClient } from '@aws-sdk/client-ecr'
+import { DescribeImagesCommand as DescribePrivateImagesCommand, ECRClient } from '@aws-sdk/client-ecr'
 import { DescribeImagesCommand, ECRPUBLICClient } from '@aws-sdk/client-ecr-public'
+import { fromIni } from '@aws-sdk/credential-providers'
 import * as k8s from '@kubernetes/client-node'
 import appRootPath from 'app-root-path'
 import { exec } from 'child_process'
@@ -99,6 +100,9 @@ export const privateECRTagRegex = /^[a-zA-Z0-9]+.dkr.ecr.([\w\d\s\-_]+).amazonaw
 
 const BRANCH_PER_PAGE = 100
 const COMMIT_PER_PAGE = 10
+
+const awsPath = './.aws/eks'
+const credentialsPath = `${awsPath}/credentials`
 
 const execAsync = promisify(exec)
 
@@ -778,63 +782,87 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
   const publicECRExec = publicECRRepoRegex.exec(builderRepo)
   const privateECRExec = privateECRRepoRegex.exec(builderRepo)
   if (publicECRExec) {
+    const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
+
+    if (!fs.existsSync(awsPath)) fs.mkdirSync(awsPath, { recursive: true })
+    fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
+
     const ecr = new ECRPUBLICClient({
-      credentials: {
-        accessKeyId: config.aws.eks.accessKeyId,
-        secretAccessKey: config.aws.eks.secretAccessKey
-      },
+      credentials: fromIni({
+        profile: config.aws.eks.roleArn ? 'role' : 'default',
+        filepath: credentialsPath
+      }),
       region: 'us-east-1'
     })
     const command = {
       repositoryName: publicECRExec[1]
     }
     const result = new DescribeImagesCommand(command)
-    const response = await ecr.send(result)
-    if (!response || !response.imageDetails) return []
-    return response.imageDetails
-      .filter(
-        (imageDetails) => imageDetails.imageTags && imageDetails.imageTags.length > 0 && imageDetails.imagePushedAt
-      )
-      .sort((a, b) => b.imagePushedAt!.getTime() - a!.imagePushedAt!.getTime())
-      .map((imageDetails) => {
-        const tag = imageDetails.imageTags!.find((tag) => !/latest/.test(tag))!
-        const tagSplit = tag ? tag.split('_') : ''
-        return {
-          tag,
-          commitSHA: tagSplit.length === 1 ? tagSplit[0] : tagSplit[1],
-          engineVersion: tagSplit.length === 1 ? 'unknown' : tagSplit[0],
-          pushedAt: imageDetails.imagePushedAt!.toJSON()
-        }
-      })
+    try {
+      const response = await ecr.send(result)
+      if (!response || !response.imageDetails) return []
+      return response.imageDetails
+        .filter(
+          (imageDetails) => imageDetails.imageTags && imageDetails.imageTags.length > 0 && imageDetails.imagePushedAt
+        )
+        .sort((a, b) => b.imagePushedAt!.getTime() - a!.imagePushedAt!.getTime())
+        .map((imageDetails) => {
+          const tag = imageDetails.imageTags!.find((tag) => !/latest/.test(tag))!
+          const tagSplit = tag ? tag.split('_') : ''
+          return {
+            tag,
+            commitSHA: tagSplit.length === 1 ? tagSplit[0] : tagSplit[1],
+            engineVersion: tagSplit.length === 1 ? 'unknown' : tagSplit[0],
+            pushedAt: imageDetails.imagePushedAt!.toJSON()
+          }
+        })
+    } catch (err) {
+      logger.error('Failure to get public ECR images')
+      logger.error('Command that was sent', result)
+      logger.error(err)
+      return []
+    }
   } else if (privateECRExec) {
+    const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
+
+    if (!fs.existsSync(awsPath)) fs.mkdirSync(awsPath, { recursive: true })
+    fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
+
     const ecr = new ECRClient({
-      credentials: {
-        accessKeyId: config.aws.eks.accessKeyId,
-        secretAccessKey: config.aws.eks.secretAccessKey
-      },
+      credentials: fromIni({
+        profile: config.aws.eks.roleArn ? 'role' : 'default',
+        filepath: credentialsPath
+      }),
       region: privateECRExec[1]
     })
     const command = {
       repositoryName: privateECRExec[2]
     }
-    const result = new DescribeImagesCommand(command)
-    const response = await ecr.send(result)
-    if (!response || !response.imageDetails) return []
-    return response.imageDetails
-      .filter(
-        (imageDetails) => imageDetails.imageTags && imageDetails.imageTags.length > 0 && imageDetails.imagePushedAt
-      )
-      .sort((a, b) => b.imagePushedAt!.getTime() - a.imagePushedAt!.getTime())
-      .map((imageDetails) => {
-        const tag = imageDetails.imageTags!.find((tag) => !/latest/.test(tag))!
-        const tagSplit = tag ? tag.split('_') : ''
-        return {
-          tag,
-          commitSHA: tagSplit.length === 1 ? tagSplit[0] : tagSplit[1],
-          engineVersion: tagSplit.length === 1 ? 'unknown' : tagSplit[0],
-          pushedAt: imageDetails.imagePushedAt!.toJSON()
-        }
-      })
+    const result = new DescribePrivateImagesCommand(command)
+    try {
+      const response = await ecr.send(result)
+      if (!response || !response.imageDetails) return []
+      return response.imageDetails
+        .filter(
+          (imageDetails) => imageDetails.imageTags && imageDetails.imageTags.length > 0 && imageDetails.imagePushedAt
+        )
+        .sort((a, b) => b.imagePushedAt!.getTime() - a.imagePushedAt!.getTime())
+        .map((imageDetails) => {
+          const tag = imageDetails.imageTags!.find((tag) => !/latest/.test(tag))!
+          const tagSplit = tag ? tag.split('_') : ''
+          return {
+            tag,
+            commitSHA: tagSplit.length === 1 ? tagSplit[0] : tagSplit[1],
+            engineVersion: tagSplit.length === 1 ? 'unknown' : tagSplit[0],
+            pushedAt: imageDetails.imagePushedAt!.toJSON()
+          }
+        })
+    } catch (err) {
+      logger.error('Failure to get private ECR images')
+      logger.error('Command that was sent %o', result)
+      logger.error(err)
+      return []
+    }
   } else {
     const registry = /docker.io\//.test(process.env.SOURCE_REPO_URL!)
       ? process.env.SOURCE_REPO_URL!.split('/')[1]
@@ -855,7 +883,8 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
         }
       })
     } catch (e) {
-      console.error(e)
+      logger.error('Failure to get Docker Hub images')
+      logger.error(e)
       return []
     }
   }

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -785,7 +785,7 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
     const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
 
     if (!fs.existsSync(awsPath)) fs.mkdirSync(awsPath, { recursive: true })
-    fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
+    if (!fs.existsSync(credentialsPath)) fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
 
     const ecr = new ECRPUBLICClient({
       credentials: fromIni({
@@ -826,7 +826,7 @@ export const findBuilderTags = async (): Promise<Array<ProjectBuilderTagsType>> 
     const awsCredentials = `[default]\naws_access_key_id=${config.aws.eks.accessKeyId}\naws_secret_access_key=${config.aws.eks.secretAccessKey}\n[role]\nrole_arn = ${config.aws.eks.roleArn}\nsource_profile = default`
 
     if (!fs.existsSync(awsPath)) fs.mkdirSync(awsPath, { recursive: true })
-    fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
+    if (!fs.existsSync(credentialsPath)) fs.writeFileSync(credentialsPath, Buffer.from(awsCredentials))
 
     const ecr = new ECRClient({
       credentials: fromIni({

--- a/packages/server/.aws/credentials
+++ b/packages/server/.aws/credentials
@@ -1,6 +1,0 @@
-[default]
-aws_access_key_id=server
-aws_secret_access_key=password
-[role]
-role_arn = undefined
-source_profile = default


### PR DESCRIPTION
## Summary

builder-info.class.ts was using the wrong value from privateECRRegexExec.

findBuilderTags in project-helper.ts was not using the new fromIni method to get credentials for AWS. Updated it to do so.

Made S3 and EKS SDKs save their credentials files to separate files, so that they don't collide with each other.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
