### PR TITLE
IR-2715: Fix Blender-created model GLTF data duplication on export

### DIFF
--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -60,14 +60,16 @@ import { createMaterialInstance } from '../materials/functions/materialSourcingF
 import { ComponentJsonType, EntityJsonType } from '../types/SceneTypes'
 import { getModelSceneID } from './loaders/ModelFunctions'
 
-export const parseECSData = (data: [string, any][]): ComponentJsonType[] => {
+export const parseECSData = (userData: Record<string, any>): ComponentJsonType[] => {
   const components: { [key: string]: any } = {}
   const prefabs: { [key: string]: any } = {}
-
+  const keysToRemove: string[] = []
+  const data = [...Object.entries(userData)]
   for (const [key, value] of data) {
     const parts = key.split('.')
     if (parts.length > 1) {
       if (parts[0] === 'xrengine') {
+        keysToRemove.push(key)
         const componentExists = ComponentMap.has(parts[1])
         const _toLoad = componentExists ? components : prefabs
         if (typeof _toLoad[parts[1]] === 'undefined') {
@@ -81,6 +83,11 @@ export const parseECSData = (data: [string, any][]): ComponentJsonType[] => {
         }
       }
     }
+  }
+
+  // remove keys that have been processed as they will be exported in different format
+  for (const key of keysToRemove) {
+    delete userData[key]
   }
 
   const result: ComponentJsonType[] = []
@@ -106,7 +113,7 @@ export const parseECSData = (data: [string, any][]): ComponentJsonType[] => {
 }
 
 export const createObjectEntityFromGLTF = (obj3d: Object3D): ComponentJsonType[] => {
-  return parseECSData(Object.entries(obj3d.userData))
+  return parseECSData(obj3d.userData)
 }
 
 export const parseObjectComponentsFromGLTF = (


### PR DESCRIPTION
Fixes issue where ECS data specified in a blender file via Custom Properties gets duplicated when imported and then exported from studio. This is done by clearing the userData from meshes after they have their ecs data parsed during the import process

Closes https://tsu.atlassian.net/browse/IR-2715
