### PR TITLE
Updated LinkedIn OAuth scopes for new app Product

### DIFF
--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -37,6 +37,12 @@ import { githubRepoAccessWebhookPath } from '@etherealengine/common/src/schemas/
 import { identityProviderPath } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
 import { loginPath } from '@etherealengine/common/src/schemas/user/login.schema'
 import multiLogger from './ServerLogger'
+import {
+  DISCORD_SCOPES,
+  GITHUB_SCOPES,
+  GOOGLE_SCOPES,
+  LINKEDIN_SCOPES
+} from './setting/authentication-setting/authentication-setting.seed'
 
 const logger = multiLogger.child({ component: 'server-core:config' })
 
@@ -289,7 +295,7 @@ const authentication = {
     discord: {
       key: process.env.DISCORD_CLIENT_ID!,
       secret: process.env.DISCORD_CLIENT_SECRET!,
-      scope: ['identify', 'email'],
+      scope: DISCORD_SCOPES,
       custom_params: {
         prompt: 'none'
       }
@@ -301,17 +307,17 @@ const authentication = {
     github: {
       key: process.env.GITHUB_CLIENT_ID!,
       secret: process.env.GITHUB_CLIENT_SECRET!,
-      scope: ['repo', 'user', 'workflow']
+      scope: GITHUB_SCOPES
     },
     google: {
       key: process.env.GOOGLE_CLIENT_ID!,
       secret: process.env.GOOGLE_CLIENT_SECRET!,
-      scope: ['profile', 'email']
+      scope: GOOGLE_SCOPES
     },
     linkedin: {
       key: process.env.LINKEDIN_CLIENT_ID!,
       secret: process.env.LINKEDIN_CLIENT_SECRET!,
-      scope: ['r_liteprofile', 'r_emailaddress']
+      scope: LINKEDIN_SCOPES
     },
     twitter: {
       key: process.env.TWITTER_CLIENT_ID!,

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
@@ -36,6 +36,11 @@ import { identityProviderPath } from '@etherealengine/common/src/schemas/user/id
 import { getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import config from '../../appconfig'
 
+export const DISCORD_SCOPES = ['email', 'identify']
+export const GITHUB_SCOPES = ['repo', 'user', 'workflow']
+export const GOOGLE_SCOPES = ['profile', 'email']
+export const LINKEDIN_SCOPES = ['profile', 'email']
+
 export async function seed(knex: Knex): Promise<void> {
   const { testEnabled } = appConfig
   const { forceRefresh } = appConfig.db
@@ -83,7 +88,7 @@ export async function seed(knex: Knex): Promise<void> {
           discord: {
             key: process.env.DISCORD_CLIENT_ID,
             secret: process.env.DISCORD_CLIENT_SECRET,
-            scope: ['email', 'identify'],
+            scope: DISCORD_SCOPES,
             custom_params: { prompt: 'none' }
           },
           facebook: {
@@ -93,17 +98,17 @@ export async function seed(knex: Knex): Promise<void> {
           github: {
             key: process.env.GITHUB_CLIENT_ID,
             secret: process.env.GITHUB_CLIENT_SECRET,
-            scope: ['repo', 'user', 'workflow']
+            scope: GITHUB_SCOPES
           },
           google: {
             key: process.env.GOOGLE_CLIENT_ID,
             secret: process.env.GOOGLE_CLIENT_SECRET,
-            scope: ['profile', 'email']
+            scope: GOOGLE_SCOPES
           },
           linkedin: {
             key: process.env.LINKEDIN_CLIENT_ID,
             secret: process.env.LINKEDIN_CLIENT_SECRET,
-            scope: ['r_liteprofile', 'r_emailaddress']
+            scope: LINKEDIN_SCOPES
           },
           twitter: {
             key: process.env.TWITTER_CLIENT_ID,

--- a/packages/server-core/src/setting/authentication-setting/migrations/20240516222541_change-linkedin-scopes.ts
+++ b/packages/server-core/src/setting/authentication-setting/migrations/20240516222541_change-linkedin-scopes.ts
@@ -1,0 +1,53 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import type { Knex } from 'knex'
+
+import { authenticationSettingPath } from '@etherealengine/common/src/schemas/setting/authentication-setting.schema'
+
+import { LINKEDIN_SCOPES } from '../authentication-setting.seed'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  const authSettings = await knex.table(authenticationSettingPath).first()
+
+  if (authSettings) {
+    const oauthSettings = JSON.parse(authSettings.oauth)
+    oauthSettings.linkedin.scope = LINKEDIN_SCOPES
+
+    await knex.table(authenticationSettingPath).update({
+      oauth: JSON.stringify(oauthSettings)
+    })
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {}


### PR DESCRIPTION
## Summary

LinkedIn changed their app product and scopes.
Apps now need to have the
"Sign in with LinkedIn with OpenID Connect"
product added, which adds scopes 'profile' and 'email'. Updated authentication-setting.seed.ts and appconfig.ts to use these new scopes for OAuth flow.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
