### PR TITLE
disallow project query without pagination

### DIFF
--- a/packages/common/src/schemas/projects/project.schema.ts
+++ b/packages/common/src/schemas/projects/project.schema.ts
@@ -117,7 +117,6 @@ export const projectQuerySchema = Type.Intersect(
     Type.Object(
       {
         assetsOnly: Type.Optional(Type.Boolean()),
-        paginate: Type.Optional(Type.Boolean()),
         action: Type.Optional(Type.String()),
         sourceURL: Type.Optional(Type.String()),
         destinationURL: Type.Optional(Type.String()),

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -197,7 +197,8 @@ const ProjectsPage = ({ studioPath }: { studioPath: string }) => {
   const { create: projectCreateQuery, remove: projectRemoveQuery } = useMutation(projectPath)
   const projectFindQuery = useFind(projectPath, {
     query: {
-      paginate: false,
+      /** @todo - add pagination to UI */
+      $limit: 1000,
       action: 'studio',
       allowed: true,
       ...(!!search.query.value && { name: { $like: `%${search.query.value}%` } }),

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -65,7 +65,6 @@ import { checkScope } from '@etherealengine/spatial/src/common/functions/checkSc
 import { HookContext } from '../../../declarations'
 import config from '../../appconfig'
 import { createSkippableHooks } from '../../hooks/createSkippableHooks'
-import enableClientPagination from '../../hooks/enable-client-pagination'
 import isAction from '../../hooks/is-action'
 import { isSignedByAppJWT } from '../../hooks/is-signed-by-app-jwt'
 import projectPermissionAuthenticate from '../../hooks/project-permission-authenticate'
@@ -587,7 +586,6 @@ export default createSkippableHooks(
     before: {
       all: [schemaHooks.validateQuery(projectQueryValidator), schemaHooks.resolveQuery(projectQueryResolver)],
       find: [
-        enableClientPagination(),
         iffElse(isAction('admin'), [], filterDisabledProjects),
         discardQuery('action'),
         ensurePushStatus,

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -191,7 +191,7 @@ function extractDirectoryWithoutOrgName(directory: string, orgName: string) {
  * @todo will be optimized away once orgname is fully supported
  */
 export const useValidProjectForFileBrowser = (path: string) => {
-  const [orgName, projectName] = path.split('/').slice(2, 3)
+  const [orgName, projectName] = path.split('/').slice(2, 4)
   const projects = useFind(projectPath, {
     query: {
       $or: [
@@ -199,7 +199,7 @@ export const useValidProjectForFileBrowser = (path: string) => {
           name: `${orgName}/${projectName}`
         },
         {
-          name: projectName
+          name: orgName
         }
       ],
       action: 'studio',
@@ -207,8 +207,8 @@ export const useValidProjectForFileBrowser = (path: string) => {
     }
   })
   return (
-    projects.data.find((project) => project.name === projectName || project.name === `${orgName}/${projectName}`)
-      ?.name ?? ''
+    projects.data.find((project) => project.name === orgName || project.name === `${orgName}/${projectName}`)?.name ??
+    ''
   )
 }
 

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -188,16 +188,28 @@ function extractDirectoryWithoutOrgName(directory: string, orgName: string) {
 
 /**
  * Gets the project name that may or may not have a single slash it in from a list of valid project names
+ * @todo will be optimized away once orgname is fully supported
  */
-export const useValidProjectForFileBrowser = (projectName: string) => {
+export const useValidProjectForFileBrowser = (path: string) => {
+  const [orgName, projectName] = path.split('/').slice(2, 3)
   const projects = useFind(projectPath, {
     query: {
-      paginate: false,
+      $or: [
+        {
+          name: `${orgName}/${projectName}`
+        },
+        {
+          name: projectName
+        }
+      ],
       action: 'studio',
       allowed: true
     }
   })
-  return projects.data.find((project) => projectName.startsWith(`/projects/${project.name}/`))?.name ?? ''
+  return (
+    projects.data.find((project) => project.name === projectName || project.name === `${orgName}/${projectName}`)
+      ?.name ?? ''
+  )
 }
 
 function GeneratingThumbnailsProgress() {


### PR DESCRIPTION
## Summary

We no longer are using the project service from the client without pagination, so we should disallow this to avoid causing considerable load on the server if someone was to request this.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
