### PR TITLE
select dropdown arrow and tooltip text centering

### DIFF
--- a/packages/ui/src/primitives/tailwind/Select/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Select/index.tsx
@@ -135,19 +135,19 @@ const Select = <T extends OptionValueType>({
         description={description}
         error={error}
         errorBorder={errorBorder}
-        className={`cursor-pointer ${inputClassName}`}
+        className={twMerge('cursor-pointer', inputClassName)}
         placeholder={placeholder || t('common:select.selectOption')}
         value={selectLabel.value}
         onChange={handleSearch}
         onClick={toggleDropdown}
         onMouseDown={handleMouseDown}
-      />
-      <MdOutlineKeyboardArrowDown
-        size="1.5em"
-        className={`absolute right-3 text-theme-primary transition-transform ${showOptions.value ? 'rotate-180' : ''} ${
-          label ? 'top-8' : 'top-2'
-        }`}
-        onClick={toggleDropdown}
+        endComponent={
+          <MdOutlineKeyboardArrowDown
+            size="1.5em"
+            className={`text-theme-primary transition-transform ${showOptions.value ? 'rotate-180' : ''}`}
+            onClick={toggleDropdown}
+          />
+        }
       />
       <div
         className={`absolute z-10 mt-2 w-full rounded border border-theme-primary bg-theme-surface-main ${

--- a/packages/ui/src/primitives/tailwind/Tooltip/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Tooltip/index.tsx
@@ -42,7 +42,7 @@ const TooltipDirectionClass = {
 
 const Tooltip = ({ title, direction = 'top', children, className }: TooltipProps) => {
   return (
-    <div className="group relative flex items-center justify-center">
+    <div className="group relative flex items-center justify-center text-center">
       {children}
       <span
         className={twMerge(


### PR DESCRIPTION
## Summary

- center the dropdown arrow in tailwind select
- text center the tooltip

## Subtasks Checklist

## Breaking Changes

## References



## QA Steps
