### PR TITLE
fix(magic-link): delete previous tokens [IR-2017]

### DIFF
--- a/packages/server-core/src/user/magic-link/magic-link.class.ts
+++ b/packages/server-core/src/user/magic-link/magic-link.class.ts
@@ -188,7 +188,7 @@ export class MagicLinkService implements ServiceInterface<MagicLinkParams> {
     })
     // Keep only the latest token and remove the rest
     if (previousTokens.total > 1) {
-      const tokensToRemove = previousTokens.data.slice(0, -1)
+      const tokensToRemove = previousTokens.data.slice(1)
       for (const token of tokensToRemove) {
         await loginTokenService.remove(token.id)
       }


### PR DESCRIPTION
## Summary

- Delete the previous token, not the current

## Evidence

https://github.com/EtherealEngine/etherealengine/assets/113119956/a488a936-9aa4-4673-a164-48cebcfb1592


## References
[IR-2017](https://tsu.atlassian.net/browse/IR-2017)

## QA Steps

- Sign out
- Use the magic link to sign in
- Create multiple emails
- The most recent one should work correctly, the previous ones should show the invalid token message

[IR-2017]: https://tsu.atlassian.net/browse/IR-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ