### PR TITLE
Remove unnecessary name overrides in vrm autoconversion

### DIFF
--- a/packages/engine/src/avatar/AvatarBoneMatching.ts
+++ b/packages/engine/src/avatar/AvatarBoneMatching.ts
@@ -680,7 +680,6 @@ export default function avatarBoneMatching(asset: VRM | GLTF): VRM | GLTF {
     if (removeSuffix) boneName = boneName.slice(0, 9) + target.name.slice(10)
     const bone = mixamoVRMRigMap[boneName] as string
     if (bone) {
-      target.name = bone
       bones[bone] = { node: target } as VRMHumanBone
     }
   })


### PR DESCRIPTION
## Summary
removes an unnecessary name override that potentially prevents animation binding working properly, observed in https://github.com/AidanCaruso/mocapbakery

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
