### PR TITLE
Update vite.config.ts to fix terser mangling bug

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -332,6 +332,15 @@ export default defineConfig(async () => {
       target: 'esnext',
       sourcemap: process.env.VITE_SOURCEMAPS === 'true' ? true : false,
       minify: 'terser',
+      terserOptions: {
+        mangle: {
+          // This is a work-around for a terser bug which occurs when a local variable named `fetch` is
+          // used in a function that also references the global `fetch` function as a default parameter value
+          // In this case, terser was mangling the local `fetch` variable a different name (which is fine),
+          // however it also updated the default parameter to the same mangled name (uh-oh), causing a runtime error.
+          reserved: ['fetch']
+        }
+      },
       dynamicImportVarsOptions: {
         warnOnError: true
       },


### PR DESCRIPTION
## Summary
This is a work-around for a terser bug which occurs when a local variable named `fetch` is used in a function that also references the global `fetch` function as a default parameter value. In this case, terser was mangling the local `fetch` variable a different name (which is fine), however it also updated the default parameter to the same mangled name (uh-oh), causing a runtime error.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
