### PR TITLE
Made client's server.js not bound to a specific host

### DIFF
--- a/packages/client/server.js
+++ b/packages/client/server.js
@@ -39,8 +39,7 @@ dotenv.config({ path: process.cwd() + '/../../.env.local' })
 
 
 const app = new koa();
-const HOST = process.env.VITE_APP_HOST || '0.0.0.0';
-const PORT = parseInt(process.env.HOST_PORT) || 3000;
+const PORT = parseInt(process.env.VITE_APP_PORT) || 3000;
 const HTTPS = process.env.VITE_LOCAL_BUILD ?? false;
 const key = process.env.KEY || 'certs/key.pem'
 const cert = process.env.CERT || 'certs/cert.pem'
@@ -69,4 +68,4 @@ app.listen = function () {
   }
   return server.listen.apply(server, arguments);
 };
-app.listen(PORT, HOST, () => console.log(`Server listening on port: ${PORT}`));
+app.listen(PORT, () => console.log(`Server listening on port: ${PORT}`));


### PR DESCRIPTION
## Summary

The client's app.listen() call was trying to listen to the host VITE_APP_HOST. In a minikube environment, this would error out since that address had no DNS routing internal to minikube, and the client pod would fail, as the listen() call attempts to ping the host while starting, and throws an error if it cannot do so.

Removing the host from app.listen just has it listen on 0.0.0.0, which will always succeed.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
