### PR TITLE
Remove react-is hackfix install

### DIFF
--- a/dockerfiles/api/Dockerfile-api-client
+++ b/dockerfiles/api/Dockerfile-api-client
@@ -40,8 +40,6 @@ COPY patches/ ./patches/
 
 ARG NODE_ENV
 RUN npm install --loglevel notice --legacy-peer-deps --production
-# Hackfix for issue with broken installation of react-is
-RUN npm install react-is
 
 # copy then compile the code
 COPY . .

--- a/dockerfiles/client/Dockerfile-client
+++ b/dockerfiles/client/Dockerfile-client
@@ -18,8 +18,6 @@ COPY patches/ ./patches/
 
 ARG NODE_ENV
 RUN npm install --loglevel notice --legacy-peer-deps --production
-# Hackfix for issue with broken installation of react-is
-RUN npm install react-is
 
 # copy then compile the code
 COPY . .

--- a/dockerfiles/client/Dockerfile-client-serve-static
+++ b/dockerfiles/client/Dockerfile-client-serve-static
@@ -18,8 +18,6 @@ COPY patches/ ./patches/
 
 ARG NODE_ENV
 RUN npm install --loglevel notice --legacy-peer-deps --production
-# Hackfix for issue with broken installation of react-is
-RUN npm install react-is
 
 # copy then compile the code
 COPY . .

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -51,6 +51,8 @@
     "cross-env": "7.0.3",
     "dayjs": "^1.11.9",
     "demolish": "^1.0.2",
+    "@emotion/react": "11.10.6",
+    "@emotion/styled": "11.10.6",
     "hark": "^1.2.3",
     "history": "^5.3.0",
     "i18next": "21.6.16",
@@ -78,8 +80,6 @@
     "uuid": "9.0.0"
   },
   "devDependencies": {
-    "@emotion/react": "11.10.6",
-    "@emotion/styled": "11.10.6",
     "@types/hark": "1.2.2",
     "@types/node": "18.15.5",
     "@types/react": "18.2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,8 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@emotion/react": "11.10.6",
+    "@emotion/styled": "11.10.6",
     "@etherealengine/common": "^1.6.0",
     "@etherealengine/engine": "^1.6.0",
     "@etherealengine/hyperflux": "^1.6.0",
@@ -56,8 +58,6 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.2.25",
-    "@emotion/react": "11.10.6",
-    "@emotion/styled": "11.10.6",
     "@jest/globals": "^29.5.0",
     "@react-theming/storybook-addon": "^1.1.10",
     "@storybook/addon-a11y": "^8.0.5",


### PR DESCRIPTION
## Summary

Recent updates to typescript and eslint versions made the hackfix install of react-is in building the client error out, and seems to no longer be necessary to get it to install properly.

Moved @emotion/react and @emotion/styled to main dependencies from devDependencies since the client build was throwing errors about them being missing.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
