### PR TITLE
loadWebappInjection skipped for OAuth callback pages

### DIFF
--- a/packages/projects/loadWebappInjection.ts
+++ b/packages/projects/loadWebappInjection.ts
@@ -29,6 +29,7 @@ import { Engine } from '@etherealengine/ecs/src/Engine'
 import { loadConfigForProject } from './loadConfigForProject'
 
 export const loadWebappInjection = async () => {
+  if (window.location.pathname.startsWith('/auth/oauth')) return []
   const projects = await Engine.instance.api.service(projectsPath).find()
   return (
     await Promise.all(


### PR DESCRIPTION
## Summary

As there may not be any login information to fetch projects with, fetching projects needs to be skipped.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
