### PR TITLE
Fixed bug in invalidation path encoding

### DIFF
--- a/scripts/run-batch-invalidation.ts
+++ b/scripts/run-batch-invalidation.ts
@@ -58,6 +58,24 @@ const options = cli.parse({
   startTime: [false, 'Timestamp of image', 'string']
 })
 
+const encodeCloudfrontInvalidation = (uri: string) =>
+  uri
+    .replaceAll('%', '%25')
+    .replaceAll(' ', '%20')
+    .replaceAll('"', '%22')
+    .replaceAll('#', '%23')
+    .replaceAll('<', '%3C')
+    .replaceAll('>', '%3E')
+    .replaceAll('[', '%5B')
+    .replaceAll('\\', '%5C')
+    .replaceAll(']', '%5D')
+    .replaceAll('^', '%5E')
+    .replaceAll('`', `%60`)
+    .replaceAll('{', '%7B')
+    .replaceAll('|', '%7C')
+    .replaceAll('}', '%7D')
+    .replaceAll('~', '%7E')
+
 cli.main(async () => {
   try {
     const app = createFeathersKoaApp(ServerMode.API, serverJobPipe)
@@ -75,7 +93,7 @@ cli.main(async () => {
       let pathArray: string[] = []
       let idArray: string[] = []
       for (let invalidation of invalidations) {
-        pathArray.push(encodeURIComponent(invalidation.path))
+        pathArray.push(encodeCloudfrontInvalidation(invalidation.path))
         idArray.push(invalidation.id)
       }
       pathArray = [...new Set(pathArray)]


### PR DESCRIPTION
## Summary

Only unsafe characters should be URL-encoded in Cloudfront invalidation paths. All others must be left as-is or else they invalidate the wrong path.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
