### PR TITLE
Fix infinite loading in `VariantComponent`

### DIFF
--- a/packages/editor/src/components/properties/VariantNodeEditor.tsx
+++ b/packages/editor/src/components/properties/VariantNodeEditor.tsx
@@ -27,7 +27,7 @@ import DeblurIcon from '@mui/icons-material/Deblur'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useComponent, useOptionalComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import { getOptionalMutableComponent, useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity, UndefinedEntity } from '@etherealengine/ecs/src/Entity'
 import { AssetLoader } from '@etherealengine/engine/src/assets/classes/AssetLoader'
 import { AssetType } from '@etherealengine/engine/src/assets/enum/AssetType'
@@ -100,7 +100,7 @@ export const VariantNodeEditor: EditorComponentType = (props: { entity: Entity }
 
   const setPreview = (index: number) => {
     previewIndex.set(index)
-    const modelComponent = useOptionalComponent(entity, ModelComponent)
+    const modelComponent = getOptionalMutableComponent(entity, ModelComponent)
     if (!modelComponent) return
     modelComponent.src.set(variantComponent.levels[index].src.value)
   }

--- a/packages/editor/src/components/properties/VariantNodeEditor.tsx
+++ b/packages/editor/src/components/properties/VariantNodeEditor.tsx
@@ -27,7 +27,7 @@ import DeblurIcon from '@mui/icons-material/Deblur'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import { useComponent, useOptionalComponent } from '@etherealengine/ecs/src/ComponentFunctions'
 import { Entity, UndefinedEntity } from '@etherealengine/ecs/src/Entity'
 import { AssetLoader } from '@etherealengine/engine/src/assets/classes/AssetLoader'
 import { AssetType } from '@etherealengine/engine/src/assets/enum/AssetType'
@@ -96,11 +96,12 @@ export const VariantNodeEditor: EditorComponentType = (props: { entity: Entity }
   const { t } = useTranslation()
   const entity = props.entity
   const variantComponent = useComponent(entity, VariantComponent)
-  const modelComponent = useComponent(entity, ModelComponent)
   const previewIndex = useHookstate(0)
 
   const setPreview = (index: number) => {
     previewIndex.set(index)
+    const modelComponent = useOptionalComponent(entity, ModelComponent)
+    if (!modelComponent) return
     modelComponent.src.set(variantComponent.levels[index].src.value)
   }
 


### PR DESCRIPTION
## Summary

Use `useOptionalComponent` instead of `useComponent` in the NodeEditor (for optional components)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
