### PR TITLE
fix: Help button in Studio

### DIFF
--- a/packages/editor/src/components/Editor2Container.tsx
+++ b/packages/editor/src/components/Editor2Container.tsx
@@ -130,7 +130,7 @@ const EditorContainer = () => {
 
   const viewerEntity = useMutableState(EngineState).viewerEntity.value
 
-  const { isWidgetVisible, openChat } = useZendesk()
+  const { initialized, isWidgetVisible, openChat } = useZendesk()
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -184,14 +184,13 @@ const EditorContainer = () => {
         </DndWrapper>
       </div>
       <PopupMenu />
-      {!isWidgetVisible && (
+      {!isWidgetVisible && initialized && (
         <Button
           rounded="partial"
           size="small"
           className="absolute bottom-5 right-5 z-10"
           startIcon={<IoHelpCircleOutline fontSize={20} />}
           onClick={openChat}
-          hidden={true}
         >
           {t('editor:help')}
         </Button>


### PR DESCRIPTION
## Summary

This change prevents the help button to be displayed until the Zendesk widget is initialized. 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

#### Test with help button displayed and responsive
1. Log in 
2. Go into the studio 
3. Click on the help button. it should be responsive if displayed. 

#### Test with help button hidden
1. Set `VITE_ZENDESK_ENABLED=false` in your local environment
2. Log in 
3. Go into the studio 
4. The help button should not be displayed
