### PR TITLE
[IR-2091] studio: update ContextMenu

### DIFF
--- a/packages/editor/src/components/toolbar/Toolbar2.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar2.tsx
@@ -112,7 +112,6 @@ export default function Toolbar() {
   const { t } = useTranslation()
   const anchorEl = useHookstate<HTMLElement | null>(null)
   const anchorPosition = useHookstate({ left: 0, top: 0 })
-  const anchorOpen = useHookstate(false)
 
   const { projectName, sceneName } = useMutableState(EditorState)
 
@@ -134,7 +133,6 @@ export default function Toolbar() {
             startIcon={<RxHamburgerMenu size={24} className="text-[#9CA0AA]" />}
             className="-mr-1 border-0 bg-transparent p-0"
             onClick={(event) => {
-              anchorOpen.set(true)
               anchorPosition.set({ left: event.clientX - 5, top: event.clientY - 2 })
               anchorEl.set(event.currentTarget)
             }}
@@ -157,9 +155,8 @@ export default function Toolbar() {
       <ContextMenu
         anchorEl={anchorEl.value as HTMLElement}
         anchorPosition={anchorPosition.value}
-        open={anchorOpen.value}
         panelId="toolbar-menu"
-        onClose={() => anchorOpen.set(false)}
+        onClose={() => anchorEl.set(null)}
       >
         {toolbarMenu.map(({ name, action, hotkey }, index) => (
           <div key={index}>

--- a/packages/editor/src/components/toolbar/Toolbar2.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar2.tsx
@@ -110,7 +110,7 @@ const toolbarMenu = generateToolbarMenu()
 
 export default function Toolbar() {
   const { t } = useTranslation()
-  const anchorEl = useHookstate<HTMLElement | null>(null)
+  const anchorEvent = useHookstate<null | React.MouseEvent<HTMLElement>>(null)
   const anchorPosition = useHookstate({ left: 0, top: 0 })
 
   const { projectName, sceneName } = useMutableState(EditorState)
@@ -134,7 +134,7 @@ export default function Toolbar() {
             className="-mr-1 border-0 bg-transparent p-0"
             onClick={(event) => {
               anchorPosition.set({ left: event.clientX - 5, top: event.clientY - 2 })
-              anchorEl.set(event.currentTarget)
+              anchorEvent.set(event)
             }}
           />
         </div>
@@ -153,10 +153,10 @@ export default function Toolbar() {
         </Button>
       </div>
       <ContextMenu
-        anchorEl={anchorEl.value as HTMLElement}
+        anchorEvent={anchorEvent.value as React.MouseEvent<HTMLElement>}
         anchorPosition={anchorPosition.value}
         panelId="toolbar-menu"
-        onClose={() => anchorEl.set(null)}
+        onClose={() => anchorEvent.set(null)}
       >
         {toolbarMenu.map(({ name, action, hotkey }, index) => (
           <div key={index}>

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -28,7 +28,6 @@ import { twMerge } from 'tailwind-merge'
 import ClickAwayListener from './ClickAwayListener'
 
 type ContextMenuProps = {
-  open: boolean
   anchorEl: null | HTMLElement
   panelId: string
   anchorPosition: { left: number; top: number }
@@ -38,13 +37,13 @@ type ContextMenuProps = {
 
 export const ContextMenu = ({
   children,
-  open,
   anchorEl,
   panelId,
   anchorPosition,
   onClose,
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {
+  const open = Boolean(anchorEl)
   const panel = document.getElementById(panelId)
   const menuRef = useRef<HTMLDivElement | null>(null)
 

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -39,13 +39,23 @@ export const ContextMenu = ({
   children,
   anchorEvent,
   panelId,
-  anchorPosition,
+  anchorPosition: propAnchorPosition,
   onClose,
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {
   const [open, setOpen] = React.useState(false)
   const panel = document.getElementById(panelId)
   const menuRef = useRef<HTMLDivElement | null>(null)
+
+  // use custom anchorPosition if explicity provided, otherwise use default anchor position when anchorEvent is defined
+  const anchorPosition = propAnchorPosition
+    ? propAnchorPosition
+    : anchorEvent
+    ? {
+        left: anchorEvent.clientX + 2,
+        top: anchorEvent.clientY - 6
+      } // default anchor position
+    : undefined
 
   // Calculate the Y position of the context menu based on the menu height and space to the bottom of the viewport in order to avoid overflow
   const calculatePositionY = () => {

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -28,9 +28,9 @@ import { twMerge } from 'tailwind-merge'
 import ClickAwayListener from './ClickAwayListener'
 
 type ContextMenuProps = {
-  anchorEvent: null | React.MouseEvent<HTMLElement>
+  anchorEvent: undefined | React.MouseEvent<HTMLElement>
   panelId: string
-  anchorPosition: { left: number; top: number }
+  anchorPosition?: undefined | { left: number; top: number }
   onClose: () => void
   className?: string
 }
@@ -39,7 +39,12 @@ export const ContextMenu = ({
   children,
   anchorEvent,
   panelId,
-  anchorPosition,
+  anchorPosition = anchorEvent
+    ? {
+        left: anchorEvent.clientX + 2,
+        top: anchorEvent.clientY - 6
+      }
+    : undefined,
   onClose,
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {
@@ -50,7 +55,7 @@ export const ContextMenu = ({
 
   // Calculate the Y position of the context menu based on the menu height and space to the bottom of the viewport in order to avoid overflow
   const calculatePositionY = () => {
-    let positionY = open ? anchorPosition.top - panel?.getBoundingClientRect().top! : 0
+    let positionY = anchorPosition ? anchorPosition.top - panel?.getBoundingClientRect().top! : 0
 
     if (open && menuRef.current) {
       const menuHeight = menuRef.current.offsetHeight
@@ -67,7 +72,7 @@ export const ContextMenu = ({
 
   // Calculate the X position of the context menu based on the menu width and space to the right of the panel in order to avoid overflow
   const calculatePositionX = () => {
-    let positionX = open ? anchorPosition.left - panel?.getBoundingClientRect().left! : 0
+    let positionX = anchorPosition ? anchorPosition.left - panel?.getBoundingClientRect().left! : 0
 
     if (open && menuRef.current) {
       const menuWidth = menuRef.current.offsetWidth

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -39,12 +39,7 @@ export const ContextMenu = ({
   children,
   anchorEvent,
   panelId,
-  anchorPosition = anchorEvent
-    ? {
-        left: anchorEvent.clientX + 2,
-        top: anchorEvent.clientY - 6
-      }
-    : undefined,
+  anchorPosition,
   onClose,
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -28,7 +28,7 @@ import { twMerge } from 'tailwind-merge'
 import ClickAwayListener from './ClickAwayListener'
 
 type ContextMenuProps = {
-  anchorEl: null | HTMLElement
+  anchorEvent: null | React.MouseEvent<HTMLElement>
   panelId: string
   anchorPosition: { left: number; top: number }
   onClose: () => void
@@ -37,12 +37,13 @@ type ContextMenuProps = {
 
 export const ContextMenu = ({
   children,
-  anchorEl,
+  anchorEvent,
   panelId,
   anchorPosition,
   onClose,
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {
+  const anchorEl = anchorEvent?.currentTarget
   const open = Boolean(anchorEl)
   const panel = document.getElementById(panelId)
   const menuRef = useRef<HTMLDivElement | null>(null)
@@ -103,7 +104,7 @@ export const ContextMenu = ({
   return (
     <ClickAwayListener onClickAway={() => onClose()}>
       <div className={`${open ? 'block' : 'hidden'}`}>
-        {open && anchorEl && (
+        {open && (
           <div
             ref={menuRef}
             className="absolute z-[200] w-fit min-w-44 rounded-lg bg-neutral-900 shadow-lg"

--- a/packages/ui/src/components/editor/layout/ContextMenu.tsx
+++ b/packages/ui/src/components/editor/layout/ContextMenu.tsx
@@ -48,8 +48,7 @@ export const ContextMenu = ({
   onClose,
   className
 }: React.PropsWithChildren<ContextMenuProps>) => {
-  const anchorEl = anchorEvent?.currentTarget
-  const open = Boolean(anchorEl)
+  const [open, setOpen] = React.useState(false)
   const panel = document.getElementById(panelId)
   const menuRef = useRef<HTMLDivElement | null>(null)
 
@@ -105,6 +104,14 @@ export const ContextMenu = ({
       setPositionX(calculatePositionX())
     }
   }, [open])
+
+  useEffect(() => {
+    if (anchorEvent) {
+      setOpen(true)
+    } else {
+      setOpen(false)
+    }
+  }, [anchorEvent])
 
   return (
     <ClickAwayListener onClickAway={() => onClose()}>

--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -99,7 +99,6 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
 
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()

--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -34,6 +34,7 @@ import { AssetSelectionChangePropsType } from '@etherealengine/editor/src/compon
 import { EditorState } from '@etherealengine/editor/src/services/EditorServices'
 import { AssetLoader } from '@etherealengine/engine/src/assets/classes/AssetLoader'
 import { getState, State, useHookstate, useMutableState } from '@etherealengine/hyperflux'
+import { ContextMenu } from '@etherealengine/ui/src/components/editor/layout/ContextMenu'
 import { useDrag } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import {
@@ -53,7 +54,6 @@ import Input from '../../../../../primitives/tailwind/Input'
 import LoadingView from '../../../../../primitives/tailwind/LoadingView'
 import Text from '../../../../../primitives/tailwind/Text'
 import Tooltip from '../../../../../primitives/tailwind/Tooltip'
-import { ContextMenu } from '../../../layout/ContextMenu'
 import { FileIcon } from '../../Files/icon'
 
 type Category = {
@@ -156,7 +156,6 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
       <span className="w-[100px] overflow-hidden overflow-ellipsis whitespace-nowrap text-sm text-white">{name}</span>
 
       <ContextMenu
-        open={open}
         anchorEl={anchorEl}
         panelId={'asset-browser-panel'}
         anchorPosition={anchorPosition}

--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -98,7 +98,7 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
   const { t } = useTranslation()
 
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
-  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
+  const [anchorEvent, setAnchorEvent] = React.useState<undefined | React.MouseEvent<HTMLDivElement>>(undefined)
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
@@ -111,8 +111,8 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
   }
 
   const handleClose = () => {
-    setAnchorEvent(null)
-    setAnchorPosition({ left: 0, top: 0 })
+    setAnchorEvent(undefined)
+    setAnchorPosition(undefined)
   }
 
   const { onAssetSelectionChanged } = useContext(AssetsPreviewContext)

--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -98,12 +98,12 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
   const { t } = useTranslation()
 
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
     event.stopPropagation()
-    setAnchorEl(event.currentTarget)
+    setAnchorEvent(event)
     setAnchorPosition({
       top: event.clientY,
       left: event.clientX
@@ -111,7 +111,7 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
   }
 
   const handleClose = () => {
-    setAnchorEl(null)
+    setAnchorEvent(null)
     setAnchorPosition({ left: 0, top: 0 })
   }
 
@@ -155,7 +155,7 @@ const ResourceFile = ({ resource }: { resource: StaticResourceType }) => {
       <span className="w-[100px] overflow-hidden overflow-ellipsis whitespace-nowrap text-sm text-white">{name}</span>
 
       <ContextMenu
-        anchorEl={anchorEl}
+        anchorEvent={anchorEvent}
         panelId={'asset-browser-panel'}
         anchorPosition={anchorPosition}
         onClose={handleClose}

--- a/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
@@ -225,14 +225,14 @@ export function FileBrowserItem({
 }: FileBrowserItemType) {
   const { t } = useTranslation()
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
 
   const fileService = useMutation(fileBrowserPath)
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
     event.stopPropagation()
-    setAnchorEl(event.currentTarget)
+    setAnchorEvent(event)
     setAnchorPosition({
       left: event.clientX + 2,
       top: event.clientY - 6
@@ -240,7 +240,7 @@ export function FileBrowserItem({
   }
 
   const handleClose = () => {
-    setAnchorEl(null)
+    setAnchorEvent(null)
     setAnchorPosition({ left: 0, top: 0 })
   }
 
@@ -362,7 +362,7 @@ export function FileBrowserItem({
       )}
 
       <ContextMenu
-        anchorEl={anchorEl}
+        anchorEvent={anchorEvent}
         panelId={'file-browser-panel'}
         anchorPosition={anchorPosition}
         onClose={handleClose}

--- a/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
@@ -37,6 +37,7 @@ import { EditorState } from '@etherealengine/editor/src/services/EditorServices'
 import { getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { useFind, useMutation } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
 import { TransformComponent } from '@etherealengine/spatial/src/transform/components/TransformComponent'
+import { ContextMenu } from '@etherealengine/ui/src/components/editor/layout/ContextMenu'
 import React, { MouseEventHandler, MutableRefObject, useEffect } from 'react'
 import { ConnectDragSource, ConnectDropTarget, useDrag, useDrop } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
@@ -46,7 +47,6 @@ import { VscBlank } from 'react-icons/vsc'
 import { twMerge } from 'tailwind-merge'
 import { Vector3 } from 'three'
 import Button from '../../../../../primitives/tailwind/Button'
-import { ContextMenu } from '../../../layout/ContextMenu'
 import { FileIcon } from '../icon'
 import DeleteFileModal from './DeleteFileModal'
 import RenameFileModal from './RenameFileModal'
@@ -226,7 +226,6 @@ export function FileBrowserItem({
   const { t } = useTranslation()
   const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
 
   const fileService = useMutation(fileBrowserPath)
 
@@ -363,7 +362,6 @@ export function FileBrowserItem({
       )}
 
       <ContextMenu
-        open={open}
         anchorEl={anchorEl}
         panelId={'file-browser-panel'}
         anchorPosition={anchorPosition}

--- a/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
@@ -6,8 +6,8 @@ Version 1.0. (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
 The License is based on the Mozilla Public License Version 1.1, but Sections 14
-and 15 have been added to cover use of software over a computer network and 
-provide for limited attribution for the Original Developer. In addition, 
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
 Exhibit A has been modified to be consistent with Exhibit B.
 
 Software distributed under the License is distributed on an "AS IS" basis,
@@ -19,7 +19,7 @@ The Original Code is Ethereal Engine.
 The Original Developer is the Initial Developer. The Initial Developer of the
 Original Code is the Ethereal Engine team.
 
-All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
 Ethereal Engine. All Rights Reserved.
 */
 
@@ -224,8 +224,7 @@ export function FileBrowserItem({
   isSelected
 }: FileBrowserItemType) {
   const { t } = useTranslation()
-  const [anchorPosition, setAnchorPosition] = React.useState<any>(undefined)
-  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
+  const [anchorEvent, setAnchorEvent] = React.useState<undefined | React.MouseEvent<HTMLDivElement>>(undefined)
 
   const fileService = useMutation(fileBrowserPath)
 
@@ -233,15 +232,10 @@ export function FileBrowserItem({
     event.preventDefault()
     event.stopPropagation()
     setAnchorEvent(event)
-    setAnchorPosition({
-      left: event.clientX + 2,
-      top: event.clientY - 6
-    })
   }
 
   const handleClose = () => {
-    setAnchorEvent(null)
-    setAnchorPosition({ left: 0, top: 0 })
+    setAnchorEvent(undefined)
   }
 
   const onClickItem = (e: React.MouseEvent) => onClick(e, item)
@@ -361,13 +355,7 @@ export function FileBrowserItem({
         </div>
       )}
 
-      <ContextMenu
-        anchorEvent={anchorEvent}
-        panelId={'file-browser-panel'}
-        anchorPosition={anchorPosition}
-        onClose={handleClose}
-        className="gap-1"
-      >
+      <ContextMenu anchorEvent={anchorEvent} panelId={'file-browser-panel'} onClose={handleClose} className="gap-1">
         <Button variant="outline" size="small" fullWidth onClick={addFolder}>
           {t('editor:layout.filebrowser.addNewFolder')}
         </Button>

--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -82,7 +82,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
   const { sceneURL, rootEntityUUID, index } = props
   const { t } = useTranslation()
   const [contextSelectedItem, setContextSelectedItem] = React.useState<undefined | HeirarchyTreeNodeType>(undefined)
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
   const [anchorPosition, setAnchorPosition] = React.useState({ left: 0, top: 0 })
   const [anchorPositionPop, setAnchorPositionPop] = React.useState<undefined | PopoverPosition>(undefined)
 
@@ -173,7 +173,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
     event.stopPropagation()
 
     setContextSelectedItem(item)
-    setAnchorEl(event.currentTarget)
+    setAnchorEvent(event)
     setAnchorPosition({
       left: event.clientX + 2,
       top: event.clientY - 6
@@ -182,7 +182,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
 
   const handleClose = () => {
     setContextSelectedItem(undefined)
-    setAnchorEl(null)
+    setAnchorEvent(null)
     setAnchorPosition({ left: 0, top: 0 })
   }
 
@@ -498,7 +498,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
         <AutoSizer onResize={HierarchyList}>{HierarchyList}</AutoSizer>
       </div>
       <ContextMenu
-        anchorEl={anchorEl}
+        anchorEvent={anchorEvent}
         panelId={'heirarchy-panel'}
         anchorPosition={anchorPosition}
         onClose={handleClose}

--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -82,8 +82,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
   const { sceneURL, rootEntityUUID, index } = props
   const { t } = useTranslation()
   const [contextSelectedItem, setContextSelectedItem] = React.useState<undefined | HeirarchyTreeNodeType>(undefined)
-  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
-  const [anchorPosition, setAnchorPosition] = React.useState({ left: 0, top: 0 })
+  const [anchorEvent, setAnchorEvent] = React.useState<undefined | React.MouseEvent<HTMLDivElement>>(undefined)
   const [anchorPositionPop, setAnchorPositionPop] = React.useState<undefined | PopoverPosition>(undefined)
 
   const [prevClickedNode, setPrevClickedNode] = useState<HeirarchyTreeNodeType | null>(null)
@@ -174,16 +173,11 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
 
     setContextSelectedItem(item)
     setAnchorEvent(event)
-    setAnchorPosition({
-      left: event.clientX + 2,
-      top: event.clientY - 6
-    })
   }
 
   const handleClose = () => {
     setContextSelectedItem(undefined)
-    setAnchorEvent(null)
-    setAnchorPosition({ left: 0, top: 0 })
+    setAnchorEvent(undefined)
   }
 
   const onMouseDown = useCallback((e: React.MouseEvent, node: HeirarchyTreeNodeType) => {}, [])
@@ -497,12 +491,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
       <div id="heirarchy-panel" className="h-5/6 overflow-hidden">
         <AutoSizer onResize={HierarchyList}>{HierarchyList}</AutoSizer>
       </div>
-      <ContextMenu
-        anchorEvent={anchorEvent}
-        panelId={'heirarchy-panel'}
-        anchorPosition={anchorPosition}
-        onClose={handleClose}
-      >
+      <ContextMenu anchorEvent={anchorEvent} panelId={'heirarchy-panel'} onClose={handleClose}>
         <Button
           fullWidth
           size="small"

--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -59,12 +59,12 @@ import { EditorState } from '@etherealengine/editor/src/services/EditorServices'
 import { SelectionState } from '@etherealengine/editor/src/services/SelectionServices'
 import { GLTFAssetState, GLTFSnapshotState } from '@etherealengine/engine/src/gltf/GLTFState'
 import { SourceComponent } from '@etherealengine/engine/src/scene/components/SourceComponent'
+import { ContextMenu } from '@etherealengine/ui/src/components/editor/layout/ContextMenu'
 import { PopoverPosition } from '@mui/material'
 import { HiMagnifyingGlass, HiOutlinePlusCircle } from 'react-icons/hi2'
 import { HierarchyPanelTab } from '..'
 import Button from '../../../../../primitives/tailwind/Button'
 import Input from '../../../../../primitives/tailwind/Input'
-import ContextMenu from '../../../layout/ContextMenu'
 import Popover from '../../../layout/Popover'
 import { PopoverContext } from '../../../util/PopoverContext'
 import ElementList from '../../Properties/elementList'
@@ -498,7 +498,6 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
         <AutoSizer onResize={HierarchyList}>{HierarchyList}</AutoSizer>
       </div>
       <ContextMenu
-        open={!!anchorEl}
         anchorEl={anchorEl}
         panelId={'heirarchy-panel'}
         anchorPosition={anchorPosition}

--- a/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
+++ b/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
@@ -41,8 +41,11 @@ interface MainMenuProp {
 }
 
 const MainMenu = ({ commands, icon }: MainMenuProp) => {
-  const [anchorPosition, setAnchorPosition] = React.useState({ left: 0, top: 0 })
-  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
+  const [anchorPosition, setAnchorPosition] = React.useState<undefined | { left: number; top: number }>({
+    left: 0,
+    top: 0
+  })
+  const [anchorEvent, setAnchorEvent] = React.useState<undefined | React.MouseEvent<HTMLDivElement>>(undefined)
 
   const onOpen = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
@@ -56,8 +59,8 @@ const MainMenu = ({ commands, icon }: MainMenuProp) => {
   }
 
   const handleClose = () => {
-    setAnchorEvent(null)
-    setAnchorPosition({ left: 0, top: 0 })
+    setAnchorEvent(undefined)
+    setAnchorPosition(undefined)
   }
 
   const renderMenu = (command: Command) => {

--- a/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
+++ b/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
@@ -25,9 +25,9 @@ Ethereal Engine. All Rights Reserved.
 
 import React from 'react'
 
+import { ContextMenu } from '@etherealengine/ui/src/components/editor/layout/ContextMenu'
 import MenuItem from '@mui/material/MenuItem'
 import Button from '../../../../primitives/tailwind/Button'
-import ContextMenu from '../../layout/ContextMenu'
 
 interface Command {
   name: string
@@ -87,7 +87,7 @@ const MainMenu = ({ commands, icon }: MainMenuProp) => {
           onClick={(event) => onOpen(event as any)}
         />
       </div>
-      <ContextMenu open={open} anchorEl={anchorEl} panelId="menu" anchorPosition={anchorPosition} onClose={handleClose}>
+      <ContextMenu anchorEl={anchorEl} panelId="menu" anchorPosition={anchorPosition} onClose={handleClose}>
         {commands.map((command: Command) => renderMenu(command))}
       </ContextMenu>
     </>

--- a/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
+++ b/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
@@ -42,13 +42,13 @@ interface MainMenuProp {
 
 const MainMenu = ({ commands, icon }: MainMenuProp) => {
   const [anchorPosition, setAnchorPosition] = React.useState({ left: 0, top: 0 })
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [anchorEvent, setAnchorEvent] = React.useState<null | React.MouseEvent<HTMLDivElement>>(null)
 
   const onOpen = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
     event.stopPropagation()
 
-    setAnchorEl(event.currentTarget)
+    setAnchorEvent(event)
     setAnchorPosition({
       left: 0,
       top: event.currentTarget.offsetHeight + 6
@@ -56,7 +56,7 @@ const MainMenu = ({ commands, icon }: MainMenuProp) => {
   }
 
   const handleClose = () => {
-    setAnchorEl(null)
+    setAnchorEvent(null)
     setAnchorPosition({ left: 0, top: 0 })
   }
 
@@ -86,7 +86,7 @@ const MainMenu = ({ commands, icon }: MainMenuProp) => {
           onClick={(event) => onOpen(event as any)}
         />
       </div>
-      <ContextMenu anchorEl={anchorEl} panelId="menu" anchorPosition={anchorPosition} onClose={handleClose}>
+      <ContextMenu anchorEvent={anchorEvent} panelId="menu" anchorPosition={anchorPosition} onClose={handleClose}>
         {commands.map((command: Command) => renderMenu(command))}
       </ContextMenu>
     </>

--- a/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
+++ b/packages/ui/src/components/editor/toolbar/mainMenu/index.tsx
@@ -43,7 +43,6 @@ interface MainMenuProp {
 const MainMenu = ({ commands, icon }: MainMenuProp) => {
   const [anchorPosition, setAnchorPosition] = React.useState({ left: 0, top: 0 })
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
 
   const onOpen = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()


### PR DESCRIPTION
## Summary
refactors ContextMenu to use anchorEvent instead of anchorEl, removing props that can be implied from anchorEvent

## Subtasks Checklist

## Breaking Changes

## References
closes [IR-2091]

## QA Steps


[IR-2091]: https://tsu.atlassian.net/browse/IR-2091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ