### PR TITLE
chore: Update thumbnailKey path in onNewScene function

### DIFF
--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -160,7 +160,7 @@ export const onNewScene = async (
       type: 'scene',
       body: templateURL,
       path: 'public/scenes/New-Scene.gltf',
-      thumbnailKey: templateURL.replace(config.client.fileServer, '').replace('.gltf', '.thumbnail.jpg'),
+      thumbnailKey: templateURL.replace(`${config.client.fileServer}/`, '').replace('.gltf', '.thumbnail.jpg'),
       unique: true
     })
     if (!sceneData) return


### PR DESCRIPTION
New scene thumbnail URL would have an extra '/' resulting in thumbnails not loading.