### PR TITLE
studio: fix tab styling

### DIFF
--- a/packages/editor/src/components/Editor2Container.css
+++ b/packages/editor/src/components/Editor2Container.css
@@ -31,11 +31,11 @@
 }
 
 .dock-tab.dock-tab-active {
-  background: var(--bg-surface-main);
+  background: var(--bg-surface-main) !important;
 }
 
 .dock-tab:not(.dock-tab-active):hover {
-  background: var(--bg-surface-input);
+  background: var(--bg-surface-input) !important;
 }
 
 .dock-tab > div {


### PR DESCRIPTION
## Summary
adds `!important` to stop overriding custom background colors for active and hovered dock tabs

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
