### PR TITLE
dynamic studio navigation in project page

### DIFF
--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -165,7 +165,7 @@ const ProjectExpansionList = (props: React.PropsWithChildren<{ id: string; summa
   )
 }
 
-const ProjectsPage = () => {
+const ProjectsPage = ({ studioPath }: { studioPath: string }) => {
   const { t } = useTranslation()
   const activeProject = useHookstate<ProjectType | null>(null)
   const activeProjectValue = activeProject.value as ProjectType | null
@@ -254,7 +254,7 @@ const ProjectsPage = () => {
   const onClickExisting = (event, project) => {
     event.preventDefault()
     if (!isInstalled(project)) return
-    navigate(`/studio?project=${project.name}`)
+    navigate(`${studioPath}?project=${project.name}`)
     getMutableState(EditorState).projectName.set(project.name)
     const parsed = new URL(window.location.href)
     const query = parsed.searchParams

--- a/packages/editor/src/pages/EditorPage.tsx
+++ b/packages/editor/src/pages/EditorPage.tsx
@@ -78,7 +78,7 @@ export const EditorPage = () => {
     }
   }, [scenePath])
 
-  if (!scenePath.value && !projectName.value) return <ProjectPage />
+  if (!scenePath.value && !projectName.value) return <ProjectPage studioPath="/studio" />
 
   return <EditorContainer />
 }

--- a/packages/editor/src/pages/ProjectPage.tsx
+++ b/packages/editor/src/pages/ProjectPage.tsx
@@ -30,12 +30,12 @@ import { useRemoveEngineCanvas } from '@etherealengine/client-core/src/hooks/use
 import { EditorNavbar } from '../components/projects/EditorNavbar'
 import Projects from '../components/projects/ProjectsPage'
 
-export const ProjectPage = () => {
+export const ProjectPage = ({ studioPath }: { studioPath: string }) => {
   useRemoveEngineCanvas()
   return (
     <>
       <EditorNavbar />
-      <Projects />
+      <Projects studioPath={studioPath} />
     </>
   )
 }


### PR DESCRIPTION
## Summary

For https://github.com/EtherealEngine/etherealengine/pull/10075, we want to dynamically route `/studio` and `/old-studio`

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
