### PR TITLE
Changes to remove duplicate component and add empty userId

### DIFF
--- a/packages/server-core/src/ServerLogger.ts
+++ b/packages/server-core/src/ServerLogger.ts
@@ -143,8 +143,22 @@ export const logger = pino(
     level: 'debug',
     enabled: useLogger,
     base: {
-      hostname: os.hostname,
-      component: 'server-core'
+      hostname: os.hostname
+    },
+    hooks: {
+      logMethod(inputArgs, method, level) {
+        const { component, userId } = this.bindings()
+
+        if (!component && !userId) {
+          inputArgs.unshift({ component: 'server-core', userId: '' })
+        } else if (component) {
+          inputArgs.unshift({ userId: '' })
+        } else if (userId) {
+          inputArgs.unshift({ component: 'server-core' })
+        }
+
+        return method.apply(this, inputArgs)
+      }
     }
   },
   multiStream


### PR DESCRIPTION
## Summary

This PR ensures if `userId` does not exist then `userId: ''` should be the part of each log object.

Also, it removes multiple `component` key being part of each log object.

Concern was raised in a following comment (Point 1, 2 addressed in this PR):
https://theinfinitereality.slack.com/archives/C07AM5JE1EG/p1720599686558509

Below is the log file generated by it:
[irengine.log](https://github.com/user-attachments/files/16176245/irengine.log)

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
