### PR TITLE
IR-2549: create static resource using project name from request data

### DIFF
--- a/packages/common/src/schemas/media/file-browser.schema.ts
+++ b/packages/common/src/schemas/media/file-browser.schema.ts
@@ -66,7 +66,8 @@ export const fileBrowserPatchSchema = Type.Object(
     fileName: Type.String(),
     body: Type.Any(),
     contentType: Type.String(),
-    storageProviderName: Type.Optional(Type.String())
+    storageProviderName: Type.Optional(Type.String()),
+    project: Type.Optional(Type.String())
   },
   {
     $id: 'FileBrowserPatch'

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -221,7 +221,7 @@ const onImportAsset = async () => {
 
   if (projectName) {
     try {
-      await inputFileWithAddToScene({ projectName })
+      await inputFileWithAddToScene({ projectName, uploadAsProjectFiles: true })
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     }

--- a/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
@@ -66,7 +66,6 @@ import LoadingView from '@etherealengine/ui/src/primitives/tailwind/LoadingView'
 import { SupportedFileTypes } from '../../../constants/AssetTypes'
 import { downloadBlobAsZip, inputFileWithAddToScene } from '../../../functions/assetFunctions'
 import { bytesToSize, unique } from '../../../functions/utils'
-import { EditorState } from '../../../services/EditorServices'
 import BooleanInput from '../../inputs/BooleanInput'
 import InputGroup from '../../inputs/InputGroup'
 import StringInput from '../../inputs/StringInput'
@@ -84,7 +83,7 @@ import { FilePropertiesPanel } from './FilePropertiesPanel'
 type FileBrowserContentPanelProps = {
   onSelectionChanged: (assetSelectionChange: AssetSelectionChangePropsType) => void
   disableDnD?: boolean
-  projectName?: string
+  projectName: string
   selectedFile?: string
   folderName?: string
   nestingDirectory?: string
@@ -132,7 +131,6 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
   const selectedDirectory = useHookstate(originalPath)
   const nestingDirectory = useHookstate(props.nestingDirectory || 'projects')
   const fileProperties = useHookstate<FileType | null>(null)
-  const { projectName } = useMutableState(EditorState)
   const openProperties = useHookstate(false)
   const openCompress = useHookstate(false)
   const openConvert = useHookstate(false)
@@ -621,7 +619,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
           <ToolButton
             tooltip={t('editor:layout.filebrowser.uploadAssets')}
             onClick={async () => {
-              await inputFileWithAddToScene({ directoryPath: selectedDirectory.value, projectName: projectName.value! })
+              await inputFileWithAddToScene({ directoryPath: selectedDirectory.value, projectName: props.projectName })
                 .then(refreshDirectory)
                 .catch((err) => {
                   NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
@@ -66,6 +66,7 @@ import LoadingView from '@etherealengine/ui/src/primitives/tailwind/LoadingView'
 import { SupportedFileTypes } from '../../../constants/AssetTypes'
 import { downloadBlobAsZip, inputFileWithAddToScene } from '../../../functions/assetFunctions'
 import { bytesToSize, unique } from '../../../functions/utils'
+import { EditorState } from '../../../services/EditorServices'
 import BooleanInput from '../../inputs/BooleanInput'
 import InputGroup from '../../inputs/InputGroup'
 import StringInput from '../../inputs/StringInput'
@@ -131,7 +132,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
   const selectedDirectory = useHookstate(originalPath)
   const nestingDirectory = useHookstate(props.nestingDirectory || 'projects')
   const fileProperties = useHookstate<FileType | null>(null)
-
+  const { projectName } = useMutableState(EditorState)
   const openProperties = useHookstate(false)
   const openCompress = useHookstate(false)
   const openConvert = useHookstate(false)
@@ -620,7 +621,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
           <ToolButton
             tooltip={t('editor:layout.filebrowser.uploadAssets')}
             onClick={async () => {
-              await inputFileWithAddToScene({ directoryPath: selectedDirectory.value })
+              await inputFileWithAddToScene({ directoryPath: selectedDirectory.value, projectName: projectName.value! })
                 .then(refreshDirectory)
                 .catch((err) => {
                   NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/editor/src/components/assets/ProjectBrowserPanel.tsx
+++ b/packages/editor/src/components/assets/ProjectBrowserPanel.tsx
@@ -66,7 +66,7 @@ export default function ProjectBrowserPanel() {
                   title: t('editor:layout.filebrowser.tab-name'),
                   content: (
                     <FileBrowserContentPanel
-                      projectName={projectName ?? undefined}
+                      projectName={projectName!}
                       selectedFile={projectName ?? undefined}
                       onSelectionChanged={onSelectionChanged}
                     />

--- a/packages/editor/src/components/toolbar/Toolbar2.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar2.tsx
@@ -49,7 +49,7 @@ const onImportAsset = async () => {
 
   if (projectName) {
     try {
-      await inputFileWithAddToScene({ projectName })
+      await inputFileWithAddToScene({ projectName, uploadAsProjectFiles: true })
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     }

--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -45,14 +45,17 @@ const logger = multiLogger.child({ component: 'editor:assetFunctions' })
 
 /**
  * @param config
+ * @param config.uploadAsProjectFiles will be uploaded to the assets directory of the project
  * @param config.projectName input and upload the file to the assets directory of the project
  * @param config.directoryPath input and upload the file to the `directoryPath`
  */
 export const inputFileWithAddToScene = async ({
+  uploadAsProjectFiles,
   projectName,
   directoryPath
 }: {
-  projectName?: string
+  projectName: string
+  uploadAsProjectFiles?: boolean
   directoryPath?: string
 }): Promise<null> =>
   new Promise((resolve, reject) => {
@@ -68,7 +71,7 @@ export const inputFileWithAddToScene = async ({
         let uploadedURLs: string[] = []
         if (el.files && el.files.length > 0) {
           const files = Array.from(el.files)
-          if (projectName) {
+          if (uploadAsProjectFiles) {
             const importSettings = getState(ImportSettingsState)
             uploadedURLs = (
               await Promise.all(
@@ -104,6 +107,7 @@ export const inputFileWithAddToScene = async ({
                   uploadToFeathersService(fileBrowserUploadPath, [file], {
                     fileName: file.name,
                     path: directoryPath,
+                    project: projectName,
                     contentType: ''
                   }).promise
               )

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.class.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.class.ts
@@ -54,7 +54,8 @@ export class FileBrowserUploadService implements ServiceInterface<string[], File
           fileName: data.fileName,
           path: data.path,
           body: file.buffer as Buffer,
-          contentType: file.mimetype
+          contentType: file.mimetype,
+          project: data.project
         })
       )
     )) as string[]

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -274,9 +274,13 @@ export class FileBrowserService
     checkDirectoryInsideNesting(reducedPath, params?.nestingDirectory)
 
     const reducedPathSplit = reducedPath.split('/')
-    const project = reducedPathSplit.length > 0 && reducedPathSplit[0] === 'projects' ? reducedPathSplit[1] : undefined
+    let project
+    if (data.project) {
+      project = data?.project
+    } else {
+      project = reducedPathSplit.length > 0 && reducedPathSplit[0] === 'projects' ? reducedPathSplit[1] : undefined
+    }
     const key = path.join(reducedPath, name)
-
     await storageProvider.putObject(
       {
         Key: key,

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -78,7 +78,7 @@ import Popover from '../../../layout/Popover'
 import { FileBrowserItem, FileTableWrapper, canDropItemOverFolder } from '../browserGrid'
 
 type FileBrowserContentPanelProps = {
-  projectName?: string
+  projectName: string
   onSelectionChanged: (assetSelectionChange: AssetSelectionChangePropsType) => void
   disableDnD?: boolean
   selectedFile?: string
@@ -140,8 +140,6 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
 
   const filesViewMode = useHookstate(getMutableState(FilesViewModeState).viewMode)
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
-
-  const { projectName } = useMutableState(EditorState)
 
   const page = useHookstate(0)
 
@@ -613,7 +611,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
           className="h-full whitespace-nowrap bg-theme-highlight px-2"
           size="small"
           onClick={async () => {
-            await inputFileWithAddToScene({ directoryPath: selectedDirectory.value, projectName: projectName.value! })
+            await inputFileWithAddToScene({ directoryPath: selectedDirectory.value, projectName: props.projectName })
               .then(refreshDirectory)
               .catch((err) => {
                 NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -54,7 +54,7 @@ import {
   ImageConvertDefaultParms,
   ImageConvertParms
 } from '@etherealengine/engine/src/assets/constants/ImageConvertParms'
-import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { useFind, useMutation, useSearch } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
 import React, { useEffect, useRef } from 'react'
 import { useDrop } from 'react-dnd'
@@ -140,6 +140,8 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
 
   const filesViewMode = useHookstate(getMutableState(FilesViewModeState).viewMode)
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
+
+  const { projectName } = useMutableState(EditorState)
 
   const page = useHookstate(0)
 
@@ -611,7 +613,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
           className="h-full whitespace-nowrap bg-theme-highlight px-2"
           size="small"
           onClick={async () => {
-            await inputFileWithAddToScene({ directoryPath: selectedDirectory.value })
+            await inputFileWithAddToScene({ directoryPath: selectedDirectory.value, projectName: projectName.value! })
               .then(refreshDirectory)
               .catch((err) => {
                 NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -54,7 +54,7 @@ import {
   ImageConvertDefaultParms,
   ImageConvertParms
 } from '@etherealengine/engine/src/assets/constants/ImageConvertParms'
-import { getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import { useFind, useMutation, useSearch } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
 import React, { useEffect, useRef } from 'react'
 import { useDrop } from 'react-dnd'


### PR DESCRIPTION
## Summary

When static resources are uploaded through the file browser service the project field is assigned by splitting the file path 
and using the first segment after project. i.e  for a file with the path `projects/default-project/drop-shadow.png`
the project would be `default-project`, however this approach doesn't work for multi-tenancy projects where the first segment of the path after `projects/` only identifies the account name. To support both single-tenant and multi-tenancy projects the project name is now attached to the request, rather than being extracted from the file path.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

- Go into the studio. 
- Click on Files in the assets sections located at the bottom of the screen 
- Click on Upload Assets 
- Select a new file. 
- Verify in the db the static resource has been created with the appropriate project name. 
