### PR TITLE
Changes to introduce isInContext hook to check for things in context

### DIFF
--- a/packages/server-core/src/hooks/is-in-context.ts
+++ b/packages/server-core/src/hooks/is-in-context.ts
@@ -27,21 +27,27 @@ import { HookContext } from '../../declarations'
 
 /**
  * This hook is used to check a value in the context.
+ * If propertyValue is not provided then it will just
+ * check if that property exists.
  * If searchIn is not provided then it will search for
  * it in the query.
  */
-export default (propertyName: string, propertyValue: any, searchIn?: 'query' | 'params' | 'data') => {
+export default (propertyName: string, propertyValue?: any, searchIn?: 'query' | 'params' | 'data') => {
   return (context: HookContext): boolean => {
     if (searchIn === 'data') {
       if (Array.isArray(context.data)) {
-        return context.data.find((item) => item[propertyName] && item[propertyName] === propertyValue)
+        return context.data.find(
+          (item) => item[propertyName] && (!propertyValue || item[propertyName] === propertyValue)
+        )
       } else {
-        return context.data[propertyName] && context.data[propertyName] === propertyValue
+        return context.data[propertyName] && (!propertyValue || context.data[propertyName] === propertyValue)
       }
     } else if (searchIn === 'params') {
-      return context.params[propertyName] && context.params[propertyName] === propertyValue
+      return context.params[propertyName] && (!propertyValue || context.params[propertyName] === propertyValue)
     } else {
-      return context.params.query[propertyName] && context.params.query[propertyName] === propertyValue
+      return (
+        context.params.query[propertyName] && (!propertyValue || context.params.query[propertyName] === propertyValue)
+      )
     }
   }
 }

--- a/packages/server-core/src/hooks/is-in-context.ts
+++ b/packages/server-core/src/hooks/is-in-context.ts
@@ -1,0 +1,47 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { HookContext } from '../../declarations'
+
+/**
+ * This hook is used to check a value in the context.
+ * If searchIn is not provided then it will search for
+ * it in the query.
+ */
+export default (propertyName: string, propertyValue: any, searchIn?: 'query' | 'params' | 'data') => {
+  return (context: HookContext): boolean => {
+    if (searchIn === 'data') {
+      if (Array.isArray(context.data)) {
+        return context.data.find((item) => item[propertyName] && item[propertyName] === propertyValue)
+      } else {
+        return context.data[propertyName] && context.data[propertyName] === propertyValue
+      }
+    } else if (searchIn === 'params') {
+      return context.params[propertyName] && context.params[propertyName] === propertyValue
+    } else {
+      return context.params.query[propertyName] && context.params.query[propertyName] === propertyValue
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This hook can be used like following:

To check for a property in query
```
before: [
  iff(isInContext('projectId') , [//If there is projectId in query])
]
```

To check for a property in query & match its value
```
before: [
  iff(isInContext('isSearch', true) , [//If there is isSearch: true in query])
]
```

To check for a property in data & match its value
```
before: [
  iff(isInContext('projectId', undefined, 'data') , [//If there is projectId in query])
]
```

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
