### PR TITLE
IR-2753: Changes to add file logger for pino

### DIFF
--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -164,15 +164,15 @@ const multiLogger = {
         }
       }
 
-      return config.client.logs.disabled
-        ? nullLogger
-        : {
+      return config.client.logs.disabled === 'false'
+        ? {
             debug: send('debug'),
             info: send('info'),
             warn: send('warn'),
             error: send('error'),
             fatal: send('fatal')
           }
+        : nullLogger
     }
   }
 }

--- a/packages/server-core/src/ServerLogger.ts
+++ b/packages/server-core/src/ServerLogger.ts
@@ -30,6 +30,7 @@ Ethereal Engine. All Rights Reserved.
  *  API endpoint).
  */
 import os from 'os'
+import path from 'path'
 import pino from 'pino'
 import pinoElastic from 'pino-elasticsearch'
 import pinoOpensearch from 'pino-opensearch'
@@ -41,6 +42,14 @@ const useLogger = !process.env.DISABLE_SERVER_LOG
 
 const streamToPretty = pretty({
   colorize: true
+})
+
+const streamToFile = pino.transport({
+  target: 'pino/file',
+  options: {
+    mkdir: true,
+    destination: path.join(__dirname, 'logs/irengine.log')
+  }
 })
 
 const streamToOpenSearch = pinoOpensearch({
@@ -62,7 +71,7 @@ const streamToElastic = pinoElastic({
   flushBytes: 1000
 })
 
-const streams = [streamToPretty, streamToElastic, streamToOpenSearch]
+const streams = [streamToFile, streamToPretty, streamToElastic, streamToOpenSearch]
 
 export const opensearchOnlyLogger = pino(
   {


### PR DESCRIPTION
## Summary
This PR introduces file logger which will store appended IR engine logs to `/logs/irengine.log` file your code base.

Make sure to update your `.env.local` file with following:

```
VITE_FORCE_CLIENT_LOG_AGGREGATE=true
VITE_DISABLE_LOG=false

LOG_TO_FILE=true
```

Below is a log file generated by it.

[irengine.log](https://github.com/user-attachments/files/16082569/irengine.log)



## Subtasks Checklist

## Breaking Changes

## References
https://tsu.atlassian.net/browse/IR-2753

## QA Steps
