### PR TITLE
[IR-1445] WebRTC improvements

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -514,6 +514,14 @@
       "screenshareMidResMaxBitrate": "Screenshare mid-res video max bitrate (kbps)",
       "screenshareHighResMaxBitrate": "Screenshare high-res video max bitrate (kbps)",
       "privacyPolicy": "Privacy Policy",
+      "webRTCSettings": {
+        "main": "WebRTC Settings",
+        "useCustomICEServers": "Use custom iceServers configuration",
+        "iceServers": "iceServers (STUN/TURN configuration; must provide proper JSON)",
+        "useTimeLimitedCredentials": "Use time-limited credentials to authenticate STUN/TURN server",
+        "webRTCStaticAuthSecretKey": "Shared static-auth-secret for authenticating STUN/TURN server",
+        "usePrivateInstanceserverIP": "Return instanceservers' raw private IP address instead of DNS record"
+      },
       "project": {
         "header": "Project",
         "subtitle": "Edit Project Settings",

--- a/packages/client-core/src/admin/components/settings/tabs/client.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/client.tsx
@@ -55,12 +55,6 @@ const ClientTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableRef
   const settingsState = useHookstate(null as null | ClientSettingType)
 
   useEffect(() => {
-    if (clientSettingQuery) {
-      state.set({ loading: clientSettingQuery.status === 'pending', errorMessage: clientSettingQuery.error })
-    }
-  }, [clientSettingQuery])
-
-  useEffect(() => {
     if (clientSettings) {
       settingsState.set(clientSettings)
       state.set({ loading: false, errorMessage: '' })
@@ -109,6 +103,7 @@ const ClientTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableRef
       createdAt: undefined!,
       updatedAt: undefined!
     } as any as ClientSettingType
+
     Engine.instance.api
       .service(clientSettingPath)
       .patch(id, newSettings)

--- a/packages/client-core/src/admin/components/settings/tabs/instanceServer.tsx
+++ b/packages/client-core/src/admin/components/settings/tabs/instanceServer.tsx
@@ -23,21 +23,82 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HiMinus, HiPlusSmall } from 'react-icons/hi2'
 
-import { instanceServerSettingPath } from '@etherealengine/common/src/schema.type.module'
-import { useHookstate } from '@etherealengine/hyperflux'
+import { instanceServerSettingPath, InstanceServerSettingType } from '@etherealengine/common/src/schema.type.module'
+import { Engine } from '@etherealengine/ecs'
+import { NO_PROXY, State, useHookstate } from '@etherealengine/hyperflux'
 import { useFind } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
+import PasswordInput from '@etherealengine/ui/src/components/tailwind/PasswordInput'
 import Accordion from '@etherealengine/ui/src/primitives/tailwind/Accordion'
+import Button from '@etherealengine/ui/src/primitives/tailwind/Button'
+import Checkbox from '@etherealengine/ui/src/primitives/tailwind/Checkbox'
 import Input from '@etherealengine/ui/src/primitives/tailwind/Input'
+import LoadingView from '@etherealengine/ui/src/primitives/tailwind/LoadingView'
+import Text from '@etherealengine/ui/src/primitives/tailwind/Text'
 import Toggle from '@etherealengine/ui/src/primitives/tailwind/Toggle'
 
 const InstanceServerTab = forwardRef(({ open }: { open: boolean }, ref: React.MutableRefObject<HTMLDivElement>) => {
   const { t } = useTranslation()
-  const instanceServerSettings = useFind(instanceServerSettingPath).data
+
+  const state = useHookstate({
+    loading: false,
+    errorMessage: ''
+  })
+
+  const instanceServerSettingQuery = useFind(instanceServerSettingPath)
+  const instanceServerSettings = instanceServerSettingQuery.data[0] ?? null
+  const id = instanceServerSettings?.id
   const local = useHookstate(true)
+
+  const settingsState = useHookstate(null as null | InstanceServerSettingType)
+  const stringifiedIceServers = useHookstate('')
+
+  useEffect(() => {
+    if (instanceServerSettings) {
+      settingsState.set(instanceServerSettings)
+      stringifiedIceServers.set(JSON.stringify(instanceServerSettings.webRTCSettings.iceServers))
+      state.set({ loading: false, errorMessage: '' })
+    }
+  }, [instanceServerSettings])
+
+  const handleSubmit = (event) => {
+    state.loading.set(true)
+    event.preventDefault()
+    const newSettings = {
+      ...settingsState.get(NO_PROXY),
+      createdAt: undefined!,
+      updatedAt: undefined!
+    } as any as InstanceServerSettingType
+    try {
+      if (stringifiedIceServers.value.length === 0) stringifiedIceServers.set('[]')
+      newSettings.webRTCSettings.iceServers = JSON.parse(stringifiedIceServers.value)
+    } catch (err) {
+      //
+    }
+
+    Engine.instance.api
+      .service(instanceServerSettingPath)
+      .patch(id, newSettings)
+      .then(() => {
+        state.set({ loading: false, errorMessage: '' })
+        instanceServerSettingQuery.refetch()
+      })
+      .catch((e) => {
+        state.set({ loading: false, errorMessage: e.message })
+      })
+  }
+
+  const handleCancel = () => {
+    settingsState.set(instanceServerSettings)
+  }
+
+  if (!settingsState.value)
+    return <LoadingView fullScreen className="block h-12 w-12" title={t('common:loader.loading')} />
+
+  const settings = settingsState as State<InstanceServerSettingType>
 
   return (
     <Accordion
@@ -48,77 +109,144 @@ const InstanceServerTab = forwardRef(({ open }: { open: boolean }, ref: React.Mu
       ref={ref}
       open={open}
     >
-      {instanceServerSettings.map((el) => (
-        <div className="mt-6 grid grid-cols-2 gap-6">
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.clientHost')}
-            value={el?.clientHost || ''}
-            disabled
-          />
+      <div className="mt-6 grid grid-cols-2 gap-6">
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.clientHost')}
+          value={settings?.clientHost.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.domain')}
-            value={el?.domain || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.domain')}
+          value={settings?.domain.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.rtcStartPort')}
-            value={el?.rtcStartPort || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.rtcStartPort')}
+          value={settings?.rtcStartPort.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.releaseName')}
-            value={el?.releaseName || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.releaseName')}
+          value={settings?.releaseName.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.rtcEndPort')}
-            value={el?.rtcEndPort || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.rtcEndPort')}
+          value={settings?.rtcEndPort.value || ''}
+          disabled
+        />
 
-          <Input className="col-span-1" label={t('admin:components.setting.port')} value={el?.port || ''} disabled />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.port')}
+          value={settings?.port.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.rtcPortBlockSize')}
-            value={el?.rtcPortBlockSize || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.rtcPortBlockSize')}
+          value={settings?.rtcPortBlockSize.value || ''}
+          disabled
+        />
 
-          <Input className="col-span-1" label={t('admin:components.setting.mode')} value={el?.mode || ''} disabled />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.mode')}
+          value={settings?.mode.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.identifierDigits')}
-            value={el?.identifierDigits || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.identifierDigits')}
+          value={settings?.identifierDigits.value || ''}
+          disabled
+        />
 
-          <Input
-            className="col-span-1"
-            label={t('admin:components.setting.locationName')}
-            value={el?.locationName || ''}
-            disabled
-          />
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.locationName')}
+          value={settings?.locationName.value || ''}
+          disabled
+        />
 
-          <Toggle
-            containerClassName="justify-start"
-            label={t('admin:components.setting.local')}
-            value={local.value}
-            disabled
-            onChange={(value) => local.set(value)}
-          />
-        </div>
-      ))}
+        <Toggle
+          containerClassName="justify-start"
+          label={t('admin:components.setting.local')}
+          value={local.value}
+          disabled
+          onChange={(value) => local.set(value)}
+        />
+
+        <Text component="h3" fontSize="xl" fontWeight="semibold" className="col-span-full mb-4">
+          {t('admin:components.setting.webRTCSettings.main')}
+        </Text>
+
+        <Input
+          className="col-span-1"
+          label={t('admin:components.setting.webRTCSettings.iceServers')}
+          value={stringifiedIceServers.value || '[]'}
+          onChange={(e) => {
+            stringifiedIceServers.set(e.target.value)
+          }}
+        />
+
+        <PasswordInput
+          className="col-span-1"
+          label={t('admin:components.setting.webRTCSettings.webRTCStaticAuthSecretKey')}
+          value={settings.webRTCSettings.webRTCStaticAuthSecretKey.value || ''}
+          onChange={(e) => {
+            settings.webRTCSettings.webRTCStaticAuthSecretKey.set(e.target.value)
+          }}
+        />
+
+        <Checkbox
+          className="col-span-1"
+          label={t('admin:components.setting.webRTCSettings.useCustomICEServers')}
+          value={settings.webRTCSettings.useCustomICEServers.value || false}
+          onChange={(value) => settings.webRTCSettings.useCustomICEServers.set(value)}
+        />
+
+        <Checkbox
+          className="col-span-1"
+          label={t('admin:components.setting.webRTCSettings.useTimeLimitedCredentials')}
+          value={settings.webRTCSettings.useTimeLimitedCredentials.value || false}
+          onChange={(value) => settings.webRTCSettings.useTimeLimitedCredentials.set(value)}
+        />
+
+        <Checkbox
+          className="col-span-1"
+          label={t('admin:components.setting.webRTCSettings.usePrivateInstanceserverIP')}
+          value={settings.webRTCSettings.usePrivateInstanceserverIP.value || false}
+          onChange={(value) => settings.webRTCSettings.usePrivateInstanceserverIP.set(value)}
+        />
+      </div>
+
+      <div className="mt-6 grid grid-cols-8 gap-6">
+        <Button size="small" className="text-primary col-span-1 bg-theme-highlight" fullWidth onClick={handleCancel}>
+          {t('admin:components.common.reset')}
+        </Button>
+        <Button
+          size="small"
+          variant="primary"
+          className="col-span-1"
+          fullWidth
+          onClick={handleSubmit}
+          startIcon={state.loading.value && <LoadingView spinnerOnly className="h-6 w-6" />}
+        >
+          {t('admin:components.common.save')}
+        </Button>
+      </div>
     </Accordion>
   )
 })

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -41,7 +41,6 @@ import { v4 as uuidv4 } from 'uuid'
 
 import config from '@etherealengine/common/src/config'
 import { BotUserAgent } from '@etherealengine/common/src/constants/BotUserAgent'
-import { PUBLIC_STUN_SERVERS } from '@etherealengine/common/src/constants/STUNServers'
 import multiLogger from '@etherealengine/common/src/logger'
 import {
   ChannelID,
@@ -486,13 +485,10 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
   const network = getState(NetworkState).networks[action.$network] as SocketWebRTCClientNetwork | undefined
   if (!network) return console.warn('Network not found', action.$network)
 
-  const { transportID, direction, sctpParameters, iceParameters, iceCandidates, dtlsParameters } = action
-
   const channelId = getChannelIdFromTransport(network)
+  const { transportID, direction, sctpParameters, iceParameters, iceCandidates, iceServers, dtlsParameters } = action
 
   let transport: MediaSoupTransport
-
-  const iceServers = config.client.nodeEnv === 'production' ? PUBLIC_STUN_SERVERS : []
 
   const transportOptions = {
     id: action.transportID,
@@ -500,7 +496,7 @@ export const onTransportCreated = async (action: typeof MediasoupTransportAction
     iceParameters: iceParameters as any,
     iceCandidates: iceCandidates as any,
     dtlsParameters: dtlsParameters as any,
-    iceServers
+    iceServers: iceServers as any
   }
 
   if (direction === 'recv') {

--- a/packages/common/src/constants/DefaultWebRTCSettings.ts
+++ b/packages/common/src/constants/DefaultWebRTCSettings.ts
@@ -1,0 +1,36 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+export const CREDENTIAL_OFFSET = 60 * 10
+//coturn requires the password be hashed via SHA1, tried SHA256 and it didn't work
+export const HASH_ALGORITHM = 'sha1'
+
+export const defaultWebRTCSettings = {
+  iceServers: [],
+  useCustomICEServers: false,
+  useTimeLimitedCredentials: false,
+  webRTCStaticAuthSecretKey: '',
+  usePrivateInstanceserverIP: false
+}

--- a/packages/common/src/schemas/setting/instance-server-setting.schema.ts
+++ b/packages/common/src/schemas/setting/instance-server-setting.schema.ts
@@ -33,6 +33,30 @@ export const instanceServerSettingPath = 'instance-server-setting'
 
 export const instanceServerSettingMethods = ['find', 'get', 'create', 'patch', 'remove'] as const
 
+export const iceServerSchema = Type.Object(
+  {
+    urls: Type.String() || Type.Array(Type.String()),
+    username: Type.Optional(Type.String()),
+    credential: Type.Optional(Type.String())
+  },
+  { $id: 'IceServerSchema', additionalProperties: false }
+)
+
+export interface IceServerType extends Static<typeof iceServerSchema> {}
+
+export const webRTCSettingsSchema = Type.Object(
+  {
+    iceServers: Type.Array(Type.Ref(iceServerSchema)),
+    useCustomICEServers: Type.Boolean(),
+    useTimeLimitedCredentials: Type.Boolean(),
+    webRTCStaticAuthSecretKey: Type.String(),
+    usePrivateInstanceserverIP: Type.Boolean()
+  },
+  { $id: 'webRTCSettingsSchema', additionalProperties: false }
+)
+
+export interface webRTCSettingsType extends Static<typeof webRTCSettingsSchema> {}
+
 // Main data model schema
 export const instanceServerSettingSchema = Type.Object(
   {
@@ -50,6 +74,7 @@ export const instanceServerSettingSchema = Type.Object(
     port: Type.String(),
     mode: Type.String(),
     locationName: Type.String(),
+    webRTCSettings: Type.Ref(webRTCSettingsSchema),
     createdAt: Type.String({ format: 'date-time' }),
     updatedAt: Type.String({ format: 'date-time' })
   },
@@ -71,7 +96,8 @@ export const instanceServerSettingDataSchema = Type.Pick(
     'releaseName',
     'port',
     'mode',
-    'locationName'
+    'locationName',
+    'webRTCSettings'
   ],
   {
     $id: 'InstanceServerSettingData'
@@ -110,6 +136,8 @@ export const instanceServerSettingQuerySchema = Type.Intersect(
 )
 export interface InstanceServerSettingQuery extends Static<typeof instanceServerSettingQuerySchema> {}
 
+export const iceServerValidator = /* @__PURE__ */ getValidator(iceServerSchema, dataValidator)
+export const webRTCSettingsValidator = /* @__PURE__ */ getValidator(webRTCSettingsSchema, dataValidator)
 export const instanceServerSettingValidator = /* @__PURE__ */ getValidator(instanceServerSettingSchema, dataValidator)
 export const instanceServerSettingDataValidator = /* @__PURE__ */ getValidator(
   instanceServerSettingDataSchema,

--- a/packages/network/src/transports/mediasoup/MediasoupTransportState.tsx
+++ b/packages/network/src/transports/mediasoup/MediasoupTransportState.tsx
@@ -66,6 +66,7 @@ export class MediasoupTransportActions {
     sctpParameters: matches.object,
     iceParameters: matches.object,
     iceCandidates: matches.arrayOf(matches.object),
+    iceServers: matches.arrayOf(matches.object),
     dtlsParameters: matches.object as Validator<
       unknown,
       {

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.resolvers.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.resolvers.ts
@@ -34,23 +34,67 @@ import {
 import { fromDateTimeSql, getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import type { HookContext } from '@etherealengine/server-core/declarations'
 
-export const instanceServerSettingResolver = resolve<InstanceServerSettingType, HookContext>({
-  createdAt: virtual(async (instanceServerSetting) => fromDateTimeSql(instanceServerSetting.createdAt)),
-  updatedAt: virtual(async (instanceServerSetting) => fromDateTimeSql(instanceServerSetting.updatedAt))
-})
+export const instanceServerSettingResolver = resolve<InstanceServerSettingType, HookContext>(
+  {
+    createdAt: virtual(async (instanceServerSetting) => fromDateTimeSql(instanceServerSetting.createdAt)),
+    updatedAt: virtual(async (instanceServerSetting) => fromDateTimeSql(instanceServerSetting.updatedAt))
+  },
+  {
+    converter: async (rawData): Promise<InstanceServerSettingType> => {
+      const webRTCSettings = JSON.parse(rawData.webRTCSettings)
+      return {
+        ...rawData,
+        webRTCSettings
+      }
+    }
+  }
+)
 
 export const instanceServerSettingExternalResolver = resolve<InstanceServerSettingType, HookContext>({})
 
-export const instanceServerSettingDataResolver = resolve<InstanceServerSettingType, HookContext>({
-  id: async () => {
-    return uuidv4()
+export const instanceServerSettingDataResolver = resolve<InstanceServerSettingType, HookContext>(
+  {
+    id: async () => {
+      return uuidv4()
+    },
+    createdAt: getDateTimeSql,
+    updatedAt: getDateTimeSql
   },
-  createdAt: getDateTimeSql,
-  updatedAt: getDateTimeSql
-})
+  {
+    converter: async (rawData, context) => {
+      try {
+        if (typeof rawData.webRTCSettings.iceServers === 'string')
+          rawData.webRTCSettings.iceServers = JSON.parse(rawData.webRTCSettings.iceServers)
+      } catch (err) {
+        // Do nothing
+      }
 
-export const instanceServerSettingPatchResolver = resolve<InstanceServerSettingType, HookContext>({
-  updatedAt: getDateTimeSql
-})
+      return {
+        ...rawData,
+        webRTCSettings: JSON.stringify(rawData.webRTCSettings)
+      }
+    }
+  }
+)
+
+export const instanceServerSettingPatchResolver = resolve<InstanceServerSettingType, HookContext>(
+  {
+    updatedAt: getDateTimeSql
+  },
+  {
+    converter: async (rawData, context) => {
+      try {
+        if (typeof rawData.webRTCSettings.iceServers === 'string')
+          rawData.webRTCSettings.iceServers = JSON.parse(rawData.webRTCSettings.iceServers)
+      } catch (err) {
+        // Do nothing
+      }
+      return {
+        ...rawData,
+        webRTCSettings: JSON.stringify(rawData.webRTCSettings)
+      }
+    }
+  }
+)
 
 export const instanceServerSettingQueryResolver = resolve<InstanceServerSettingQuery, HookContext>({})

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.seed.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.seed.ts
@@ -26,10 +26,12 @@ Ethereal Engine. All Rights Reserved.
 import { Knex } from 'knex'
 import { v4 as uuidv4 } from 'uuid'
 
+import { defaultWebRTCSettings } from '@etherealengine/common/src/constants/DefaultWebRTCSettings'
 import {
   instanceServerSettingPath,
   InstanceServerSettingType
 } from '@etherealengine/common/src/schemas/setting/instance-server-setting.schema'
+
 import { getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import appConfig from '@etherealengine/server-core/src/appconfig'
 
@@ -50,7 +52,8 @@ export async function seed(knex: Knex): Promise<void> {
         releaseName: process.env.RELEASE_NAME || 'local',
         port: process.env.INSTANCESERVER_PORT || '3031',
         mode: process.env.INSTANCESERVER_MODE || 'dev',
-        locationName: process.env.PRELOAD_LOCATION_NAME || ''
+        locationName: process.env.PRELOAD_LOCATION_NAME || '',
+        webRTCSettings: defaultWebRTCSettings
       }
     ].map(async (item) => ({
       ...item,

--- a/packages/server-core/src/setting/instance-server-setting/migrations/20240703210203_webrtc-settings-column.ts
+++ b/packages/server-core/src/setting/instance-server-setting/migrations/20240703210203_webrtc-settings-column.ts
@@ -1,0 +1,59 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import type { Knex } from 'knex'
+
+import { defaultWebRTCSettings } from '@etherealengine/common/src/constants/DefaultWebRTCSettings'
+import { instanceServerSettingPath } from '@etherealengine/common/src/schemas/setting/instance-server-setting.schema'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  const webRTCSettingsColumnExists = await knex.schema.hasColumn(instanceServerSettingPath, 'webRTCSettings')
+  if (!webRTCSettingsColumnExists) {
+    await knex.schema.alterTable(instanceServerSettingPath, async (table) => {
+      table.json('webRTCSettings')
+    })
+    await knex.table(instanceServerSettingPath).update({
+      webRTCSettings: JSON.stringify(defaultWebRTCSettings)
+    })
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  const webRTCSettingsColumnExists = await knex.schema.hasColumn(instanceServerSettingPath, 'webRTCSettings')
+
+  if (webRTCSettingsColumnExists) {
+    await knex.schema.alterTable(instanceServerSettingPath, async (table) => {
+      table.dropColumn('webRTCSettings')
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Upgraded WebRTC options
    
Added webRTCSettings column to instance-server-settings table.
This allows for configuration of custom iceServers definition, as
well as returning raw IP addresses for private instanceserver addresses
instead of private DNS records, and using the TURN REST API to generate
temporary credentials for users to access a TURN server.

This allows for using a TURN server to relay WebRTC connections, so that
instanceservers can be placed behind private subnets and still be reachable.
This will also work inside a VPN as a STUN server, and can still make direct
connections.

iceServers definition is now always provided to the client from the instanceserver
over the websocket connection when making a transport. This allows the
instanceserver to generate credentials for the TURN REST API from the shared
secret without the client knowing anything about the workings of that process.
It just gets told where to connect to for STUN/TURN, and any credentials if
that's relevant.

Resolves IR-1445 and all associated issues.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
