### PR TITLE
fix the download project button

### DIFF
--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -348,7 +348,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
 
   const currentContentRef = useRef(null! as { item: FileDataType; isCopy: boolean })
 
-  const showDownloadButtons = selectedDirectory.value === '/projects/' + projectName + '/'
+  const showDownloadButtons = selectedDirectory.value.startsWith('/projects/' + projectName + '/')
   const showUploadButtons =
     selectedDirectory.value.startsWith('/projects/' + projectName + '/public/') ||
     selectedDirectory.value.startsWith('/projects/' + projectName + '/assets/')


### PR DESCRIPTION
## Summary

show the download project button whenever inside a projects directory

## Subtasks Checklist

## Breaking Changes

## References

https://tsu.atlassian.net/browse/IR-1351

## QA Steps
