### PR TITLE
Update useRealtime hook to pass more data to refetch

### DIFF
--- a/packages/spatial/src/common/functions/FeathersHooks.tsx
+++ b/packages/spatial/src/common/functions/FeathersHooks.tsx
@@ -357,14 +357,17 @@ export function hashObject(obj) {
  * An internal hook that will listen to realtime updates to a service
  * and update the cache as changes happen.
  */
-export function useRealtime(serviceName: keyof ServiceTypes, refetch: () => void) {
+export function useRealtime(
+  serviceName: keyof ServiceTypes,
+  refetch: (data: any, eventType: 'created' | 'updated' | 'patched' | 'removed') => void
+) {
   useLayoutEffect(() => {
     const service = Engine.instance.api.service(serviceName)
 
-    service.on('created', refetch)
-    service.on('updated', refetch)
-    service.on('patched', refetch)
-    service.on('removed', refetch)
+    service.on('created', (data: any) => refetch(data, 'created'))
+    service.on('updated', (data: any) => refetch(data, 'updated'))
+    service.on('patched', (data: any) => refetch(data, 'patched'))
+    service.on('removed', (data: any) => refetch(data, 'removed'))
 
     return () => {
       service.off('created', refetch)

--- a/packages/spatial/src/common/functions/FeathersHooks.tsx
+++ b/packages/spatial/src/common/functions/FeathersHooks.tsx
@@ -364,16 +364,21 @@ export function useRealtime(
   useLayoutEffect(() => {
     const service = Engine.instance.api.service(serviceName)
 
-    service.on('created', (data: any) => refetch(data, 'created'))
-    service.on('updated', (data: any) => refetch(data, 'updated'))
-    service.on('patched', (data: any) => refetch(data, 'patched'))
-    service.on('removed', (data: any) => refetch(data, 'removed'))
+    const handleCreated = (data: any) => refetch(data, 'created')
+    const handleUpdated = (data: any) => refetch(data, 'updated')
+    const handlePatched = (data: any) => refetch(data, 'patched')
+    const handleRemoved = (data: any) => refetch(data, 'removed')
+
+    service.on('created', handleCreated)
+    service.on('updated', handleUpdated)
+    service.on('patched', handlePatched)
+    service.on('removed', handleRemoved)
 
     return () => {
-      service.off('created', refetch)
-      service.off('updated', refetch)
-      service.off('patched', refetch)
-      service.off('removed', refetch)
+      service.off('created', handleCreated)
+      service.off('updated', handleUpdated)
+      service.off('patched', handlePatched)
+      service.off('removed', handleRemoved)
     }
   }, [serviceName])
 }


### PR DESCRIPTION
## Summary

`useRealtime` now passes the message received from server's channel and the `eventType` which caused it.
`eventType` can be of the type: `'created' | 'updated' | 'patched' | 'removed'`.

Related to:
- https://tsu.atlassian.net/browse/IR-2748
- https://github.com/theinfinitereality/eepro-multitenancy/pull/307

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
