### PR TITLE
IR 2768 Set z offset to zero when exiting first person mode

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarTransparencySystem.tsx
+++ b/packages/engine/src/avatar/systems/AvatarTransparencySystem.tsx
@@ -99,7 +99,7 @@ export const AvatarTransparencySystem = defineSystem({
       const followCamera = getOptionalComponent(Engine.instance.viewerEntity, FollowCameraComponent)
       if (!followCamera) return
       const prevOffsetZ = followCamera.offset.z
-      followCamera.offset.setZ(eyeOffset)
+      followCamera.offset.setZ(hasDecapComponent ? eyeOffset : 0)
       return () => {
         followCamera.offset.setZ(prevOffsetZ)
       }


### PR DESCRIPTION
## Summary
Fixes camera offset never being set back to zero after exiting first person mode

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
