### PR TITLE
Remove assetTypeOverride from ModelComponent

### DIFF
--- a/packages/engine/src/assets/classes/AssetLoader.ts
+++ b/packages/engine/src/assets/classes/AssetLoader.ts
@@ -365,7 +365,6 @@ const getAbsolutePath = (url) => (isAbsolutePath(url) ? url : getState(EngineSta
 
 export type LoadingArgs = {
   ignoreDisposeGeometry?: boolean
-  forceAssetType?: AssetType | null
   assetRoot?: Entity
 }
 
@@ -383,7 +382,7 @@ const load = async (
   }
   let url = getAbsolutePath(_url)
 
-  const assetType = args.forceAssetType ? args.forceAssetType : AssetLoader.getAssetType(url)
+  const assetType = AssetLoader.getAssetType(url)
   const loader = getLoader(assetType)
   if (iOS && (assetType === AssetType.PNG || assetType === AssetType.JPEG)) {
     const img = new Image()

--- a/packages/engine/src/scene/components/ModelComponent.tsx
+++ b/packages/engine/src/scene/components/ModelComponent.tsx
@@ -56,7 +56,6 @@ import { VRM } from '@pixiv/three-vrm'
 import { Not } from 'bitecs'
 import React, { FC, useEffect } from 'react'
 import { AnimationMixer, Group, Scene } from 'three'
-import { AssetType } from '../../assets/enum/AssetType'
 import { useGLTF } from '../../assets/functions/resourceLoaderHooks'
 import { GLTF } from '../../assets/loaders/gltf/GLTFLoader'
 import { AnimationComponent } from '../../avatar/components/AnimationComponent'
@@ -82,8 +81,6 @@ export const ModelComponent = defineComponent({
       cameraOcclusion: true,
       /** optional, only for bone matchable avatars */
       convertToVRM: false,
-      // internal
-      assetTypeOverride: null as null | AssetType,
       scene: null as Group | null,
       asset: null as VRM | GLTF | null,
       dereference: false
@@ -119,7 +116,6 @@ function ModelReactor() {
   const modelSceneID = getModelSceneID(entity)
 
   const [gltf, error] = useGLTF(modelComponent.src.value, entity, {
-    forceAssetType: modelComponent.assetTypeOverride.value,
     ignoreDisposeGeometry: modelComponent.cameraOcclusion.value
   })
 


### PR DESCRIPTION
## Summary

This override has been unused for a while aside from in the dev test suite in which it is unnecessary, so we can remove it.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
