### PR TITLE
Made some project fields conditionally submitted

### DIFF
--- a/packages/common/src/schemas/projects/project.schema.ts
+++ b/packages/common/src/schemas/projects/project.schema.ts
@@ -55,7 +55,7 @@ export const projectSchema = Type.Object(
     hasLocalChanges: Type.Boolean(),
     sourceRepo: Type.Optional(Type.String()),
     sourceBranch: Type.Optional(Type.String()),
-    updateType: StringEnum(projectUpdateTypes),
+    updateType: Type.Optional(StringEnum(projectUpdateTypes)),
     updateSchedule: Type.Optional(Type.String()),
     updateUserId: Type.Optional(Type.String()),
     hasWriteAccess: Type.Optional(Type.Boolean()),

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -159,6 +159,7 @@ export class FileBrowserService
     for (const file of result) {
       const resource = resourceMap[file.key]
       if (resource) {
+        file.url = resource.url
         file.thumbnailURL = resource.thumbnailURL
       }
     }


### PR DESCRIPTION
## Summary
   
New validators will reject if you supply null for a string value.
You have to either supply a string or not supply the field at all.
Fixed this on project.update when creating or patching the project
record.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
