### PR TITLE
Added migration to fix identity-provider token length.

### DIFF
--- a/packages/server-core/src/user/identity-provider/migrations/20240514172212_identity-provider-change-token-length.ts
+++ b/packages/server-core/src/user/identity-provider/migrations/20240514172212_identity-provider-change-token-length.ts
@@ -1,0 +1,61 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { identityProviderPath } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
+import type { Knex } from 'knex'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  // Added transaction here in order to ensure both below queries run on same pool.
+  // https://github.com/knex/knex/issues/218#issuecomment-56686210
+  const trx = await knex.transaction()
+  await trx.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  await trx.schema.alterTable(identityProviderPath, (table) => {
+    table.string('token', 255).defaultTo(null).alter()
+  })
+
+  await trx.raw('SET FOREIGN_KEY_CHECKS=1')
+  await trx.commit()
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  const trx = await knex.transaction()
+  await trx.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  await trx.schema.alterTable(identityProviderPath, (table) => {
+    table.uuid('token').defaultTo(null).alter()
+  })
+
+  await trx.raw('SET FOREIGN_KEY_CHECKS=1')
+  await trx.commit()
+}


### PR DESCRIPTION
## Summary

It had mistakenly been declared a UUID, but it should be varchar(255).

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
