### PR TITLE
Fix fog color and improve colorInput

### DIFF
--- a/packages/ui/src/components/editor/properties/fog/index.tsx
+++ b/packages/ui/src/components/editor/properties/fog/index.tsx
@@ -90,6 +90,7 @@ export const FogSettingsEditor: EditorComponentType = (props) => {
             <ColorInput
               value={new Color(fogState.color.value)}
               onChange={(val) => updateProperty(FogSettingsComponent, 'color')('#' + val.getHexString())}
+              onRelease={(val) => commitProperty(FogSettingsComponent, 'color')('#' + val.getHexString())}
             />
           </InputGroup>
           {fogState.type.value === FogType.Linear ? (

--- a/packages/ui/src/primitives/tailwind/Color/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Color/index.tsx
@@ -66,12 +66,12 @@ export function ColorInput({
     >
       <div
         tabIndex={0}
-        className={`group h-5 w-5 rounded border border-black focus:border-theme-primary`}
+        className={`group h-5 w-5 cursor-pointer rounded border border-black focus:border-theme-primary`}
         style={{ backgroundColor: hexColor }}
       >
         <SketchPicker
           className={twMerge(
-            'absolute z-10 mt-5 scale-0 bg-theme-surface-main group-hover:scale-100 group-focus:scale-100',
+            'absolute z-10 mt-5 scale-0 bg-theme-surface-main focus-within:scale-100 group-focus:scale-100',
             sketchPickerClassName
           )}
           color={hexColor}


### PR DESCRIPTION
## Summary
Okay just a small fix for fog. But I also wanted to bring up the difficult of hovering over the color swatch and then going to edit the color and it unhovers. So I modified to to work only on focus and to have a pointer on hover. I think the UX is much better this way.

focus-within property is needed so that when you click on the swatches or inputs in the color component that it stays open.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
