### PR TITLE
Made userId in project-setting.schema.ts optional

### DIFF
--- a/packages/common/src/schemas/setting/project-setting.schema.ts
+++ b/packages/common/src/schemas/setting/project-setting.schema.ts
@@ -46,9 +46,11 @@ export const projectSettingSchema = Type.Object(
     projectId: Type.String({
       format: 'uuid'
     }),
-    userId: TypedString<UserID>({
-      format: 'uuid'
-    }),
+    userId: Type.Optional(
+      TypedString<UserID>({
+        format: 'uuid'
+      })
+    ),
     createdAt: Type.String({ format: 'date-time' }),
     updatedAt: Type.String({ format: 'date-time' })
   },

--- a/packages/server-core/src/projects/project/migrations/20240606125000_migrate-project-settings.ts
+++ b/packages/server-core/src/projects/project/migrations/20240606125000_migrate-project-settings.ts
@@ -26,7 +26,6 @@ Ethereal Engine. All Rights Reserved.
 import type { Knex } from 'knex'
 import { v4 as uuidv4 } from 'uuid'
 
-import { UserID } from '@etherealengine/common/src/schema.type.module'
 import { ProjectDatabaseType, projectPath } from '@etherealengine/common/src/schemas/projects/project.schema'
 import {
   ProjectSettingType,
@@ -62,7 +61,6 @@ const getConvertedProjectSettings = async (projects: ProjectDatabaseType[]) => {
         value: setting.value,
         type: 'private',
         projectId: project.id,
-        userId: '' as UserID,
         createdAt: await getDateTimeSql(),
         updatedAt: await getDateTimeSql()
       })


### PR DESCRIPTION
## Summary

Removed userId from migrate-project-settings because it was erroring out due to not finding any user ID of empty string.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
