### PR TITLE
[IR-2991] studio: use different FileIcon sizing for list and grid

### DIFF
--- a/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
@@ -124,7 +124,7 @@ export const FileTableListBody = ({
     name: (
       <span className="flex max-h-7 flex-row items-center gap-2 text-[#e7e7e7]" style={{ fontSize: `${fontSize}px` }}>
         {file.isFolder ? <IoIosArrowForward /> : <VscBlank />}
-        <FileIcon thumbnailURL={thumbnailURL} type={file.type} isFolder={file.isFolder} />
+        <FileIcon isMinified={true} thumbnailURL={thumbnailURL} type={file.type} isFolder={file.isFolder} />
         {file.fullName}
       </span>
     ),

--- a/packages/ui/src/components/editor/panels/Files/icon/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/icon/index.tsx
@@ -67,12 +67,14 @@ export const FileIcon = ({
   thumbnailURL,
   type,
   isFolder,
-  color = 'text-white'
+  color = 'text-white',
+  isMinified = false
 }: {
   thumbnailURL?: string
   type: string
   isFolder?: boolean
   color?: string
+  isMinified?: boolean
 }) => {
   const FallbackIcon = FileIconType[type ?? '']
 
@@ -81,7 +83,12 @@ export const FileIcon = ({
       {isFolder ? (
         <HiFolder className={`${color}`} />
       ) : thumbnailURL ? (
-        <img className="h-4 w-4 object-contain" crossOrigin="anonymous" src={thumbnailURL} alt="" />
+        <img
+          className={`${isMinified ? 'h-4 w-4' : 'h-full w-full min-w-[90px]'} object-contain`}
+          crossOrigin="anonymous"
+          src={thumbnailURL}
+          alt=""
+        />
       ) : FallbackIcon ? (
         <FallbackIcon className={`${color}`} />
       ) : (


### PR DESCRIPTION
## Summary
fixes bug: [IR-2991], changing default thumbnail size (used in assets panel & file grid view) with a minified option for list view thumbnails

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-2991]: https://tsu.atlassian.net/browse/IR-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ