### PR TITLE
[IR-2561] studio: avoid locking studio with generating thumbnails indicator

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1352,5 +1352,9 @@
   "tabs": {
     "scene-assets": "Assets",
     "project-assets": "Project Assets"
+  },
+  "generatingThumbnails": {
+    "title": "Generating Thumbnails",
+    "amountRemaining": "{{count}} remaining"
   }
 }

--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -129,19 +129,12 @@ const ProgressBar = () => {
   return (
     <div
       key="thumbnail-generation-progress-bar"
-      style={{
-        position: 'fixed',
-        width: '100%',
-        height: '100%',
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        justifyContent: 'center',
-        zIndex: 1000,
-        padding: '1em'
-      }}
+      className="pointer-events-none fixed inset-x-0 top-0 z-[1000] m-2 flex justify-center"
     >
-      <div>Generating Thumbnails</div>
-      <div>{thumbnailJobState.length} remaining</div>
+      <div className="flex max-w-[500px] flex-col items-center rounded-md bg-gray-700 bg-opacity-50 px-4 py-2">
+        <div>Generating Thumbnails</div>
+        <div>{thumbnailJobState.length} remaining</div>
+      </div>
     </div>
   )
 }

--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -68,6 +68,7 @@ import { projectResourcesPath } from '@etherealengine/common/src/schemas/media/p
 import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
 import { iterateEntityNode } from '@etherealengine/spatial/src/transform/components/EntityTree'
 import { Paginated } from '@feathersjs/feathers'
+import { useTranslation } from 'react-i18next'
 import { uploadToFeathersService } from '../../util/upload'
 import { getCanvasBlob } from '../utils'
 import { ProgressBarState } from './ProgressBarState'
@@ -125,6 +126,7 @@ const seenThumbnails = new Set<string>()
 
 const ProgressBar = () => {
   const thumbnailJobState = useMutableState(FileThumbnailJobState)
+  const { t } = useTranslation()
 
   return (
     <div
@@ -132,8 +134,8 @@ const ProgressBar = () => {
       className="pointer-events-none fixed inset-x-0 top-0 z-[1000] m-2 flex justify-center"
     >
       <div className="flex max-w-[500px] flex-col items-center rounded-md bg-gray-700 bg-opacity-50 px-4 py-2">
-        <div>Generating Thumbnails</div>
-        <div>{thumbnailJobState.length} remaining</div>
+        <div>{t('editor:generatingThumbnails.title')}</div>
+        <div>{t('editor:generatingThumbnails.amountRemaining', { count: thumbnailJobState.length })}</div>
       </div>
     </div>
   )


### PR DESCRIPTION
# Summary
resolves [IR-2561] by setting pointer-events to 'none' for the ProgressBar.. also reduces height of the component and adds some light styling to avoid overlaying the entire studio with the black bg color

eventually we may want to add additional styling or get rid of this useEffect to avoid showing the ProgressBar altogether:
```
useEffect(() => {
    if (jobState.length > 0) {
      const newJob = jobState[0].get(NO_PROXY)
      currentJob.set(JSON.parse(JSON.stringify(newJob)))
      getMutableState(ProgressBarState)['thumbnail-generation'].set(<ProgressBar />)
    } else {
      getMutableState(ProgressBarState)['thumbnail-generation'].set(none)
      cleanupState()
    }
  }, [jobState.length])
```

[IR-2561]: https://tsu.atlassian.net/browse/IR-2561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ