### PR TITLE
IR-2441 AddComponent search autofocus

### DIFF
--- a/packages/ui/src/components/editor/input/String/index.tsx
+++ b/packages/ui/src/components/editor/input/String/index.tsx
@@ -31,9 +31,10 @@ export interface StringInputProps extends Omit<InputProps, 'onChange'> {
   value: string
   onChange?: (value: string) => void
   onRelease?: (value: string) => void
+  inputRef?: React.Ref<any>
 }
 
-const StringInput = ({ value, onChange, onRelease, className, ...rest }: StringInputProps) => {
+const StringInput = ({ value, onChange, onRelease, className, inputRef, ...rest }: StringInputProps) => {
   return (
     <Input
       containerClassname="w-50 h-7 bg-[#1A1A1A] rounded"
@@ -51,6 +52,7 @@ const StringInput = ({ value, onChange, onRelease, className, ...rest }: StringI
       onFocus={(e) => {
         onRelease?.(e.target.value)
       }}
+      ref={inputRef}
       {...rest}
     />
   )

--- a/packages/ui/src/components/editor/panels/Properties/elementList/index.tsx
+++ b/packages/ui/src/components/editor/panels/Properties/elementList/index.tsx
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { startCase } from 'lodash'
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Component } from '@etherealengine/ecs/src/ComponentFunctions'
@@ -129,6 +129,11 @@ export function ElementList() {
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const shelves = useComponentShelfCategories(search.query.value)
+  const inputReference = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputReference.current?.focus()
+  }, [])
 
   const onSearch = (text: string) => {
     search.local.set(text)
@@ -147,6 +152,7 @@ export function ElementList() {
             placeholder={t('editor:layout.assetGrid.components-search')}
             value={search.local.value}
             onChange={(val) => onSearch(val)}
+            inputRef={inputReference}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
adding inputRef argument to StringInputProps and StringInput element for new studio. adding auto-focus for search field in elementList/index.tsx

## References
closes [https://tsu.atlassian.net/browse/IR-2441](https://tsu.atlassian.net/browse/IR-2441)

## QA Steps
Click "AddComponent" on an entity in the new studio, the search bar for components should get cursor focus now without requiring the user to click it