### PR TITLE
IR-1293 click to select mesh objects in scene edit mode

### DIFF
--- a/packages/editor/src/systems/EditorControlSystem.tsx
+++ b/packages/editor/src/systems/EditorControlSystem.tsx
@@ -298,8 +298,12 @@ const execute = () => {
       if (hasComponent(clickedEntity, SourceComponent)) {
         const modelComponent = getAncestorWithComponent(clickedEntity, ModelComponent)
         const ancestorModelEntity = modelComponent || clickedEntity
-
-        SelectionState.updateSelection([getComponent(ancestorModelEntity, UUIDComponent)])
+        SelectionState.updateSelection([
+          getComponent(
+            SelectionState.getSelectedEntities()[0] === ancestorModelEntity ? clickedEntity : ancestorModelEntity,
+            UUIDComponent
+          )
+        ])
       }
     }
   }

--- a/packages/editor/src/systems/EditorControlSystem.tsx
+++ b/packages/editor/src/systems/EditorControlSystem.tsx
@@ -58,7 +58,6 @@ import {
   getAncestorWithComponent
 } from '@etherealengine/spatial/src/transform/components/EntityTree'
 
-import { GLTFComponent } from '@etherealengine/engine/src/gltf/GLTFComponent'
 import { ModelComponent } from '@etherealengine/engine/src/scene/components/ModelComponent'
 import { TransformGizmoControlComponent } from '../classes/TransformGizmoControlComponent'
 import { TransformGizmoControlledComponent } from '../classes/TransformGizmoControlledComponent'
@@ -297,9 +296,9 @@ const execute = () => {
         clickedEntity = getComponent(clickedEntity, EntityTreeComponent).parentEntity!
       }
       if (hasComponent(clickedEntity, SourceComponent)) {
-        const ancestorModelEntity =
-          getAncestorWithComponent(clickedEntity, ModelComponent) ??
-          getAncestorWithComponent(clickedEntity, GLTFComponent)
+        const modelComponent = getAncestorWithComponent(clickedEntity, ModelComponent)
+        const ancestorModelEntity = modelComponent || clickedEntity
+
         SelectionState.updateSelection([getComponent(ancestorModelEntity, UUIDComponent)])
       }
     }

--- a/packages/editor/src/systems/EditorControlSystem.tsx
+++ b/packages/editor/src/systems/EditorControlSystem.tsx
@@ -53,8 +53,13 @@ import { InputComponent } from '@etherealengine/spatial/src/input/components/Inp
 import { InputSourceComponent } from '@etherealengine/spatial/src/input/components/InputSourceComponent'
 import { InfiniteGridComponent } from '@etherealengine/spatial/src/renderer/components/InfiniteGridHelper'
 import { RendererState } from '@etherealengine/spatial/src/renderer/RendererState'
-import { EntityTreeComponent } from '@etherealengine/spatial/src/transform/components/EntityTree'
+import {
+  EntityTreeComponent,
+  getAncestorWithComponent
+} from '@etherealengine/spatial/src/transform/components/EntityTree'
 
+import { GLTFComponent } from '@etherealengine/engine/src/gltf/GLTFComponent'
+import { ModelComponent } from '@etherealengine/engine/src/scene/components/ModelComponent'
 import { TransformGizmoControlComponent } from '../classes/TransformGizmoControlComponent'
 import { TransformGizmoControlledComponent } from '../classes/TransformGizmoControlledComponent'
 import { addMediaNode } from '../functions/addMediaNode'
@@ -292,7 +297,10 @@ const execute = () => {
         clickedEntity = getComponent(clickedEntity, EntityTreeComponent).parentEntity!
       }
       if (hasComponent(clickedEntity, SourceComponent)) {
-        SelectionState.updateSelection([getComponent(clickedEntity, UUIDComponent)])
+        const ancestorModelEntity =
+          getAncestorWithComponent(clickedEntity, ModelComponent) ??
+          getAncestorWithComponent(clickedEntity, GLTFComponent)
+        SelectionState.updateSelection([getComponent(ancestorModelEntity, UUIDComponent)])
       }
     }
   }

--- a/packages/ui/src/components/editor/properties/link/index.tsx
+++ b/packages/ui/src/components/editor/properties/link/index.tsx
@@ -23,16 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PiLinkBreak } from 'react-icons/pi'
 
-import { useComponent } from '@etherealengine/ecs'
+import { getComponent, hasComponent, useComponent, UUIDComponent } from '@etherealengine/ecs'
 import {
-  EditorComponentType,
   commitProperty,
+  EditorComponentType,
   updateProperty
 } from '@etherealengine/editor/src/components/properties/Util'
+import { EditorControlFunctions } from '@etherealengine/editor/src/functions/EditorControlFunctions'
+import {
+  InteractableComponent,
+  XRUIActivationType
+} from '@etherealengine/engine/src/interaction/components/InteractableComponent'
 import { getEntityErrors } from '@etherealengine/engine/src/scene/components/ErrorComponent'
 import { LinkComponent } from '@etherealengine/engine/src/scene/components/LinkComponent'
 import BooleanInput from '../../input/Boolean'
@@ -48,6 +53,23 @@ export const LinkNodeEditor: EditorComponentType = (props) => {
 
   const linkComponent = useComponent(props.entity, LinkComponent)
   const errors = getEntityErrors(props.entity, LinkComponent)
+
+  useEffect(() => {
+    if (!hasComponent(props.entity, InteractableComponent)) {
+      EditorControlFunctions.addOrRemoveComponent([props.entity], InteractableComponent, true, {
+        label: LinkComponent.interactMessage,
+        uiInteractable: false,
+        clickInteract: true,
+        uiActivationType: XRUIActivationType.hover,
+        callbacks: [
+          {
+            callbackID: LinkComponent.linkCallbackName,
+            target: getComponent(props.entity, UUIDComponent)
+          }
+        ]
+      })
+    }
+  }, [])
 
   return (
     <NodeEditor

--- a/packages/ui/src/components/editor/properties/mountPoint/index.tsx
+++ b/packages/ui/src/components/editor/properties/mountPoint/index.tsx
@@ -23,18 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useComponent } from '@etherealengine/ecs'
+import { getComponent, getMutableComponent, hasComponent, useComponent, UUIDComponent } from '@etherealengine/ecs'
 import InputGroup from '@etherealengine/editor/src/components/inputs/InputGroup'
 import {
-  EditorComponentType,
   commitProperty,
+  EditorComponentType,
   updateProperty
 } from '@etherealengine/editor/src/components/properties/Util'
+import { EditorControlFunctions } from '@etherealengine/editor/src/functions/EditorControlFunctions'
+import { InteractableComponent } from '@etherealengine/engine/src/interaction/components/InteractableComponent'
 import { MountPoint, MountPointComponent } from '@etherealengine/engine/src/scene/components/MountPointComponent'
 import { LuUsers2 } from 'react-icons/lu'
+import { Vector3 } from 'three'
 import SelectInput from '../../input/Select'
 import Vector3Input from '../../input/Vector3'
 import NodeEditor from '../nodeEditor'
@@ -48,7 +51,23 @@ export const MountPointNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
 
   const mountComponent = useComponent(props.entity, MountPointComponent)
-
+  const onChangeOffset = (value: Vector3) => {
+    getMutableComponent(props.entity, MountPointComponent).dismountOffset.set(value)
+  }
+  useEffect(() => {
+    if (!hasComponent(props.entity, InteractableComponent)) {
+      const mountPoint = getComponent(props.entity, MountPointComponent)
+      EditorControlFunctions.addOrRemoveComponent([props.entity], InteractableComponent, true, {
+        label: MountPointComponent.mountPointInteractMessages[mountPoint.type],
+        callbacks: [
+          {
+            callbackID: MountPointComponent.mountCallbackName,
+            target: getComponent(props.entity, UUIDComponent)
+          }
+        ]
+      })
+    }
+  }, [])
   return (
     <NodeEditor
       {...props}


### PR DESCRIPTION
## Summary
enabling click to select in scene, fixing interactable issue from studio update


## References
closes [https://tsu.atlassian.net/browse/IR-1293](https://tsu.atlassian.net/browse/IR-1293)

## QA Steps
while in edit mode, try single-clicking on an object with a mesh, it should become your selected entity in the hierarchy view
