### PR TITLE
chore: Update project removal logic to ignore resources JSON

### DIFF
--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -506,7 +506,7 @@ const removeStaticResourcesFromProject = async (context: HookContext<ProjectServ
   })) as any as StaticResourceType[]
   staticResourceItems.length &&
     staticResourceItems.forEach(async (staticResource) => {
-      await context.app.service(staticResourcePath).remove(staticResource.id)
+      await context.app.service(staticResourcePath).remove(staticResource.id, { ignoreResourcesJson: true })
     })
 }
 


### PR DESCRIPTION
When removing a project, `removeProjectFiles` hook runs before `removeStaticResourcesFromProject` hook. After this when `resources.json` is being removed in static-resource hooks, it cannot find the file and throws a `NoSuchKey` error.
