### PR TITLE
IR-2447 MountPoint i18n string config fix

### DIFF
--- a/packages/ui/src/components/editor/properties/mountPoint/index.tsx
+++ b/packages/ui/src/components/editor/properties/mountPoint/index.tsx
@@ -75,7 +75,7 @@ export const MountPointNodeEditor: EditorComponentType = (props) => {
       description={t('editor:properties.mountPoint.description')}
       icon={<LuUsers2 />}
     >
-      <InputGroup name="Mount Type" label={t('editor:properties.mountpoint.lbl-mountType')}>
+      <InputGroup name="Mount Type" label={t('editor:properties.mountPoint.lbl-type')}>
         <SelectInput // we dont know the options and the component for this
           key={props.entity}
           value={mountComponent.type.value}
@@ -83,7 +83,7 @@ export const MountPointNodeEditor: EditorComponentType = (props) => {
           onChange={commitProperty(MountPointComponent, 'type')}
         />
       </InputGroup>
-      <InputGroup name="Dismount Offset" label={t('editor:properties.mountpoint.lbl-dismountOffset')}>
+      <InputGroup name="Dismount Offset" label={t('editor:properties.mountPoint.lbl-dismount')}>
         <Vector3Input
           value={mountComponent.dismountOffset.value}
           onChange={updateProperty(MountPointComponent, 'dismountOffset')}


### PR DESCRIPTION
## Summary
fixing i18n string configuration for new studio editor on MountPoint

## References
closes [https://tsu.atlassian.net/browse/IR-2447](https://tsu.atlassian.net/browse/IR-2447)

## QA Steps
observe MountPoint fields and check that the labels make sense (and do not appear as things like "lbl-offset"