### PR TITLE
Fix thumbnail queries to get full list of static resources

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -147,13 +147,15 @@ export class FileBrowserService
       })
     }
 
-    const resourceQuery = await this.app.service(staticResourcePath).find({
+    const resourceQuery = (await this.app.service(staticResourcePath).find({
       query: {
-        key: { $in: result.map((file) => file.key) }
-      }
-    })
+        key: { $in: result.map((file) => file.key) },
+        $limit: 10000,
+        paginate: false
+      } as any
+    })) as unknown as StaticResourceType[]
     const resourceMap: Record<string, StaticResourceType> = {}
-    for (const resource of resourceQuery.data) {
+    for (const resource of resourceQuery) {
       resourceMap[resource.key] = resource
     }
     for (const file of result) {


### PR DESCRIPTION
Fixes two static resource queries where less than the total number of resources is getting returned, leading to incomplete thumbnail generation and thumbnail display
