### PR TITLE
[IR-2087] studio: update ContextMenu

### DIFF
--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -82,11 +82,9 @@ export const ContextMenu = ({
 
       // Make the menu scrollable if it is too tall for the parent component
       setIsScrollable(parentHeight < menuHeight)
-    }
-  }, [open])
 
-  useEffect(() => {
-    setPositionY(calculatePositionY())
+      setPositionY(calculatePositionY())
+    }
   }, [open])
 
   return (

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -23,7 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import ClickAwayListener from './ClickAwayListener'
 
@@ -46,14 +46,42 @@ export const ContextMenu = ({
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {
   const panel = document.getElementById(panelId)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  // Calculate the Y position of the context menu based on the menu height and space to the bottom of the viewport in order to avoid overflow
+  const calculatePositionY = () => {
+    let positionY = open ? anchorPosition.top - panel?.getBoundingClientRect().top! : 0
+
+    if (open && menuRef.current) {
+      const menuHeight = menuRef.current.offsetHeight
+
+      // The amount of space that the menu can fill based on the current anchor position
+      const spaceToBottomFromAnchor = window.innerHeight - anchorPosition.top
+      // We want to reposition the context menu whenever it will overflow the bottom of the screen
+      const shouldRepositionMenu = menuHeight > spaceToBottomFromAnchor
+
+      if (shouldRepositionMenu) {
+        // Align the menu bottom with the bottom of the viewport
+        positionY = window.innerHeight - menuHeight - (panel?.getBoundingClientRect().top || 0) + 50
+      }
+    }
+
+    return positionY
+  }
+
   const positionX = open ? anchorPosition.left - panel?.getBoundingClientRect().left! : 0
-  const positionY = open ? anchorPosition.top - panel?.getBoundingClientRect().top! : 0
+  const [positionY, setPositionY] = useState(calculatePositionY())
+
+  useEffect(() => {
+    setPositionY(calculatePositionY())
+  }, [open, anchorPosition.top])
 
   return (
     <ClickAwayListener onClickAway={() => onClose()}>
       <div className={`${open ? 'block' : 'hidden'}`}>
         {open && anchorEl && (
           <div
+            ref={menuRef}
             className="absolute z-[200] w-40 rounded-lg bg-neutral-900 shadow-lg"
             style={{ top: `${positionY}px`, left: `${positionX}px` }}
           >

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -72,9 +72,22 @@ export const ContextMenu = ({
   const positionX = open ? anchorPosition.left - panel?.getBoundingClientRect().left! : 0
   const [positionY, setPositionY] = useState(calculatePositionY())
 
+  const [isScrollable, setIsScrollable] = useState(false)
+  const parentRect = panel?.getBoundingClientRect()
+
+  useEffect(() => {
+    if (open && menuRef.current) {
+      const menuHeight = menuRef.current.offsetHeight
+      const parentHeight = parentRect?.height || 0
+
+      // Make the menu scrollable if it is too tall for the parent component
+      setIsScrollable(parentHeight < menuHeight)
+    }
+  }, [open])
+
   useEffect(() => {
     setPositionY(calculatePositionY())
-  }, [open, anchorPosition.top])
+  }, [open])
 
   return (
     <ClickAwayListener onClickAway={() => onClose()}>
@@ -83,7 +96,12 @@ export const ContextMenu = ({
           <div
             ref={menuRef}
             className="absolute z-[200] w-40 rounded-lg bg-neutral-900 shadow-lg"
-            style={{ top: `${positionY}px`, left: `${positionX}px` }}
+            style={{
+              top: `${positionY}px`,
+              left: `${positionX}px`,
+              maxHeight: `${panel?.getBoundingClientRect().height}px`,
+              overflowY: isScrollable ? 'auto' : 'visible'
+            }}
           >
             <div className={twMerge('flex flex-col truncate py-1', className)}>{children}</div>
           </div>

--- a/packages/ui/src/components/editor/layout/Panel.tsx
+++ b/packages/ui/src/components/editor/layout/Panel.tsx
@@ -82,7 +82,7 @@ export const PanelCheckbox = ({ children }) => {
 }
 
 export const PanelDragContainer = ({ children }) => {
-  return <div className="bg-theme-surface-main cursor-pointer' rounded-t-md px-4 py-1">{children}</div>
+  return <div className="bg-theme-surface-main cursor-pointer rounded-t-md px-4 py-1">{children}</div>
 }
 
 export const PanelContainer = ({ children, ...rest }) => {

--- a/packages/ui/src/components/editor/layout/Panel.tsx
+++ b/packages/ui/src/components/editor/layout/Panel.tsx
@@ -82,7 +82,7 @@ export const PanelCheckbox = ({ children }) => {
 }
 
 export const PanelDragContainer = ({ children }) => {
-  return <div className="bg-theme-surface-main rounded-t-md px-4 py-1">{children}</div>
+  return <div className="bg-theme-surface-main cursor-pointer' rounded-t-md px-4 py-1">{children}</div>
 }
 
 export const PanelContainer = ({ children, ...rest }) => {


### PR DESCRIPTION
## Summary
Dynamically repositions ContextMenu if the bottom is trimmed. Also makes the component smaller and scrollable to avoid trimming the top when height exceeds the available space.

## Subtasks Checklist

## Breaking Changes

## References
[IR-2087] Avoid the context menu being trimmed

## QA Steps


[IR-2087]: https://tsu.atlassian.net/browse/IR-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ