### PR TITLE
[IR-2433] studio: fix Create Folder and Download Project buttons

### DIFF
--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -585,18 +585,19 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
 
         <div id="downloadProject" className="flex items-center">
           <Tooltip title={t('editor:layout.filebrowser.downloadProject')} direction="bottom">
-            <Button variant="transparent" startIcon={<FiDownload />} className="p-0" onClick={createNewFolder} />
+            <Button
+              variant="transparent"
+              startIcon={<FiDownload />}
+              className="p-0"
+              onClick={handleDownloadProject}
+              disabled={!showUploadAndDownloadButtons}
+            />
           </Tooltip>
         </div>
 
         <div id="newFolder" className="flex items-center">
           <Tooltip title={t('editor:layout.filebrowser.addNewFolder')} direction="bottom">
-            <Button
-              variant="transparent"
-              startIcon={<PiFolderPlusBold />}
-              className="p-0"
-              onClick={handleDownloadProject}
-            />
+            <Button variant="transparent" startIcon={<PiFolderPlusBold />} className="p-0" onClick={createNewFolder} />
           </Tooltip>
         </div>
 


### PR DESCRIPTION
## Summary
[IR-2433]: Unable to Add a New Folder

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-2433]: https://tsu.atlassian.net/browse/IR-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ