### PR TITLE
IR-2554 Facer Component

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -268,6 +268,11 @@
         "lbl-callbackID": "Callback ID"
       }
     },
+    "facer": {
+      "name": "Facer",
+      "description": "A facer component that makes the entity always face the user, or another entity",
+      "target": "Target Entity"
+    },
     "grabbable": {
       "name": "Grabbable",
       "description": "A grabbable component that can be picked up and manipulated by the user"

--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -271,7 +271,9 @@
     "facer": {
       "name": "Facer",
       "description": "A facer component that makes the entity always face the user, or another entity",
-      "target": "Target Entity"
+      "target": "Target Entity",
+      "xAxis": "X Axis",
+      "yAxis": "Y Axis"
     },
     "grabbable": {
       "name": "Grabbable",

--- a/packages/editor/src/services/ComponentEditors.tsx
+++ b/packages/editor/src/services/ComponentEditors.tsx
@@ -95,11 +95,13 @@ import { NewVolumetricComponent } from '@etherealengine/engine/src/scene/compone
 import { PlaylistComponent } from '@etherealengine/engine/src/scene/components/PlaylistComponent'
 import { InputComponent } from '@etherealengine/spatial/src/input/components/InputComponent'
 import { ColliderComponent } from '@etherealengine/spatial/src/physics/components/ColliderComponent'
+import { FacerComponent } from '@etherealengine/spatial/src/transform/components/FacerComponent'
 import LoopAnimationNodeEditor from '@etherealengine/ui/src/components/editor/properties/animation'
 import CameraPropertiesNodeEditor from '@etherealengine/ui/src/components/editor/properties/camera'
 import ColliderComponentEditor from '@etherealengine/ui/src/components/editor/properties/collider'
 import EnvMapEditor from '@etherealengine/ui/src/components/editor/properties/envmap'
 import EnvMapBakeNodeEditor from '@etherealengine/ui/src/components/editor/properties/envMapBake'
+import FacerNodeEditor from '@etherealengine/ui/src/components/editor/properties/facer'
 import GroundPlaneNodeEditor from '@etherealengine/ui/src/components/editor/properties/groundPlane'
 import ImageNodeEditor from '@etherealengine/ui/src/components/editor/properties/image'
 import AmbientLightNodeEditor from '@etherealengine/ui/src/components/editor/properties/light/ambient'
@@ -184,7 +186,8 @@ export const ComponentEditorsState = defineState({
       [InputComponent.name]: InputComponentNodeEditor,
       [GrabbableComponent.name]: GrabbableComponentNodeEditor,
       [ScreenshareTargetComponent.name]: ScreenshareTargetNodeEditor,
-      [TextComponent.name]: TextNodeEditor
+      [TextComponent.name]: TextNodeEditor,
+      [FacerComponent.name]: FacerNodeEditor
     } as Record<string, EditorComponentType>
   }
 })

--- a/packages/editor/src/services/ComponentShelfCategoriesState.ts
+++ b/packages/editor/src/services/ComponentShelfCategoriesState.ts
@@ -73,6 +73,7 @@ import { RigidBodyComponent } from '@etherealengine/spatial/src/physics/componen
 import { TriggerComponent } from '@etherealengine/spatial/src/physics/components/TriggerComponent'
 import { GroupComponent } from '@etherealengine/spatial/src/renderer/components/GroupComponent'
 import { PostProcessingComponent } from '@etherealengine/spatial/src/renderer/components/PostProcessingComponent'
+import { FacerComponent } from '@etherealengine/spatial/src/transform/components/FacerComponent'
 
 export const ComponentShelfCategoriesState = defineState({
   name: 'ee.editor.ComponentShelfCategories',
@@ -128,7 +129,8 @@ export const ComponentShelfCategoriesState = defineState({
         SplineTrackComponent,
         SplineComponent,
         TextComponent,
-        ScreenshareTargetComponent
+        ScreenshareTargetComponent,
+        FacerComponent
       ]
     } as Record<string, Component[]>
   }

--- a/packages/engine/src/scene/components/ParticleSystemComponent.ts
+++ b/packages/engine/src/scene/components/ParticleSystemComponent.ts
@@ -28,6 +28,7 @@ import {
   AdditiveBlending,
   Blending,
   BufferGeometry,
+  DoubleSide,
   Material,
   MeshBasicMaterial,
   Object3D,
@@ -847,17 +848,18 @@ export const ParticleSystemComponent = defineComponent({
     const [dudMaterial] = useDisposable(MeshBasicMaterial, entity, {
       color: 0xffffff,
       transparent: componentState.value.systemParameters.transparent ?? true,
-      blending: componentState.value.systemParameters.blending as Blending
+      blending: componentState.value.systemParameters.blending as Blending,
+      side: DoubleSide
     })
     //@todo: this is a hack to make trail rendering mode work correctly. We need to find out why an additional snapshot is needed
     useEffect(() => {
       if (rootGLTF?.value?.progress !== 100) return
       if (refreshed.value) return
 
-      if (componentState.systemParameters.renderMode.value === RenderMode.Trail) {
-        const snapshot = GLTFSnapshotState.cloneCurrentSnapshot(sceneID!)
-        dispatchAction(GLTFSnapshotAction.createSnapshot(snapshot))
-      }
+      //if (componentState.systemParameters.renderMode.value === RenderMode.Trail) {
+      const snapshot = GLTFSnapshotState.cloneCurrentSnapshot(sceneID!)
+      dispatchAction(GLTFSnapshotAction.createSnapshot(snapshot))
+      //}
       refreshed.set(true)
     }, [rootGLTF?.value?.progress])
 

--- a/packages/spatial/src/transform/components/FacerComponent.ts
+++ b/packages/spatial/src/transform/components/FacerComponent.ts
@@ -1,0 +1,17 @@
+import { EntityUUID, defineComponent } from '@etherealengine/ecs'
+import { matches } from '@etherealengine/hyperflux'
+export const FacerComponent = defineComponent({
+  name: 'FacerComponent',
+  jsonID: 'IR_facer',
+  onInit: (entity) => ({
+    target: null as EntityUUID | null
+  }),
+  onSet: (entity, component, props) => {
+    if (matches.string.test(props?.target)) {
+      component.target.set(props.target)
+    }
+  },
+  toJSON: (entity, component) => ({
+    target: component.target.value
+  })
+})

--- a/packages/spatial/src/transform/components/FacerComponent.ts
+++ b/packages/spatial/src/transform/components/FacerComponent.ts
@@ -29,14 +29,30 @@ export const FacerComponent = defineComponent({
   name: 'FacerComponent',
   jsonID: 'IR_facer',
   onInit: (entity) => ({
-    target: null as EntityUUID | null
+    target: null as EntityUUID | null,
+    axes: {
+      x: true,
+      y: true
+    }
   }),
   onSet: (entity, component, props) => {
     if (matches.string.test(props?.target)) {
       component.target.set(props.target)
     }
+    if (matches.object.test(props?.axes)) {
+      if (matches.boolean.test(props.axes.x)) {
+        component.axes.x.set(props.axes.x)
+      }
+      if (matches.boolean.test(props.axes.y)) {
+        component.axes.y.set(props.axes.y)
+      }
+    }
   },
   toJSON: (entity, component) => ({
-    target: component.target.value
+    target: component.target.value,
+    axes: {
+      x: component.axes.x.value,
+      y: component.axes.y.value
+    }
   })
 })

--- a/packages/spatial/src/transform/components/FacerComponent.ts
+++ b/packages/spatial/src/transform/components/FacerComponent.ts
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
 import { EntityUUID, defineComponent } from '@etherealengine/ecs'
 import { matches } from '@etherealengine/hyperflux'
 export const FacerComponent = defineComponent({

--- a/packages/spatial/src/transform/components/FacerComponent.ts
+++ b/packages/spatial/src/transform/components/FacerComponent.ts
@@ -24,7 +24,6 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { EntityUUID, defineComponent } from '@etherealengine/ecs'
-import { matches } from '@etherealengine/hyperflux'
 export const FacerComponent = defineComponent({
   name: 'FacerComponent',
   jsonID: 'IR_facer',
@@ -36,14 +35,14 @@ export const FacerComponent = defineComponent({
     }
   }),
   onSet: (entity, component, props) => {
-    if (matches.string.test(props?.target)) {
+    if (typeof props?.target === 'string') {
       component.target.set(props.target)
     }
-    if (matches.object.test(props?.axes)) {
-      if (matches.boolean.test(props.axes.x)) {
+    if (typeof props?.axes === 'object') {
+      if (typeof props.axes.x === 'boolean') {
         component.axes.x.set(props.axes.x)
       }
-      if (matches.boolean.test(props.axes.y)) {
+      if (typeof props.axes.y === 'boolean') {
         component.axes.y.set(props.axes.y)
       }
     }

--- a/packages/spatial/src/transform/components/FacerComponent.ts
+++ b/packages/spatial/src/transform/components/FacerComponent.ts
@@ -29,29 +29,23 @@ export const FacerComponent = defineComponent({
   jsonID: 'IR_facer',
   onInit: (entity) => ({
     target: null as EntityUUID | null,
-    axes: {
-      x: true,
-      y: true
-    }
+    xAxis: true,
+    yAxis: true
   }),
   onSet: (entity, component, props) => {
     if (typeof props?.target === 'string') {
       component.target.set(props.target)
     }
-    if (typeof props?.axes === 'object') {
-      if (typeof props.axes.x === 'boolean') {
-        component.axes.x.set(props.axes.x)
-      }
-      if (typeof props.axes.y === 'boolean') {
-        component.axes.y.set(props.axes.y)
-      }
+    if (typeof props?.xAxis === 'boolean') {
+      component.xAxis.set(props.xAxis)
+    }
+    if (typeof props?.yAxis === 'boolean') {
+      component.yAxis.set(props.yAxis)
     }
   },
   toJSON: (entity, component) => ({
     target: component.target.value,
-    axes: {
-      x: component.axes.x.value,
-      y: component.axes.y.value
-    }
+    xAxis: component.xAxis.value,
+    yAxis: component.yAxis.value
   })
 })

--- a/packages/spatial/src/transform/systems/FacerSystem.ts
+++ b/packages/spatial/src/transform/systems/FacerSystem.ts
@@ -1,0 +1,31 @@
+import { Engine, Entity, UUIDComponent, defineQuery, defineSystem, getComponent } from '@etherealengine/ecs'
+import { Matrix4, Quaternion, Vector3 } from 'three'
+import { FacerComponent } from '../components/FacerComponent'
+import { TransformComponent } from '../components/TransformComponent'
+import { TransformSystem } from './TransformSystem'
+
+const facerQuery = defineQuery([FacerComponent, TransformComponent])
+const srcPosition = new Vector3()
+const dstPosition = new Vector3()
+const up = new Vector3(0, 1, 0)
+const lookMatrix = new Matrix4()
+const lookRotation = new Quaternion()
+
+export const FacerSystem = defineSystem({
+  uuid: 'ir.spatial.FacerSystem',
+  insert: { before: TransformSystem },
+  execute: () => {
+    const viewerEntity = Engine.instance.viewerEntity
+    for (const entity of facerQuery()) {
+      const facer = getComponent(entity, FacerComponent)
+      const targetEntity: Entity | null = facer.target ? UUIDComponent.getEntityByUUID(facer.target) : viewerEntity
+      if (!targetEntity) continue
+      TransformComponent.getWorldPosition(entity, srcPosition)
+      TransformComponent.getWorldPosition(targetEntity, dstPosition)
+      lookMatrix.lookAt(srcPosition, dstPosition, up)
+      lookRotation.setFromRotationMatrix(lookMatrix)
+      TransformComponent.setWorldRotation(entity, lookRotation)
+      TransformComponent.updateFromWorldMatrix(entity)
+    }
+  }
+})

--- a/packages/spatial/src/transform/systems/FacerSystem.ts
+++ b/packages/spatial/src/transform/systems/FacerSystem.ts
@@ -32,6 +32,8 @@ import { TransformSystem } from './TransformSystem'
 const facerQuery = defineQuery([FacerComponent, TransformComponent])
 const srcPosition = new Vector3()
 const dstPosition = new Vector3()
+const direction = new Vector3()
+const zero = new Vector3()
 const up = new Vector3(0, 1, 0)
 const lookMatrix = new Matrix4()
 const lookRotation = new Quaternion()
@@ -47,7 +49,15 @@ export const FacerSystem = defineSystem({
       if (!targetEntity) continue
       TransformComponent.getWorldPosition(entity, srcPosition)
       TransformComponent.getWorldPosition(targetEntity, dstPosition)
-      lookMatrix.lookAt(srcPosition, dstPosition, up)
+      direction.subVectors(dstPosition, srcPosition).normalize()
+      // look at target about enabled axes
+      if (!facer.axes.x) {
+        direction.y = 0
+      }
+      if (!facer.axes.y) {
+        direction.x = 0
+      }
+      lookMatrix.lookAt(zero, direction, up)
       lookRotation.setFromRotationMatrix(lookMatrix)
       TransformComponent.setWorldRotation(entity, lookRotation)
       TransformComponent.updateFromWorldMatrix(entity)

--- a/packages/spatial/src/transform/systems/FacerSystem.ts
+++ b/packages/spatial/src/transform/systems/FacerSystem.ts
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
 import { Engine, Entity, UUIDComponent, defineQuery, defineSystem, getComponent } from '@etherealengine/ecs'
 import { Matrix4, Quaternion, Vector3 } from 'three'
 import { FacerComponent } from '../components/FacerComponent'

--- a/packages/spatial/src/transform/systems/FacerSystem.ts
+++ b/packages/spatial/src/transform/systems/FacerSystem.ts
@@ -51,10 +51,10 @@ export const FacerSystem = defineSystem({
       TransformComponent.getWorldPosition(targetEntity, dstPosition)
       direction.subVectors(dstPosition, srcPosition).normalize()
       // look at target about enabled axes
-      if (!facer.axes.x) {
+      if (!facer.xAxis) {
         direction.y = 0
       }
-      if (!facer.axes.y) {
+      if (!facer.yAxis) {
         direction.x = 0
       }
       lookMatrix.lookAt(zero, direction, up)

--- a/packages/ui/src/components/editor/input/Node/index.stories.tsx
+++ b/packages/ui/src/components/editor/input/Node/index.stories.tsx
@@ -23,8 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { SpawnPoseState } from './SpawnPoseState'
-import { FacerSystem } from './systems/FacerSystem'
-import { TransformSystem } from './systems/TransformSystem'
+import Component from './index'
 
-export { SpawnPoseState, TransformSystem, FacerSystem }
+const argTypes = {}
+
+export default {
+  title: 'Editor/Input/Model',
+  component: Component,
+  parameters: {
+    componentSubtitle: 'ModelInput',
+    jest: 'Model.test.tsx',
+    design: {
+      type: 'figma',
+      url: ''
+    }
+  },
+  argTypes
+}
+export const Default = { args: Component.defaultProps }

--- a/packages/ui/src/components/editor/input/Node/index.tsx
+++ b/packages/ui/src/components/editor/input/Node/index.tsx
@@ -23,8 +23,37 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { SpawnPoseState } from './SpawnPoseState'
-import { FacerSystem } from './systems/FacerSystem'
-import { TransformSystem } from './systems/TransformSystem'
+import { Entity, EntityUUID, UUIDComponent, getComponent } from '@etherealengine/ecs'
+import { ItemTypes } from '@etherealengine/editor/src/constants/AssetTypes'
+import React from 'react'
+import { useDrop } from 'react-dnd'
+import { InputProps } from '../../../../primitives/tailwind/Input'
+import { ControlledStringInput } from '../String'
 
-export { SpawnPoseState, TransformSystem, FacerSystem }
+export interface NodeInputProps extends Omit<InputProps, 'onChange'> {
+  value: EntityUUID
+  onChange?: (value: EntityUUID) => void
+  onRelease?: (value: EntityUUID) => void
+  inputRef?: React.Ref<any>
+}
+
+export function NodeInput({ onRelease, value, ...rest }: NodeInputProps) {
+  const [{ canDrop, isOver }, dropRef] = useDrop({
+    accept: [ItemTypes.Node],
+    async drop(item: any, monitor) {
+      const entity: Entity = item.value as Entity
+      const uuid = getComponent(entity, UUIDComponent)
+      onRelease?.(uuid)
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop()
+    })
+  })
+
+  return <ControlledStringInput ref={dropRef} value={value} {...rest} />
+}
+
+NodeInput.defaultProps = {}
+
+export default NodeInput

--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -161,8 +161,27 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
     [expandedNodes]
   )
 
-  /* Event handlers */
-  const onMouseDown = useCallback(
+  const onContextMenu = (event: React.MouseEvent<HTMLDivElement>, item: HeirarchyTreeNodeType) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    setContextSelectedItem(item)
+    setAnchorEl(event.currentTarget)
+    setAnchorPosition({
+      left: event.clientX + 2,
+      top: event.clientY - 6
+    })
+  }
+
+  const handleClose = () => {
+    setContextSelectedItem(undefined)
+    setAnchorEl(null)
+    setAnchorPosition({ left: 0, top: 0 })
+  }
+
+  const onMouseDown = useCallback((e: React.MouseEvent, node: HeirarchyTreeNodeType) => {}, [])
+
+  const onClick = useCallback(
     (e: MouseEvent, node: HeirarchyTreeNodeType) => {
       if (e.detail === 1) {
         if (e.ctrlKey) {
@@ -183,36 +202,14 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
           }
         }
         setPrevClickedNode(node)
+      } else if (e.detail === 2) {
+        const editorCameraState = getMutableComponent(Engine.instance.cameraEntity, CameraOrbitComponent)
+        editorCameraState.focusedEntities.set([node.entity])
+        editorCameraState.refocus.set(true)
       }
     },
     [prevClickedNode, entityHierarchy]
   )
-
-  const onContextMenu = (event: React.MouseEvent<HTMLDivElement>, item: HeirarchyTreeNodeType) => {
-    event.preventDefault()
-    event.stopPropagation()
-
-    setContextSelectedItem(item)
-    setAnchorEl(event.currentTarget)
-    setAnchorPosition({
-      left: event.clientX + 2,
-      top: event.clientY - 6
-    })
-  }
-
-  const handleClose = () => {
-    setContextSelectedItem(undefined)
-    setAnchorEl(null)
-    setAnchorPosition({ left: 0, top: 0 })
-  }
-
-  const onClick = useCallback((e: MouseEvent, node: HeirarchyTreeNodeType) => {
-    if (e.detail === 2) {
-      const editorCameraState = getMutableComponent(Engine.instance.cameraEntity, CameraOrbitComponent)
-      editorCameraState.focusedEntities.set([node.entity])
-      editorCameraState.refocus.set(true)
-    }
-  }, [])
 
   const onToggle = useCallback(
     (_, node: HeirarchyTreeNodeType) => {

--- a/packages/ui/src/components/editor/panels/Hierarchy/node/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/node/index.tsx
@@ -148,12 +148,20 @@ export const HierarchyTreeNode = (props: HierarchyTreeNodeProps) => {
     type: ItemTypes.Node,
     item() {
       const selectedEntities = SelectionState.getSelectedEntities()
-      const multiple = selectedEntities.length > 1
 
-      return {
-        type: ItemTypes.Node,
-        multiple,
-        value: multiple ? selectedEntities : selectedEntities[0]
+      if (selectedEntities.includes(node.entity)) {
+        const multiple = selectedEntities.length > 1
+        return {
+          type: ItemTypes.Node,
+          multiple,
+          value: multiple ? selectedEntities : selectedEntities[0]
+        }
+      } else {
+        return {
+          type: ItemTypes.Node,
+          multiple: false,
+          value: node.entity
+        }
       }
     },
     canDrag() {

--- a/packages/ui/src/components/editor/properties/facer/index.stories.tsx
+++ b/packages/ui/src/components/editor/properties/facer/index.stories.tsx
@@ -23,8 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { SpawnPoseState } from './SpawnPoseState'
-import { FacerSystem } from './systems/FacerSystem'
-import { TransformSystem } from './systems/TransformSystem'
+import Component from './index'
 
-export { SpawnPoseState, TransformSystem, FacerSystem }
+const argTypes = {}
+
+export default {
+  title: 'Editor/Properties/Facer',
+  component: Component,
+  parameters: {
+    componentSubtitle: 'FacerNodeEditor',
+    jest: 'facerNodeEditor.test.tsx',
+    design: {
+      type: 'figma',
+      url: ''
+    }
+  },
+  argTypes
+}
+export const Default = { args: {} }

--- a/packages/ui/src/components/editor/properties/facer/index.tsx
+++ b/packages/ui/src/components/editor/properties/facer/index.tsx
@@ -1,0 +1,68 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+
+import { FaRegFaceFlushed } from 'react-icons/fa6'
+
+import { EntityUUID } from '@etherealengine/ecs'
+import { EditorComponentType, commitProperty } from '@etherealengine/editor/src/components/properties/Util'
+import { FacerComponent } from '@etherealengine/spatial/src/transform/components/FacerComponent'
+import InputGroup from '../../input/Group'
+import NodeInput from '../../input/Node'
+import NodeEditor from '../nodeEditor'
+
+/**
+ * FacerNodeEditor component used to customize the facer element on the scene
+ */
+export const FacerNodeEditor: EditorComponentType = (props) => {
+  const { t } = useTranslation()
+
+  const facerComponent = useComponent(props.entity, FacerComponent)
+
+  return (
+    <NodeEditor
+      entity={props.entity}
+      component={FacerComponent}
+      name={t('editor:properties.facer.name')}
+      description={t('editor:properties.facer.description')}
+    >
+      <InputGroup name="Target" label={t('editor:properties.facer.target')}>
+        <NodeInput
+          value={facerComponent.target.value ?? ('' as EntityUUID)}
+          onRelease={commitProperty(FacerComponent, 'target')}
+          onChange={commitProperty(FacerComponent, 'target')}
+        />
+      </InputGroup>
+    </NodeEditor>
+  )
+}
+
+FacerNodeEditor.iconComponent = FaRegFaceFlushed
+
+export default FacerNodeEditor

--- a/packages/ui/src/components/editor/properties/facer/index.tsx
+++ b/packages/ui/src/components/editor/properties/facer/index.tsx
@@ -61,20 +61,10 @@ export const FacerNodeEditor: EditorComponentType = (props) => {
         />
       </InputGroup>
       <InputGroup name="X Axis" label={t('editor:properties.facer.xAxis')}>
-        <BooleanInput
-          value={facerComponent.axes.x.value}
-          onChange={() =>
-            commitProperty(FacerComponent, 'axes')({ x: !facerComponent.axes.x.value, y: facerComponent.axes.y.value })
-          }
-        />
+        <BooleanInput value={facerComponent.xAxis.value} onChange={commitProperty(FacerComponent, 'xAxis')} />
       </InputGroup>
       <InputGroup name="Y Axis" label={t('editor:properties.facer.yAxis')}>
-        <BooleanInput
-          value={facerComponent.axes.y.value}
-          onChange={() =>
-            commitProperty(FacerComponent, 'axes')({ x: facerComponent.axes.x.value, y: !facerComponent.axes.y.value })
-          }
-        />
+        <BooleanInput value={facerComponent.yAxis.value} onChange={commitProperty(FacerComponent, 'yAxis')} />
       </InputGroup>
     </NodeEditor>
   )

--- a/packages/ui/src/components/editor/properties/facer/index.tsx
+++ b/packages/ui/src/components/editor/properties/facer/index.tsx
@@ -33,6 +33,7 @@ import { FaRegFaceFlushed } from 'react-icons/fa6'
 import { EntityUUID } from '@etherealengine/ecs'
 import { EditorComponentType, commitProperty } from '@etherealengine/editor/src/components/properties/Util'
 import { FacerComponent } from '@etherealengine/spatial/src/transform/components/FacerComponent'
+import BooleanInput from '../../input/Boolean'
 import InputGroup from '../../input/Group'
 import NodeInput from '../../input/Node'
 import NodeEditor from '../nodeEditor'
@@ -57,6 +58,22 @@ export const FacerNodeEditor: EditorComponentType = (props) => {
           value={facerComponent.target.value ?? ('' as EntityUUID)}
           onRelease={commitProperty(FacerComponent, 'target')}
           onChange={commitProperty(FacerComponent, 'target')}
+        />
+      </InputGroup>
+      <InputGroup name="X Axis" label={t('editor:properties.facer.xAxis')}>
+        <BooleanInput
+          value={facerComponent.axes.x.value}
+          onChange={() =>
+            commitProperty(FacerComponent, 'axes')({ x: !facerComponent.axes.x.value, y: facerComponent.axes.y.value })
+          }
+        />
+      </InputGroup>
+      <InputGroup name="Y Axis" label={t('editor:properties.facer.yAxis')}>
+        <BooleanInput
+          value={facerComponent.axes.y.value}
+          onChange={() =>
+            commitProperty(FacerComponent, 'axes')({ x: facerComponent.axes.x.value, y: !facerComponent.axes.y.value })
+          }
         />
       </InputGroup>
     </NodeEditor>


### PR DESCRIPTION
Adds a Facer Component, which makes the component entity look at either the viewer, or a specific entity in the scene.
Implements a NodeInput UI component which allows nodes to be dragged and dropped onto it.
Changes the behavior of hierarchy nodes such that they are not selected immediately on mouse down but on click instead. Also changes their drag behavior to allow dragging of non-selected nodes.

Closes https://tsu.atlassian.net/browse/IR-2554