### PR TITLE
Added code to prevent default scene files being moved/deleted

### DIFF
--- a/packages/client-core/src/util/upload.tsx
+++ b/packages/client-core/src/util/upload.tsx
@@ -72,12 +72,12 @@ export const uploadToFeathersService = (
             resolve(JSON.parse(request.responseText))
           } else {
             if (aborted) return
+            const errorResponse = JSON.parse(request.responseText)
             console.error('Oh no! There has been an error with the request!', request, e)
             if (status === 403) {
-              const errorResponse = JSON.parse(request.responseText)
               reject(new Error(errorResponse.message))
             } else {
-              reject()
+              reject(errorResponse)
             }
           }
         }

--- a/packages/editor/src/components/dialogs/SaveSceneDialog2.tsx
+++ b/packages/editor/src/components/dialogs/SaveSceneDialog2.tsx
@@ -70,6 +70,7 @@ export const SaveSceneDialog = () => {
       PopoverState.showPopupover(
         <ErrorDialog title={t('editor:savingError')} description={error.message || t('editor:savingErrorMsg')} />
       )
+      throw error
     }
     modalProcessing.set(false)
   }

--- a/packages/server-core/src/assets/asset/asset.hooks.ts
+++ b/packages/server-core/src/assets/asset/asset.hooks.ts
@@ -34,6 +34,7 @@ import { AssetPatch, AssetType } from '@etherealengine/common/src/schemas/assets
 import { ProjectType, projectPath } from '@etherealengine/common/src/schemas/projects/project.schema'
 
 import { HookContext } from '../../../declarations'
+import config from '../../appconfig'
 import { createSkippableHooks } from '../../hooks/createSkippableHooks'
 import enableClientPagination from '../../hooks/enable-client-pagination'
 import projectPermissionAuthenticate from '../../hooks/project-permission-authenticate'
@@ -69,6 +70,9 @@ const removeAssetFiles = async (context: HookContext<AssetService>) => {
 
   const assetURL = asset.assetURL
   const thumbnailURL = asset.thumbnailURL
+
+  if (!config.fsProjectSyncEnabled && assetURL.startsWith('projects/default-project'))
+    throw new BadRequest("You cannot delete assets or scenes in project 'default-project'")
 
   const resourceKeys = thumbnailURL ? [assetURL, thumbnailURL] : [assetURL]
 
@@ -264,6 +268,9 @@ export const renameAsset = async (context: HookContext<AssetService>) => {
   }
 
   const asset = await context.app.service(assetPath).get(context.id!)
+
+  if (!config.fsProjectSyncEnabled && asset.assetURL.startsWith('projects/default-project'))
+    throw new BadRequest("You cannot rename any scenes in project 'default-project'")
 
   const data = context.data! as AssetPatch
 

--- a/packages/server-core/src/assets/asset/default-project-assets.test.ts
+++ b/packages/server-core/src/assets/asset/default-project-assets.test.ts
@@ -1,0 +1,103 @@
+/*
+CPAL-1.0 License
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+The Original Code is Ethereal Engine.
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import assert from 'assert'
+
+import { assetPath } from '@etherealengine/common/src/schema.type.module'
+import { destroyEngine } from '@etherealengine/ecs/src/Engine'
+
+import { Application } from '../../../declarations'
+import config from '../../appconfig'
+import { createFeathersKoaApp } from '../../createApp'
+
+const fsProjectSyncEnabled = config.fsProjectSyncEnabled
+
+describe('asset.test', () => {
+  let app: Application
+  let projectName: string
+  const params = { isInternal: true }
+
+  before(async () => {
+    config.fsProjectSyncEnabled = false
+    app = createFeathersKoaApp()
+    await app.setup()
+    projectName = `default-project`
+  })
+
+  after(async () => {
+    await destroyEngine()
+    config.fsProjectSyncEnabled = fsProjectSyncEnabled
+  })
+
+  it('should not allow patches to default-project files', async () => {
+    const assetResult = await app.service(assetPath).find({
+      query: {
+        assetURL: 'projects/default-project/public/scenes/default.gltf'
+      }
+    })
+
+    const asset = assetResult.data[0]
+
+    assert.rejects(
+      async () =>
+        await app.service(assetPath).patch(
+          asset.id,
+          {
+            assetURL: 'projects/default-project/test/default.gltf',
+            project: projectName
+          },
+          params
+        )
+    )
+  })
+
+  it('should not allow updates to default-project files', async () => {
+    const assetResult = await app.service(assetPath).find({
+      query: {
+        assetURL: 'projects/default-project/public/scenes/apartment.gltf'
+      }
+    })
+
+    const asset = assetResult.data[0]
+
+    assert.rejects(async () =>
+      app.service(assetPath).update(
+        asset.id,
+        {
+          assetURL: 'projects/default-project/public/scenes/default.gltf',
+          project: projectName
+        },
+        params
+      )
+    )
+  })
+
+  it('should not allow deletions of default-project files', async () => {
+    const assetResult = await app.service(assetPath).find({
+      query: {
+        assetURL: 'projects/default-project/public/scenes/sky-station.gltf'
+      }
+    })
+
+    const asset = assetResult.data[0]
+
+    assert.rejects(async () => app.service(assetPath).remove(asset.id, params))
+  })
+})

--- a/packages/server-core/src/media/file-browser/default-project-file-browser.test.ts
+++ b/packages/server-core/src/media/file-browser/default-project-file-browser.test.ts
@@ -1,0 +1,92 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import assert from 'assert'
+
+import { fileBrowserPath } from '@etherealengine/common/src/schemas/media/file-browser.schema'
+import { destroyEngine } from '@etherealengine/ecs/src/Engine'
+
+import { Application } from '../../../declarations'
+import config from '../../appconfig'
+import { createFeathersKoaApp } from '../../createApp'
+
+const fsProjectSyncEnabled = config.fsProjectSyncEnabled
+
+const PREFIX = 'test'
+
+const getRandomizedName = (name: string, suffix = '', prefix = PREFIX) =>
+  `${prefix}-${name}-${(Math.random() + 1).toString(36).substring(7)}${suffix}`
+
+/**prepends `projects` and appends `/` for directory paths */
+const getDirectoryPath = (name: string) => 'projects/' + name + '/'
+
+describe('file-browser.test', () => {
+  let app: Application
+  before(async () => {
+    config.fsProjectSyncEnabled = false
+    app = createFeathersKoaApp()
+    await app.setup()
+  })
+
+  after(async () => {
+    await destroyEngine()
+    config.fsProjectSyncEnabled = fsProjectSyncEnabled
+  })
+
+  it('should not allow default-project files to be moved', async () => {
+    const oldName = 'default.gltf'
+    const oldPath = 'projects/default-project/public/scenes'
+    const newName = 'defaults.gltf'
+    const newPath = 'projects/default-project/test'
+    const isCopy = false
+    assert.rejects(app.service(fileBrowserPath).update(null, { oldName, newName, oldPath, newPath, isCopy }))
+  })
+
+  it('should allow default-project files to be copied', async () => {
+    const oldName = 'default.gltf'
+    const oldPath = 'projects/default-project/public/scenes'
+    const newName = 'defaults.gltf'
+    const newPath = 'projects/default-project/test'
+    const isCopy = true
+    await app.service(fileBrowserPath).update(null, { oldName, newName, oldPath, newPath, isCopy })
+  })
+
+  it('should not allow default-project files to be patched', async () => {
+    const newData = getRandomizedName('new data')
+    const body = Buffer.from(newData, 'utf-8')
+    assert.rejects(
+      app.service(fileBrowserPath).patch(null, {
+        fileName: 'default.gltf',
+        path: getDirectoryPath('projects/default-project/public/scenes/'),
+        body,
+        contentType: 'any'
+      })
+    )
+  })
+
+  it('should not allow default-project files to be deleted', async () => {
+    assert.rejects(app.service(fileBrowserPath).remove('projects/default-project/public/scenes/default.gltf'))
+  })
+})

--- a/packages/ui/src/components/editor/panels/Files/browserGrid/RenameFileModal.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/RenameFileModal.tsx
@@ -38,16 +38,22 @@ export default function RenameFileModal({ file }: { file: FileDataType }) {
   const { t } = useTranslation()
   const newFileName = useHookstate(file.name)
   const fileService = useMutation(fileBrowserPath)
+  const error = useHookstate('')
 
   const handleSubmit = async () => {
-    fileService.update(null, {
-      oldName: file.fullName,
-      newName: file.isFolder ? newFileName.value : `${newFileName.value}.${file.type}`,
-      oldPath: file.path,
-      newPath: file.path,
-      isCopy: false
-    })
-    PopoverState.hidePopupover()
+    try {
+      await fileService.update(null, {
+        oldName: file.fullName,
+        newName: file.isFolder ? newFileName.value : `${newFileName.value}.${file.type}`,
+        oldPath: file.path,
+        newPath: file.path,
+        isCopy: false
+      })
+      PopoverState.hidePopupover()
+    } catch (err) {
+      console.error(err)
+      error.set(err.message)
+    }
   }
 
   return (
@@ -57,6 +63,7 @@ export default function RenameFileModal({ file }: { file: FileDataType }) {
       onSubmit={handleSubmit}
       onClose={PopoverState.hidePopupover}
     >
+      {error.value && <p className="mt-2 text-red-700">{error.value}</p>}
       <Input value={newFileName.value} onChange={(event) => newFileName.set(event.target.value)} />
     </Modal>
   )

--- a/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
@@ -23,6 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+import { NotificationService } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { PopoverState } from '@etherealengine/client-core/src/common/services/PopoverState'
 import { fileBrowserPath, staticResourcePath } from '@etherealengine/common/src/schema.type.module'
 import {
@@ -278,14 +279,19 @@ export function FileBrowserItem({
   const pasteContent = async () => {
     handleClose()
 
-    if (isFilesLoading) return
-    fileService.update(null, {
-      oldName: currentContent.current.item.fullName,
-      newName: currentContent.current.item.fullName,
-      oldPath: currentContent.current.item.path,
-      newPath: item.isFolder ? item.path + item.fullName : item.path,
-      isCopy: currentContent.current.isCopy
-    })
+    try {
+      if (isFilesLoading) return
+      await fileService.update(null, {
+        oldName: currentContent.current.item.fullName,
+        newName: currentContent.current.item.fullName,
+        oldPath: currentContent.current.item.path,
+        newPath: item.isFolder ? item.path + item.fullName : item.path,
+        isCopy: currentContent.current.isCopy
+      })
+    } catch (err) {
+      console.error(err)
+      NotificationService.dispatchNotify(err.message, { variant: 'error' })
+    }
   }
 
   const viewAssetProperties = () => {

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -28,8 +28,8 @@ import { NotificationService } from '@etherealengine/client-core/src/common/serv
 import { uploadToFeathersService } from '@etherealengine/client-core/src/util/upload'
 import config from '@etherealengine/common/src/config'
 import {
-  FileBrowserContentType,
   archiverPath,
+  FileBrowserContentType,
   fileBrowserPath,
   fileBrowserUploadPath,
   staticResourcePath
@@ -39,9 +39,9 @@ import { processFileName } from '@etherealengine/common/src/utils/processFileNam
 import { Engine } from '@etherealengine/ecs'
 import { AssetSelectionChangePropsType } from '@etherealengine/editor/src/components/assets/AssetsPreviewPanel'
 import {
+  availableTableColumns,
   FilesViewModeSettings,
-  FilesViewModeState,
-  availableTableColumns
+  FilesViewModeState
 } from '@etherealengine/editor/src/components/assets/FileBrowser/FileBrowserState'
 import { FileDataType } from '@etherealengine/editor/src/components/assets/FileBrowser/FileDataType'
 import { DndWrapper } from '@etherealengine/editor/src/components/dnd/DndWrapper'
@@ -75,7 +75,7 @@ import Tooltip from '../../../../../primitives/tailwind/Tooltip'
 import BooleanInput from '../../../input/Boolean'
 import InputGroup from '../../../input/Group'
 import Popover from '../../../layout/Popover'
-import { FileBrowserItem, FileTableWrapper, canDropItemOverFolder } from '../browserGrid'
+import { canDropItemOverFolder, FileBrowserItem, FileTableWrapper } from '../browserGrid'
 
 type FileBrowserContentPanelProps = {
   projectName?: string

--- a/packages/ui/src/components/editor/panels/Scenes/modals/RenameScene.tsx
+++ b/packages/ui/src/components/editor/panels/Scenes/modals/RenameScene.tsx
@@ -38,13 +38,19 @@ import Modal from '../../../../../primitives/tailwind/Modal'
 export default function RenameSceneModal({ sceneName, scene }: { sceneName: string; scene: AssetType }) {
   const { t } = useTranslation()
   const newSceneName = useHookstate(sceneName)
+  const error = useHookstate('')
 
   const handleSubmit = async () => {
     const currentURL = scene.assetURL
     const newURL = currentURL.replace(currentURL.split('/').pop()!, newSceneName.value + '.gltf')
-    const newData = await renameScene(scene.id, newURL, scene.projectName)
-    getMutableState(EditorState).scenePath.set(newData.assetURL)
-    PopoverState.hidePopupover()
+    try {
+      const newData = await renameScene(scene.id, newURL, scene.projectName)
+      getMutableState(EditorState).scenePath.set(newData.assetURL)
+      PopoverState.hidePopupover()
+    } catch (err) {
+      console.error('rename scene error', err)
+      error.set(err.message)
+    }
   }
 
   return (
@@ -54,6 +60,7 @@ export default function RenameSceneModal({ sceneName, scene }: { sceneName: stri
       onSubmit={handleSubmit}
       onClose={PopoverState.hidePopupover}
     >
+      {error.value && <p className="mt-2 text-red-700">{error.value}</p>}
       <Input value={newSceneName.value} onChange={(event) => newSceneName.set(event.target.value)} />
     </Modal>
   )


### PR DESCRIPTION
## Summary

Since new scene creation runs off of default-project/public/scenes/default.gltf, if this file has been moved, scene creation will break. The backend now disallows moving or deleting this scene and its related files.

Resolves IR-2566.


## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
