### PR TITLE
Changes to set default TTL of 1 day for k8s job

### DIFF
--- a/packages/server-core/src/k8s-job-helper.ts
+++ b/packages/server-core/src/k8s-job-helper.ts
@@ -76,7 +76,8 @@ export async function getJobBody(
   app: Application,
   command: string[],
   name: string,
-  labels: { [key: string]: string }
+  labels: { [key: string]: string },
+  ttlSecondsAfterFinished = 86400 // This value is 1 day
 ): Promise<k8s.V1Job> {
   const apiPods = await getPodsData(
     `app.kubernetes.io/instance=${config.server.releaseName},app.kubernetes.io/component=api`,
@@ -96,6 +97,7 @@ export async function getJobBody(
       labels
     },
     spec: {
+      ttlSecondsAfterFinished,
       template: {
         metadata: {
           labels


### PR DESCRIPTION
## Summary

It seems like currently our k8s jobs does not have a default TTL and they remain there infinitely. As we are using jobs in MT for various purposes like provisioning a domain, deleting an account and everything under it like projects etc. Therefore if we dont automatically clean a job, the list of pods/jobs will keep on growing. This PR ensures a k8s job once completed is removed after 1 day.

https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#cleanup-for-finished-jobs

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
