### PR TITLE
Fixed webcam light not turning off when camera paused.

### DIFF
--- a/packages/client-core/src/components/UserMediaWindow/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindow/index.tsx
@@ -181,12 +181,12 @@ export const useUserMediaWindowHook = ({ peerID, type }: Props) => {
   useEffect(() => {
     if (peerMediaChannelState.videoStream.value?.track)
       videoTrackId.set(peerMediaChannelState.videoStream.value.track.id)
-  }, [peerMediaChannelState.videoStream])
+  }, [peerMediaChannelState.videoStream.value?.track?.id])
 
   useEffect(() => {
     if (peerMediaChannelState.audioStream.value?.track)
       audioTrackId.set(peerMediaChannelState.audioStream.value.track.id)
-  }, [peerMediaChannelState.audioStream])
+  }, [peerMediaChannelState.audioStream.value?.track?.id])
 
   useEffect(() => {
     function onUserInteraction() {
@@ -284,6 +284,8 @@ export const useUserMediaWindowHook = ({ peerID, type }: Props) => {
         }
       }, 100)
     }
+    if (isSelf && videoProducerPaused && videoStream != null && videoElement != null)
+      videoTrackClones.get(NO_PROXY).forEach((track) => track.stop())
   }, [videoProducerPaused])
 
   useEffect(() => {

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -1111,6 +1111,7 @@ export const toggleWebcamPaused = async () => {
       if (videoPaused) resumeProducer(mediaNetwork, mediaStreamState.camVideoProducer.value! as ProducerExtension)
       else pauseProducer(mediaNetwork, mediaStreamState.camVideoProducer.value! as ProducerExtension)
       mediaStreamState.videoPaused.set(!videoPaused)
+      if (!videoPaused) mediaStreamState.camVideoProducer.value!.track?.stop()
     }
   }
 }


### PR DESCRIPTION
## Summary

Video tracks, and clones thereof, were not being stopped when one's camera was paused. This would lead the webcam 'active' light to stay on.


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
