### PR TITLE
Changes for feature flag schema to be string enum

### DIFF
--- a/packages/client-core/src/networking/NetworkInstanceProvisioning.tsx
+++ b/packages/client-core/src/networking/NetworkInstanceProvisioning.tsx
@@ -40,7 +40,7 @@ import {
 } from '@etherealengine/client-core/src/common/services/MediaInstanceConnectionService'
 import { ChannelService, ChannelState } from '@etherealengine/client-core/src/social/services/ChannelService'
 import { LocationState } from '@etherealengine/client-core/src/social/services/LocationService'
-import { FeatureFlag, InstanceID, LocationID, RoomCode } from '@etherealengine/common/src/schema.type.module'
+import { InstanceID, LocationID, RoomCode } from '@etherealengine/common/src/schema.type.module'
 import { getMutableState, getState, none, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { NetworkState } from '@etherealengine/network'
 
@@ -244,12 +244,10 @@ export const SocialMenus = {
   Messages: 'Messages'
 }
 
-const SocialMenuFlag = 'ir.client.menu.social' as FeatureFlag
-
 export const FriendMenus = () => {
   const { t } = useTranslation()
 
-  const socialsEnabled = FeatureFlagsState.useEnabled(SocialMenuFlag)
+  const socialsEnabled = FeatureFlagsState.useEnabled('ir.client.menu.social')
 
   useEffect(() => {
     if (!socialsEnabled) return

--- a/packages/client-core/src/user/UserUISystem.tsx
+++ b/packages/client-core/src/user/UserUISystem.tsx
@@ -30,7 +30,6 @@ import { defineSystem } from '@etherealengine/ecs/src/SystemFunctions'
 import { PresentationSystemGroup } from '@etherealengine/ecs/src/SystemGroups'
 import { getMutableState, none } from '@etherealengine/hyperflux'
 
-import { FeatureFlag } from '@etherealengine/common/src/schema.type.module'
 import { FeatureFlagsState } from '@etherealengine/engine/src/FeatureFlagsState'
 import { InviteService } from '../social/services/InviteService'
 import { PopupMenuState } from './components/UserMenu/PopupMenuService'
@@ -66,17 +65,13 @@ export const UserMenus = {
   Emote: 'user.Emote'
 }
 
-export const EmoteMenuFlag = 'ir.client.menu.emote' as FeatureFlag
-export const AvaturnMenuFlag = 'ir.client.menu.avaturn' as FeatureFlag
-export const RPMMenuFlag = 'ir.client.menu.readyPlayerMe' as FeatureFlag
-
 const reactor = () => {
   const { t } = useTranslation()
   InviteService.useAPIListeners()
 
-  const emotesEnabled = FeatureFlagsState.useEnabled(EmoteMenuFlag)
-  const avaturnEnabled = FeatureFlagsState.useEnabled(AvaturnMenuFlag)
-  const rpmEnabled = FeatureFlagsState.useEnabled(RPMMenuFlag)
+  const emotesEnabled = FeatureFlagsState.useEnabled('ir.client.menu.emote')
+  const avaturnEnabled = FeatureFlagsState.useEnabled('ir.client.menu.avaturn')
+  const rpmEnabled = FeatureFlagsState.useEnabled('ir.client.menu.readyPlayerMe')
 
   useEffect(() => {
     const FaceRetouchingNatural = lazy(() => import('@mui/icons-material/FaceRetouchingNatural'))

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarModifyMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarModifyMenu.tsx
@@ -53,7 +53,7 @@ import Icon from '@etherealengine/ui/src/primitives/mui/Icon'
 import IconButton from '@etherealengine/ui/src/primitives/mui/IconButton'
 
 import { FeatureFlagsState } from '@etherealengine/engine/src/FeatureFlagsState'
-import { AvaturnMenuFlag, RPMMenuFlag, UserMenus } from '../../../UserUISystem'
+import { UserMenus } from '../../../UserUISystem'
 import { AvatarService } from '../../../services/AvatarService'
 import { PopupMenuServices } from '../PopupMenuService'
 import styles from '../index.module.scss'
@@ -84,8 +84,8 @@ const AvatarModifyMenu = ({ selectedAvatar }: Props) => {
   const [isSaving, setIsSaving] = useState(false)
   const avatarRef = useRef<HTMLInputElement | null>(null)
   const thumbnailRef = useRef<HTMLInputElement | null>(null)
-  const avaturnEnabled = FeatureFlagsState.useEnabled(AvaturnMenuFlag)
-  const rpmEnabled = FeatureFlagsState.useEnabled(RPMMenuFlag)
+  const avaturnEnabled = FeatureFlagsState.useEnabled('ir.client.menu.avaturn')
+  const rpmEnabled = FeatureFlagsState.useEnabled('ir.client.menu.readyPlayerMe')
 
   let thumbnailSrc = state.thumbnailUrl
   if (state.thumbnailFile) {

--- a/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
+++ b/packages/common/src/schemas/setting/feature-flag-setting.schema.ts
@@ -25,12 +25,10 @@ Ethereal Engine. All Rights Reserved.
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import type { Static } from '@feathersjs/typebox'
-import { getValidator, querySyntax, Type } from '@feathersjs/typebox'
-import { OpaqueType } from '../../interfaces/OpaqueType'
-import { TypedString } from '../../types/TypeboxUtils'
+import { getValidator, querySyntax, StringEnum, Type } from '@feathersjs/typebox'
 import { dataValidator, queryValidator } from '../validators'
 
-export type FeatureFlag = OpaqueType<'FeatureFlag'> & string
+export type FeatureFlag = FeatureFlagSettingType['flagName']
 
 export const featureFlagSettingPath = 'feature-flag-setting'
 
@@ -42,7 +40,12 @@ export const featureFlagSettingSchema = Type.Object(
     id: Type.String({
       format: 'uuid'
     }),
-    flagName: TypedString<FeatureFlag>(),
+    flagName: StringEnum([
+      'ir.client.menu.social',
+      'ir.client.menu.emote',
+      'ir.client.menu.avaturn',
+      'ir.client.menu.readyPlayerMe'
+    ]),
     flagValue: Type.Boolean(),
     createdAt: Type.String({ format: 'date-time' }),
     updatedAt: Type.String({ format: 'date-time' })

--- a/packages/engine/src/FeatureFlagsState.tsx
+++ b/packages/engine/src/FeatureFlagsState.tsx
@@ -44,7 +44,7 @@ export const FeatureFlagsState = defineState({
 
     useEffect(() => {
       const data = featureFlagQuery.data
-      getMutableState(FeatureFlagsState).set(
+      getMutableState(FeatureFlagsState).merge(
         Object.fromEntries(data.map(({ flagName, flagValue }) => [flagName, flagValue]))
       )
     }, [featureFlagQuery.data])


### PR DESCRIPTION
## Summary

Made this change so that FeatureFlag is now an enum. New ones can be directly added into schema. This change has to do nothing with DB table as there its still a string.

Below is the example of how autocomplete will pick possible values of FeatureFlag type
![image](https://github.com/EtherealEngine/etherealengine/assets/10975502/9df7c32a-8d02-484b-83c5-a4fbeae72c59)


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
