### PR TITLE
fix not uploading existing projects locally

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -190,7 +190,9 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
     const promises: Promise<any>[] = []
 
     for (const projectName of locallyInstalledProjects) {
+      let seeded = false
       if (!data.find((e) => e.name === projectName)) {
+        seeded = true
         try {
           promises.push(this._seedProject(projectName))
         } catch (e) {
@@ -210,6 +212,8 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
         { enabled, commitSHA, commitDate: toDateTimeSql(commitDate) },
         { query: { name: projectName } }
       )
+
+      if (!seeded) await uploadLocalProjectToProvider(this.app, projectName)
     }
 
     await Promise.all(promises)


### PR DESCRIPTION
## Summary

Running `npm run dev` does not upload all files from the project folder to the storage provider. This means any changes to the project folder manually will not populate to the storage provider, causing a desync. This is a regression from https://github.com/EtherealEngine/etherealengine/pull/10144

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
