### PR TITLE
Fixed issues with archiving projects

### DIFF
--- a/packages/server-core/src/media/recursive-archiver/archiver.class.ts
+++ b/packages/server-core/src/media/recursive-archiver/archiver.class.ts
@@ -126,11 +126,12 @@ export class ArchiverService implements ServiceInterface<string, ArchiverParams>
         returnData: '',
         status: 'pending'
       })
+      const projectJobName = project.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
       const jobBody = await getDirectoryArchiveJobBody(this.app, project, newJob.id)
       await this.app.service(apiJobPath).patch(newJob.id, {
         name: jobBody.metadata!.name
       })
-      const jobLabelSelector = `etherealengine/projectField=${project},etherealengine/release=${process.env.RELEASE_NAME},etherealengine/directoryArchiver=true`
+      const jobLabelSelector = `etherealengine/projectField=${projectJobName},etherealengine/release=${process.env.RELEASE_NAME},etherealengine/directoryArchiver=true`
       const jobFinishedPromise = createExecutorJob(
         this.app,
         jobBody,

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -96,11 +96,12 @@ function handler(event) {
     var recordingsRegex = new RegExp(recordingsRegexRoot)
     var publicRegexRoot = __$publicRegex$__
     var publicRegex = new RegExp(publicRegexRoot)
+    var tempRegex = new RegExp('/temp/')
     
     if (publicRegex.test(request.uri)) {
         request.uri = '/client' + request.uri
-    } else if (projectsRegex.test(request.uri) || recordingsRegex.test(request.uri)) {
-        // Projects and recordings paths should be passed as-is
+    } else if (projectsRegex.test(request.uri) || recordingsRegex.test(request.uri) || tempRegex.test(request.uri)) {
+        // Projects, temp files, and recordings paths should be passed as-is
     } else {
       // Anything that is not a static/public file, or a project or recording file, is assumed to be some sort
       // of engine route and passed to index.html to be handled by the router

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1037,14 +1037,17 @@ export async function getProjectUpdateJobBody(
     command.push(data.reset.toString())
   }
 
+  const projectJobName = data.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+
   const labels = {
     'etherealengine/projectUpdater': 'true',
     'etherealengine/autoUpdate': 'false',
-    'etherealengine/projectField': data.name,
+    'etherealengine/projectField': projectJobName,
     'etherealengine/release': process.env.RELEASE_NAME!
   }
 
-  const name = `${process.env.RELEASE_NAME}-${data.name}-update`
+  const name = `${process.env.RELEASE_NAME}-${projectJobName}-update`
+
   return getJobBody(app, command, name, labels)
 }
 export async function getProjectPushJobBody(
@@ -1082,25 +1085,28 @@ export async function getProjectPushJobBody(
     command.push(storageProviderName)
   }
 
+  const projectJobName = project.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+
   const labels = {
     'etherealengine/projectPusher': 'true',
-    'etherealengine/projectField': project.name,
+    'etherealengine/projectField': projectJobName,
     'etherealengine/release': process.env.RELEASE_NAME!
   }
 
-  const name = `${process.env.RELEASE_NAME}-${project.name.toLowerCase()}-gh-push`
+  const name = `${process.env.RELEASE_NAME}-${projectJobName}-gh-push`
 
   return getJobBody(app, command, name, labels)
 }
 
 export const getCronJobBody = (project: ProjectType, image: string): object => {
+  const projectJobName = project.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
   return {
     metadata: {
-      name: `${process.env.RELEASE_NAME}-${project.name.toLowerCase()}-auto-update`,
+      name: `${process.env.RELEASE_NAME}-${projectJobName}-auto-update`,
       labels: {
         'etherealengine/projectUpdater': 'true',
         'etherealengine/autoUpdate': 'true',
-        'etherealengine/projectField': project.name,
+        'etherealengine/projectField': projectJobName,
         'etherealengine/projectId': project.id,
         'etherealengine/release': process.env.RELEASE_NAME
       }
@@ -1117,7 +1123,7 @@ export const getCronJobBody = (project: ProjectType, image: string): object => {
               labels: {
                 'etherealengine/projectUpdater': 'true',
                 'etherealengine/autoUpdate': 'true',
-                'etherealengine/projectField': project.name,
+                'etherealengine/projectField': projectJobName,
                 'etherealengine/projectId': project.id,
                 'etherealengine/release': process.env.RELEASE_NAME
               }
@@ -1169,13 +1175,15 @@ export async function getDirectoryArchiveJobBody(
     jobId
   ]
 
+  const projectJobName = projectName.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+
   const labels = {
     'etherealengine/directoryArchiver': 'true',
-    'etherealengine/projectField': projectName,
+    'etherealengine/projectField': projectJobName,
     'etherealengine/release': process.env.RELEASE_NAME || ''
   }
 
-  const name = `${process.env.RELEASE_NAME}-${projectName}-archive`
+  const name = `${process.env.RELEASE_NAME}-${projectJobName}-archive`
 
   return getJobBody(app, command, name, labels)
 }

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -542,6 +542,7 @@ const updateProjectJob = async (context: HookContext) => {
       returnData: '',
       status: 'pending'
     })
+    const projectJobName = data.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
     const jobBody = await getProjectUpdateJobBody(
       data,
       context.app,
@@ -552,7 +553,7 @@ const updateProjectJob = async (context: HookContext) => {
     await context.app.service(apiJobPath).patch(newJob.id, {
       name: jobBody.metadata!.name
     })
-    const jobLabelSelector = `etherealengine/projectField=${data.name},etherealengine/release=${process.env.RELEASE_NAME},etherealengine/autoUpdate=false`
+    const jobLabelSelector = `etherealengine/projectField=${projectJobName},etherealengine/release=${process.env.RELEASE_NAME},etherealengine/autoUpdate=false`
     const jobFinishedPromise = createExecutorJob(context.app, jobBody, jobLabelSelector, 1000, newJob.id)
     try {
       await jobFinishedPromise


### PR DESCRIPTION
## Summary

Cloudfront function was not passing /temp paths as-is, and was mistakenly redirecting them to client/index.html

Some setups' projects have slashes in the project name (<org_name>/<project_name>), and slashes cannot be included in k8s job/service/pod/etc. names. Now replacing all disallowed characters in job names with slashes.

Resolves IR-1351

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
