### PR TITLE
vrm expressionmanager was being thrown away it is actually needed for…

### DIFF
--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -90,6 +90,7 @@ export const autoconvertMixamoAvatar = (model: GLTF | VRM) => {
     bones.hips.node.rotateY(Math.PI)
     const humanoid = new VRMHumanoid(bones)
     const vrm = new VRM({
+      ...model,
       humanoid,
       scene: model.scene,
       meta: { name: model.scene.children[0].name } as VRM1Meta


### PR DESCRIPTION
The current building of the retargeted expression manager throws away some details that I need to preserve. It seems to be harmless to preserve these facts...

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
