### PR TITLE
Reworked assetURL in saveSceneGLTF

### DIFF
--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -67,6 +67,8 @@ export const renameScene = async (id: string, newURL: string, params?: AssetPara
   }
 }
 
+const fileServer = config.client.fileServer
+
 export const saveSceneGLTF = async (
   sceneAssetID: string | null,
   projectName: string,
@@ -86,8 +88,6 @@ export const saveSceneGLTF = async (
   const file = new File(blob, `${sceneName}.gltf`)
   const currentSceneDirectory = getState(EditorState).scenePath!.split('/').slice(0, -1).join('/')
   const [[newPath]] = await Promise.all(uploadProjectFiles(projectName, [file], [currentSceneDirectory]).promises)
-
-  const fileServer = config.client.fileServer
 
   const assetURL = new URL(newPath).toString().replace(fileServer, '').slice(1) // remove leading slash
 
@@ -141,8 +141,6 @@ export const onNewScene = async () => {
     logger.error(error)
   }
 }
-
-const fileServer = config.client.fileServer
 
 export const setCurrentEditorScene = (sceneURL: string, uuid: EntityUUID) => {
   const gltfEntity = GLTFSourceState.load(fileServer + '/' + sceneURL, uuid)

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -89,7 +89,7 @@ export const saveSceneGLTF = async (
   const currentSceneDirectory = getState(EditorState).scenePath!.split('/').slice(0, -1).join('/')
   const [[newPath]] = await Promise.all(uploadProjectFiles(projectName, [file], [currentSceneDirectory]).promises)
 
-  const assetURL = new URL(newPath).toString().replace(fileServer, '').slice(1) // remove leading slash
+  const assetURL = newPath.replace(fileServer, '').slice(1) // remove leading slash
 
   if (sceneAssetID) {
     const result = await Engine.instance.api.service(assetPath).patch(sceneAssetID, { assetURL, project: projectName })

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -87,7 +87,9 @@ export const saveSceneGLTF = async (
   const currentSceneDirectory = getState(EditorState).scenePath!.split('/').slice(0, -1).join('/')
   const [[newPath]] = await Promise.all(uploadProjectFiles(projectName, [file], [currentSceneDirectory]).promises)
 
-  const assetURL = new URL(newPath).pathname.slice(1) // remove leading slash
+  const fileServer = config.client.fileServer
+
+  const assetURL = new URL(newPath).toString().replace(fileServer, '').slice(1) // remove leading slash
 
   if (sceneAssetID) {
     const result = await Engine.instance.api.service(assetPath).patch(sceneAssetID, { assetURL, project: projectName })


### PR DESCRIPTION
When using minio, bucket name would get appended to the assetURL and break saving scene flow. In this PR, the assetURL is now formed by replacing fileServer rather than using `url.pathname`. This is just reverse-engineering the key for GLTF Entity that is being set on line 146 of `sceneFunctions.ts`: https://github.com/EtherealEngine/etherealengine/blob/dev/packages/editor/src/functions/sceneFunctions.tsx#L146