### PR TITLE
Support project update via GH app JWT

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -355,6 +355,7 @@
         "subtitle": "Edit Authentication Settings"
       },
       "service": "Service",
+      "githubAppId": "App ID (Enter for GitHub App, omit for OAuth App)",
       "secret": "Secret",
       "entity": "Entity",
       "authStrategies": "Authentication Strategies",

--- a/packages/client-core/src/admin/components/project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/project/ProjectTable.tsx
@@ -90,7 +90,7 @@ export default function ProjectTable() {
       await ProjectService.uploadProject({
         sourceURL: projectUpdateStatus.sourceURL,
         destinationURL: projectUpdateStatus.destinationURL,
-        name: projectUpdateStatus.projectName,
+        name: project.name,
         reset: true,
         commitSHA: projectUpdateStatus.selectedSHA,
         sourceBranch: projectUpdateStatus.selectedBranch,

--- a/packages/client-core/src/admin/components/settings/tabs/authentication.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/authentication.tsx
@@ -143,6 +143,16 @@ const AuthenticationTab = forwardRef(({ open }: { open: boolean }, ref: React.Mu
     state.set(temp)
   }
 
+  const handleOnChangeAppId = (event, type) => {
+    keySecret.set({
+      ...JSON.parse(JSON.stringify(keySecret.value)),
+      [type]: {
+        ...JSON.parse(JSON.stringify(keySecret[type].value)),
+        appId: event.target.value
+      }
+    })
+  }
+
   const handleOnChangeKey = (event, type) => {
     keySecret.set({
       ...JSON.parse(JSON.stringify(keySecret.value)),
@@ -370,6 +380,12 @@ const AuthenticationTab = forwardRef(({ open }: { open: boolean }, ref: React.Mu
             <Text component="h4" fontSize="base" fontWeight="medium" className="my-4 w-full">
               {t('admin:components.setting.github')}
             </Text>
+
+            <PasswordInput
+              label={t('admin:components.setting.githubAppId')}
+              value={keySecret?.value?.github?.appId || ''}
+              onChange={(e) => handleOnChangeAppId(e, OAUTH_TYPES.GITHUB)}
+            />
 
             <PasswordInput
               label={t('admin:components.setting.key')}

--- a/packages/client-core/src/admin/services/ProjectUpdateService.ts
+++ b/packages/client-core/src/admin/services/ProjectUpdateService.ts
@@ -72,7 +72,7 @@ export const ProjectUpdateService = {
       sourceProjectName: '',
       sourceVsDestinationChecked: false,
       selectedSHA: '',
-      projectName: '',
+      projectName: projectName,
       submitDisabled: true,
       triggerSetDestination: '',
       updateType: 'none' as ProjectType['updateType'],

--- a/packages/common/src/schemas/projects/project-build.schema.ts
+++ b/packages/common/src/schemas/projects/project-build.schema.ts
@@ -39,7 +39,8 @@ export const ProjectBuildUpdateItemSchema = Type.Object(
     commitSHA: Type.String(),
     sourceBranch: Type.String(),
     updateType: StringEnum(projectUpdateTypes),
-    updateSchedule: Type.String()
+    updateSchedule: Type.String(),
+    token: Type.Optional(Type.Boolean())
   },
   { $id: 'ProjectUpdate', additionalProperties: false }
 )

--- a/packages/common/src/schemas/setting/authentication-setting.schema.ts
+++ b/packages/common/src/schemas/setting/authentication-setting.schema.ts
@@ -89,6 +89,7 @@ export interface AuthDefaultsType extends Static<typeof authDefaultsSchema> {}
 
 export const authAppCredentialsSchema = Type.Object(
   {
+    appId: Type.Optional(Type.String()),
     key: Type.String(),
     secret: Type.String(),
     scope: Type.Optional(Type.Array(Type.String())),

--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -306,6 +306,7 @@ const authentication = {
       secret: process.env.FACEBOOK_CLIENT_SECRET!
     },
     github: {
+      appId: process.env.GITHUB_APP_ID!,
       key: process.env.GITHUB_CLIENT_ID!,
       secret: process.env.GITHUB_CLIENT_SECRET!,
       scope: GITHUB_SCOPES

--- a/packages/server-core/src/hooks/authenticate.ts
+++ b/packages/server-core/src/hooks/authenticate.ts
@@ -24,7 +24,9 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import * as authentication from '@feathersjs/authentication'
+import { NotAuthenticated } from '@feathersjs/errors'
 import { HookContext, NextFunction, Paginated } from '@feathersjs/feathers'
+import { Octokit } from '@octokit/rest'
 import { AsyncLocalStorage } from 'async_hooks'
 import { isProvider } from 'feathers-hooks-common'
 
@@ -32,8 +34,9 @@ import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schem
 import { userPath, UserType } from '@etherealengine/common/src/schemas/user/user.schema'
 import { toDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 
+import { decode, JwtPayload } from 'jsonwebtoken'
+import { Application } from '../../declarations'
 import config from '../appconfig'
-import { Application } from './../../declarations'
 
 const { authenticate } = authentication.hooks
 
@@ -62,6 +65,26 @@ export default async (context: HookContext<Application>, next: NextFunction): Pr
       asyncLocalStorage.enterWith({ user: context.params.user })
     }
 
+    return next()
+  }
+
+  if (context.arguments[1]?.token && context.path === 'project' && context.method === 'update') {
+    const appId = config.authentication.oauth.github.appId ? parseInt(config.authentication.oauth.github.appId) : null
+    const token = context.arguments[1].token
+    const jwtDecoded = decode(token)! as JwtPayload
+    if (jwtDecoded.iss == null || parseInt(jwtDecoded.iss) !== appId)
+      throw new NotAuthenticated('Invalid app credentials')
+    const octokit = new Octokit({ auth: token })
+    let appResponse
+    try {
+      appResponse = await octokit.rest.apps.getAuthenticated()
+    } catch (err) {
+      throw new NotAuthenticated('Invalid app credentials')
+    }
+    if (appResponse.data.id !== appId) throw new NotAuthenticated('App ID of JWT does not match installed App ID')
+    context.params.appJWT = token
+    context.params.signedByAppJWT = true
+    delete context.arguments[1].token
     return next()
   }
 

--- a/packages/server-core/src/hooks/is-signed-by-app-jwt.ts
+++ b/packages/server-core/src/hooks/is-signed-by-app-jwt.ts
@@ -23,7 +23,13 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-export const GITHUB_URL_REGEX = /(?:git@|https:\/\/)([a-zA-Z0-9\-]+:[a-zA-Z0-9_]+@)?github.com[:/](.*)[.git]?/
-export const GITHUB_PER_PAGE = 100
-export const PUBLIC_SIGNED_REGEX = /https:\/\/[\w\d\s\-_]+:[\w\d\s\-_]+@github.com\/([\w\d\s\-_]+)\/([\w\d\s\-_]+).git/
-export const INSTALLATION_SIGNED_REGEX = /https:\/\/oauth2:[\w\d\s\-_]+@github.com\/([\w\d\s\-_]+)\/([\w\d\s\-_]+).git/
+import { HookContext } from '../../declarations'
+
+/**
+ * Hook used to check if request is signed by App JWT
+ */
+export const isSignedByAppJWT = () => {
+  return (context: HookContext) => {
+    return context.params.signedByAppJWT
+  }
+}

--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -67,9 +67,12 @@ const TOKEN_REGEX = /"RemoteAuth ([0-9a-zA-Z-_]+)"/
 const OID_REGEX = /oid sha256:([0-9a-fA-F]{64})/
 const PUSH_TIMEOUT = 60 * 10 //10 minute timeout on GitHub push jobs completing or failing
 
-export const getAuthenticatedRepo = async (token: string, repositoryPath: string) => {
+export const getAuthenticatedRepo = async (token: string, repositoryPath: string, isInstallationToken = false) => {
   try {
     if (!/.git$/.test(repositoryPath)) repositoryPath = repositoryPath + '.git'
+    if (isInstallationToken) {
+      return repositoryPath.replace('https://', `https://oauth2:${token}@`)
+    }
     const user = await getUser(token)
     return repositoryPath.replace('https://', `https://${user.data.login}:${token}@`)
   } catch (error) {

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -64,7 +64,9 @@ const UPDATE_JOB_TIMEOUT = 60 * 5 //5 minute timeout on project update jobs comp
 
 const projectsRootFolder = path.join(appRootPath.path, 'packages/projects/projects/')
 
-export interface ProjectParams extends KnexAdapterParams<ProjectQuery>, ProjectUpdateParams {}
+export interface ProjectParams extends KnexAdapterParams<ProjectQuery>, ProjectUpdateParams {
+  appJWT?: string
+}
 
 export type ProjectParamsClient = Omit<ProjectParams, 'user'>
 

--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
@@ -96,6 +96,7 @@ export async function seed(knex: Knex): Promise<void> {
             secret: process.env.FACEBOOK_CLIENT_SECRET
           },
           github: {
+            appId: process.env.GITHUB_APP_ID,
             key: process.env.GITHUB_CLIENT_ID,
             secret: process.env.GITHUB_CLIENT_SECRET,
             scope: GITHUB_SCOPES


### PR DESCRIPTION
## Summary

Implements functionality for IR-2465

If project.update is called with a GitHub App JWT in the body (passed as 'token'), this will trigger alternative logic in the authenticate hook. It will check that the token comes from the same GH App that's registered with the deployment and that the token is valid. This will bypass user authentication, and put the token on context.params.appJWT.

updateProject will use this token to generate an installation access token for the repo the project is in (throwing an error if the app is not installed such that it can access that repo), then use that token to do the git clone instead of a user OAuth token.

Updated GitHub admin authentication-settings to allow for entry of AppID. Also updated OAuth authentication-setting schema to account for appId.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
