### PR TITLE
standardize IR-Engine Deploy across dev,int,stg; IR-2698

### DIFF
--- a/.github/workflows/ir-engine-deploy.yml
+++ b/.github/workflows/ir-engine-deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy IR Engine
 
 on:
-  pull_request:
   push:
     branches: [dev, int, stg]
     paths-ignore: 

--- a/.github/workflows/ir-engine-dev-deploy.yml
+++ b/.github/workflows/ir-engine-dev-deploy.yml
@@ -1,17 +1,33 @@
-name: IR Engine Dev Deployment
+name: Deploy IR Engine
 
 on:
+  pull_request:
   push:
-    branches: [dev]
+    branches: [dev, int, stg]
+    paths-ignore: 
+      - '**/*.md'
+      - '.*ignore'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Evironment to Deploy
+        required: true
+        type: choice
+        options: 
+        - dev
+        - int
+        - stg
+
+env:
+  TARGET_BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
 
 jobs:
-  remote-dispatch-dev-deploy:
+  remote-dispatch-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Remote Dispatch to Deploy Dev
-        id: check-secrets-webhook
+      - name: Send Remote Dispatch to Deploy IR-Engine
         run: |
           curl -H "Authorization: token ${{ secrets.IR_ORG_ACCESS_TOKEN }}" \
-              -H 'Accept: application/vnd.github.everest-preview+json' \
-              ${{ secrets.IR_ENGINE_OPS_API_URL }} \
-              -d '{"event_type": "deploy-dev"}'
+            -H 'Accept: application/vnd.github.everest-preview+json' \
+            ${{ secrets.IR_ENGINE_OPS_API_URL }} \
+            -d '{"event_type": "deploy-ir-engine", "client_payload": {"environment": "${{ env.TARGET_BRANCH_NAME }}"}}'


### PR DESCRIPTION
## Summary
Multi-Environment IR-Engine deploy:

On any merge into `dev`, `int`, or `stg` branches on this repo, a request is sent which will trigger this workflow: https://github.com/theinfinitereality/ir-engine-devops/blob/dev/.github/workflows/deploy-ir-engine.yml

That workflow will build and push the docker images for the engine and deploy the builder. Everything is synced via the git branch, so if you merge a feature into `dev` on this repo, the `dev` branch on EtherealEngine will be checked out, the deployment will and the builder will be deployed to the `dev` cluster. Same for `int` and `stg`.


## References
[IR-2698]



[IR-2698]: https://tsu.atlassian.net/browse/IR-2698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ