### PR TITLE
Updated usage of refreshApiPods

### DIFF
--- a/packages/server-core/src/hooks/refresh-api-pods.ts
+++ b/packages/server-core/src/hooks/refresh-api-pods.ts
@@ -1,0 +1,69 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { getState } from '@etherealengine/hyperflux'
+import * as k8s from '@kubernetes/client-node'
+import logger from '../ServerLogger'
+import { ServerState } from '../ServerState'
+import config from '../appconfig'
+
+export default async () => {
+  const k8AppsClient = getState(ServerState).k8AppsClient
+
+  if (k8AppsClient) {
+    try {
+      logger.info('Attempting to refresh API pods')
+      const refreshApiPodResponse = await k8AppsClient.patchNamespacedDeployment(
+        `${config.server.releaseName}-etherealengine-api`,
+        'default',
+        {
+          spec: {
+            template: {
+              metadata: {
+                annotations: {
+                  'kubectl.kubernetes.io/restartedAt': new Date().toISOString()
+                }
+              }
+            }
+          }
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          headers: {
+            'Content-Type': k8s.PatchUtils.PATCH_FORMAT_STRATEGIC_MERGE_PATCH
+          }
+        }
+      )
+      logger.info(refreshApiPodResponse, 'updateBuilderTagResponse')
+    } catch (e) {
+      logger.error(e)
+      return e
+    }
+  }
+}

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.hooks.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.hooks.ts
@@ -34,14 +34,11 @@ import {
   authenticationSettingPath,
   authenticationSettingQueryValidator
 } from '@etherealengine/common/src/schemas/setting/authentication-setting.schema'
-import * as k8s from '@kubernetes/client-node'
 
-import { getState } from '@etherealengine/hyperflux'
 import { BadRequest } from '@feathersjs/errors'
 import { HookContext } from '../../../declarations'
-import logger from '../../ServerLogger'
-import { ServerState } from '../../ServerState'
 import config from '../../appconfig'
+import refreshApiPods from '../../hooks/refresh-api-pods'
 import verifyScope from '../../hooks/verify-scope'
 import { AuthenticationSettingService } from './authentication-setting.class'
 import {
@@ -117,44 +114,6 @@ const ensureOAuth = async (context: HookContext<AuthenticationSettingService>) =
  * @param context
  * @returns
  */
-const refreshAPIPods = async (context: HookContext<AuthenticationSettingService>) => {
-  const k8AppsClient = getState(ServerState).k8AppsClient
-
-  if (k8AppsClient) {
-    try {
-      logger.info('Attempting to refresh API pods')
-      const refreshApiPodResponse = await k8AppsClient.patchNamespacedDeployment(
-        `${config.server.releaseName}-etherealengine-api`,
-        'default',
-        {
-          spec: {
-            template: {
-              metadata: {
-                annotations: {
-                  'kubectl.kubernetes.io/restartedAt': new Date().toISOString()
-                }
-              }
-            }
-          }
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          headers: {
-            'Content-Type': k8s.PatchUtils.PATCH_FORMAT_STRATEGIC_MERGE_PATCH
-          }
-        }
-      )
-      logger.info(refreshApiPodResponse, 'updateBuilderTagResponse')
-    } catch (e) {
-      logger.error(e)
-      return e
-    }
-  }
-}
 
 export default {
   around: {
@@ -192,7 +151,7 @@ export default {
     get: [],
     create: [],
     update: [],
-    patch: [refreshAPIPods],
+    patch: [refreshApiPods],
     remove: []
   },
 

--- a/packages/server-core/src/user/email/email.hooks.ts
+++ b/packages/server-core/src/user/email/email.hooks.ts
@@ -26,6 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import { emailDataValidator } from '@etherealengine/common/src/schemas/user/email.schema'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { disallow } from 'feathers-hooks-common'
+import refreshApiPods from '../../hooks/refresh-api-pods'
 
 export default {
   before: {
@@ -44,7 +45,7 @@ export default {
     get: [],
     create: [],
     update: [],
-    patch: [],
+    patch: [refreshApiPods],
     remove: []
   },
 


### PR DESCRIPTION
## Summary

Moved refreshApiPods to a separate hook file.

Added refreshApiPods to email-settings.patch:after hooks. The email client is configured on startup and
does not change if appConfig changes.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
