### PR TITLE
Change scene thumbnail css for SVG on new branding changes

### DIFF
--- a/packages/ui/src/components/editor/panels/Scenes/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Scenes/container/index.tsx
@@ -104,7 +104,7 @@ export default function ScenesPanel() {
                       e.currentTarget.src = 'static/ir.svg'
                     }}
                     crossOrigin="anonymous"
-                    className="block h-auto w-full grow cursor-pointer rounded-t-lg object-cover"
+                    className="block h-full grow cursor-pointer self-center rounded-t-lg object-cover"
                     onClick={() => onClickScene(scene)}
                   />
                   <div className="flex items-center justify-between px-4 py-1">


### PR DESCRIPTION
## Before
![image](https://github.com/EtherealEngine/etherealengine/assets/3631206/aa5c60a5-7a4d-4bf9-a563-64536970d8cb)

## After
![image](https://github.com/EtherealEngine/etherealengine/assets/3631206/ee026bf1-60f6-47c1-ae44-0e93f6170ad8)



**Idk why there's the white bars again. It's not from this PR as those screenshots come from manual ir-engine-dev edits**