### PR TITLE
IR-2153:  Disable/Enable Publish button based on permissions & Scopes

### DIFF
--- a/packages/editor/src/components/Editor2Container.tsx
+++ b/packages/editor/src/components/Editor2Container.tsx
@@ -27,7 +27,7 @@ import { PopoverState } from '@etherealengine/client-core/src/common/services/Po
 import { useRemoveEngineCanvas } from '@etherealengine/client-core/src/hooks/useRemoveEngineCanvas'
 import { assetPath } from '@etherealengine/common/src/schema.type.module'
 import { EntityUUID } from '@etherealengine/ecs'
-import { getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
+import { NO_PROXY, getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { useFind } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
 import { AssetsPanelTab } from '@etherealengine/ui/src/components/editor/panels/Assets'
 import { FilesPanelTab } from '@etherealengine/ui/src/components/editor/panels/Files'
@@ -53,6 +53,8 @@ import { SaveSceneDialog } from './dialogs/SaveSceneDialog2'
 import { DndWrapper } from './dnd/DndWrapper'
 import DragLayer from './dnd/DragLayer'
 
+import { AuthState } from '@etherealengine/client-core/src/user/services/AuthService'
+import { useProjectPermissions } from '@etherealengine/client-core/src/user/useUserProjectPermission'
 import '@etherealengine/ui/src/fonts/font.css'
 import 'rc-dock/dist/rc-dock.css'
 import './Editor2Container.css'
@@ -123,6 +125,11 @@ const EditorContainer = () => {
 
   useHotkeys(`${cmdOrCtrlString}+s`, () => PopoverState.showPopupover(<SaveSceneDialog />))
 
+  const user = useHookstate(getMutableState(AuthState).user)
+  const hasLocationWriteScope = user.scopes.get(NO_PROXY)?.find((item) => item?.type === 'location:write')
+  const permission = useProjectPermissions(projectName.value!)
+  const hasPublishAccess = hasLocationWriteScope || permission?.type === 'owner' || permission?.type === 'editor'
+
   useEffect(() => {
     const scene = sceneQuery[0]
     if (!scene) return
@@ -156,7 +163,7 @@ const EditorContainer = () => {
       >
         <DndWrapper id="editor-container">
           <DragLayer />
-          <Toolbar />
+          <Toolbar publishSceneDisabled={!hasPublishAccess} />
           <div className="mt-1 flex overflow-hidden">
             <AssetDropZone />
             <DockContainer>

--- a/packages/editor/src/components/Editor2Container.tsx
+++ b/packages/editor/src/components/Editor2Container.tsx
@@ -27,7 +27,7 @@ import { PopoverState } from '@etherealengine/client-core/src/common/services/Po
 import { useRemoveEngineCanvas } from '@etherealengine/client-core/src/hooks/useRemoveEngineCanvas'
 import { assetPath } from '@etherealengine/common/src/schema.type.module'
 import { EntityUUID } from '@etherealengine/ecs'
-import { NO_PROXY, getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { useFind } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
 import { AssetsPanelTab } from '@etherealengine/ui/src/components/editor/panels/Assets'
 import { FilesPanelTab } from '@etherealengine/ui/src/components/editor/panels/Files'
@@ -53,8 +53,6 @@ import { SaveSceneDialog } from './dialogs/SaveSceneDialog2'
 import { DndWrapper } from './dnd/DndWrapper'
 import DragLayer from './dnd/DragLayer'
 
-import { AuthState } from '@etherealengine/client-core/src/user/services/AuthService'
-import { useProjectPermissions } from '@etherealengine/client-core/src/user/useUserProjectPermission'
 import '@etherealengine/ui/src/fonts/font.css'
 import 'rc-dock/dist/rc-dock.css'
 import './Editor2Container.css'
@@ -125,11 +123,6 @@ const EditorContainer = () => {
 
   useHotkeys(`${cmdOrCtrlString}+s`, () => PopoverState.showPopupover(<SaveSceneDialog />))
 
-  const user = useHookstate(getMutableState(AuthState).user)
-  const hasLocationWriteScope = user.scopes.get(NO_PROXY)?.find((item) => item?.type === 'location:write')
-  const permission = useProjectPermissions(projectName.value!)
-  const hasPublishAccess = hasLocationWriteScope || permission?.type === 'owner' || permission?.type === 'editor'
-
   useEffect(() => {
     const scene = sceneQuery[0]
     if (!scene) return
@@ -163,7 +156,7 @@ const EditorContainer = () => {
       >
         <DndWrapper id="editor-container">
           <DragLayer />
-          <Toolbar publishSceneDisabled={!hasPublishAccess} />
+          <Toolbar />
           <div className="mt-1 flex overflow-hidden">
             <AssetDropZone />
             <DockContainer>

--- a/packages/editor/src/components/toolbar/Toolbar2.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar2.tsx
@@ -105,7 +105,11 @@ const generateToolbarMenu = () => {
 
 const toolbarMenu = generateToolbarMenu()
 
-export default function Toolbar() {
+interface Props {
+  publishSceneDisabled: boolean
+}
+
+export default function Toolbar({ publishSceneDisabled }: Props) {
   const { t } = useTranslation()
   const anchorEl = useHookstate<HTMLElement | null>(null)
   const anchorPosition = useHookstate({ left: 0, top: 0 })
@@ -130,7 +134,9 @@ export default function Toolbar() {
           <div className="rounded-2xl px-2.5">{t('editor:toolbar.lbl-simple')}</div>
           <div className="rounded-2xl bg-blue-primary px-2.5">{t('editor:toolbar.lbl-advanced')}</div>
         </div> */}
-        <Button rounded="none">{t('editor:toolbar.lbl-publish')}</Button>
+        <Button rounded="none" disabled={publishSceneDisabled}>
+          {t('editor:toolbar.lbl-publish')}
+        </Button>
       </div>
       <ContextMenu
         anchorEl={anchorEl.value as HTMLElement}

--- a/packages/editor/src/components/toolbar/Toolbar2.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar2.tsx
@@ -26,8 +26,10 @@ Ethereal Engine. All Rights Reserved.
 import { NotificationService } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { PopoverState } from '@etherealengine/client-core/src/common/services/PopoverState'
 import { RouterState } from '@etherealengine/client-core/src/common/services/RouterService'
+import { useProjectPermissions } from '@etherealengine/client-core/src/user/useUserProjectPermission'
+import { useUserHasAccessHook } from '@etherealengine/client-core/src/user/userHasAccess'
 import { GLTFModifiedState } from '@etherealengine/engine/src/gltf/GLTFDocumentState'
-import { getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, getState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import ContextMenu from '@etherealengine/ui/src/components/editor/layout/ContextMenu'
 import Button from '@etherealengine/ui/src/primitives/tailwind/Button'
 import { t } from 'i18next'
@@ -105,15 +107,16 @@ const generateToolbarMenu = () => {
 
 const toolbarMenu = generateToolbarMenu()
 
-interface Props {
-  publishSceneDisabled: boolean
-}
-
-export default function Toolbar({ publishSceneDisabled }: Props) {
+export default function Toolbar() {
   const { t } = useTranslation()
   const anchorEl = useHookstate<HTMLElement | null>(null)
   const anchorPosition = useHookstate({ left: 0, top: 0 })
   const anchorOpen = useHookstate(false)
+
+  const { projectName } = useMutableState(EditorState)
+  const hasLocationWriteScope = useUserHasAccessHook('location:write')
+  const permission = useProjectPermissions(projectName.value!)
+  const hasPublishAccess = hasLocationWriteScope || permission?.type === 'owner' || permission?.type === 'editor'
 
   return (
     <>
@@ -134,7 +137,7 @@ export default function Toolbar({ publishSceneDisabled }: Props) {
           <div className="rounded-2xl px-2.5">{t('editor:toolbar.lbl-simple')}</div>
           <div className="rounded-2xl bg-blue-primary px-2.5">{t('editor:toolbar.lbl-advanced')}</div>
         </div> */}
-        <Button rounded="none" disabled={publishSceneDisabled}>
+        <Button rounded="none" disabled={!hasPublishAccess}>
           {t('editor:toolbar.lbl-publish')}
         </Button>
       </div>


### PR DESCRIPTION
## Summary

This disables/enables the publish button in the tool bar in the new studio UI. 
It is only enable if a user in the owner or an editor, or if the user has location:write scope. 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps