### PR TITLE
IR-2677 system registration spam issue

### DIFF
--- a/packages/editor/src/systems/EditorControlSystem.tsx
+++ b/packages/editor/src/systems/EditorControlSystem.tsx
@@ -35,7 +35,6 @@ import {
   hasComponent,
   setComponent
 } from '@etherealengine/ecs/src/ComponentFunctions'
-import { ECSState } from '@etherealengine/ecs/src/ECSState'
 import { Engine } from '@etherealengine/ecs/src/Engine'
 import { defineQuery } from '@etherealengine/ecs/src/QueryFunctions'
 import { defineSystem } from '@etherealengine/ecs/src/SystemFunctions'
@@ -245,8 +244,6 @@ const execute = () => {
 
   if (hasComponent(Engine.instance.cameraEntity, FlyControlComponent)) return
 
-  const deltaSeconds = getState(ECSState).deltaSeconds
-
   const selectedEntities = SelectionState.getSelectedEntities()
 
   const inputSources = inputQuery()
@@ -295,18 +292,15 @@ const execute = () => {
   }
   if (buttons.PrimaryClick?.up && !buttons.PrimaryClick?.dragging) {
     if (hasComponent(clickStartEntity, SourceComponent)) {
+      const selectedEntities = SelectionState.getSelectedEntities()
       const modelComponent = getAncestorWithComponent(clickStartEntity, ModelComponent)
       const ancestorModelEntity = modelComponent || clickStartEntity
+      const targetSelection = selectedEntities[0] === ancestorModelEntity ? clickStartEntity : ancestorModelEntity
 
-      console.log(
-        SelectionState.getSelectedEntities()[0] === ancestorModelEntity ? clickStartEntity : ancestorModelEntity
-      )
-      SelectionState.updateSelection([
-        getComponent(
-          SelectionState.getSelectedEntities()[0] === ancestorModelEntity ? clickStartEntity : ancestorModelEntity,
-          UUIDComponent
-        )
-      ])
+      //only update selection if the selection actually changed (prevents unnecessarily creating new transform gizmos in edit mode)
+      if (selectedEntities.length !== 1 || (selectedEntities.length === 1 && selectedEntities[0] !== targetSelection)) {
+        SelectionState.updateSelection([getComponent(targetSelection, UUIDComponent)])
+      }
     }
   }
 }

--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -46,7 +46,7 @@ import { getState, NO_PROXY, useMutableState } from '@etherealengine/hyperflux'
 import { TransformComponent } from '@etherealengine/spatial'
 import { CallbackComponent } from '@etherealengine/spatial/src/common/CallbackComponent'
 import { createTransitionState } from '@etherealengine/spatial/src/common/functions/createTransitionState'
-import { InputComponent } from '@etherealengine/spatial/src/input/components/InputComponent'
+import { InputComponent, InputExecutionOrder } from '@etherealengine/spatial/src/input/components/InputComponent'
 import { RigidBodyComponent } from '@etherealengine/spatial/src/physics/components/RigidBodyComponent'
 import { VisibleComponent } from '@etherealengine/spatial/src/renderer/components/VisibleComponent'
 import {
@@ -292,21 +292,25 @@ export const InteractableComponent = defineComponent({
     const entity = useEntityContext()
     const isEditing = useMutableState(EngineState).isEditing
 
-    InputComponent.useExecuteWithInput(() => {
-      const buttons = InputComponent.getMergedButtons(entity)
+    InputComponent.useExecuteWithInput(
+      () => {
+        const buttons = InputComponent.getMergedButtons(entity)
 
-      if (
-        buttons.Interact?.pressed &&
-        !buttons.Interact?.dragging &&
-        getState(InputState).capturingEntity === UndefinedEntity
-      ) {
-        InputState.setCapturingEntity(entity)
+        if (
+          buttons.Interact?.pressed &&
+          !buttons.Interact?.dragging &&
+          getState(InputState).capturingEntity === UndefinedEntity
+        ) {
+          InputState.setCapturingEntity(entity)
 
-        if (buttons.Interact?.up) {
-          callInteractCallbacks(entity)
+          if (buttons.Interact?.up) {
+            callInteractCallbacks(entity)
+          }
         }
-      }
-    }, true)
+      },
+      true,
+      InputExecutionOrder.After
+    )
 
     useEffect(() => {
       setComponent(entity, DistanceFromCameraComponent)


### PR DESCRIPTION
## Summary
cleaning up system registration spam issue, removing a log and changing execution order of InteractableComponent's input subsystem to the end to prevent conflict with drag events for others using useExecuteWithInput

## References
[https://tsu.atlassian.net/browse/IR-2677](https://tsu.atlassian.net/browse/IR-2677)

## QA Steps
click anywhere in the scene without changing what you are clicking on (but not on a gizmo control)

before this bugfix you should see console logs spamming "Registered system ____ before ee.engine.InputExecutionSystemGroup". This fix gets rid of that unless the selected object actually changes (if your click changes the selected object you should still get that message)