### PR TITLE
fix drag and drop on file browser

### DIFF
--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -269,7 +269,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
         moveContent(data.fullName, data.fullName, data.path, path, false)
       }
     } else {
-      const relativePath = folder.replace('projects/' + projectName + '/', '')
+      const relativePath = folder.replace('projects/' + projectName + '/', '').replace(/^\//gi, '')
       await Promise.all(
         data.files.map(async (file) => {
           const assetType = !file.type ? AssetLoader.getAssetType(file.name) : file.type
@@ -314,6 +314,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
     isCopy = false
   ): Promise<void> => {
     if (isLoading) return
+    console.log('debug2', oldName, newName, oldPath, newPath)
     fileService.update(null, {
       oldProject: projectName,
       newProject: projectName,

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -314,7 +314,6 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
     isCopy = false
   ): Promise<void> => {
     if (isLoading) return
-    console.log('debug2', oldName, newName, oldPath, newPath)
     fileService.update(null, {
       oldProject: projectName,
       newProject: projectName,


### PR DESCRIPTION
## Summary

the starting `/` was producing error on the [file-browser patch if condition](https://github.com/EtherealEngine/etherealengine/blob/2d3027a2d1af0eaa3c90583d4528766e1f8af1ff/packages/server-core/src/media/file-browser/file-browser.class.ts/#L253)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
