### PR TITLE
fixing context menu position

### DIFF
--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -55,14 +55,10 @@ export const ContextMenu = ({
     if (open && menuRef.current) {
       const menuHeight = menuRef.current.offsetHeight
 
-      // The amount of space that the menu can fill based on the current anchor position
-      const spaceToBottomFromAnchor = window.innerHeight - anchorPosition.top
-      // We want to reposition the context menu whenever it will overflow the bottom of the screen
-      const shouldRepositionMenu = menuHeight > spaceToBottomFromAnchor
-
-      if (shouldRepositionMenu) {
-        // Align the menu bottom with the bottom of the viewport
-        positionY = window.innerHeight - menuHeight - (panel?.getBoundingClientRect().top || 0) + 30
+      // if the panel height is less than the menu height plus the menu pos y offset, we need to move the menu up
+      const offset = panel?.getBoundingClientRect().height! - (menuHeight + positionY)
+      if (offset < 0) {
+        positionY = positionY + offset
       }
     }
 


### PR DESCRIPTION
## Summary
context menu would overflow and be hidden for the lower components
![](https://files.slack.com/files-pri/TM1SNFJKX-F077G5B2CRF/screenshot_2024-06-07_at_10.11.22_am.png)


If this ha
![](https://files.slack.com/files-pri/TM1SNFJKX-F07745LQG1Y/screenshot_2024-06-07_at_11.56.34_am.png)
ppens I now move it up until it fits into the container, if it cant fit it become scrollable 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
