### PR TITLE
allow only alphanumeric and dashes in scene name

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1339,7 +1339,7 @@
     "saveNewScene": {
       "title": "Save As",
       "lbl-name": "Scene Name",
-      "info-name": "Name must be between 4 and 64 characters and cannot contain underscores",
+      "info-name": "Name must be between 4 and 64 characters (with only alphabets, numbers, dashes allowed)",
       "lbl-confirm": "Save Scene"
     },
     "support": {

--- a/packages/common/src/regex/index.ts
+++ b/packages/common/src/regex/index.ts
@@ -26,7 +26,7 @@ Ethereal Engine. All Rights Reserved.
 // eslint-disable-next-line no-control-regex
 export const INVALID_FILENAME_REGEX = /[_<>:"/\\|?*\u0000-\u001F]/g
 export const WINDOWS_RESERVED_NAME_REGEX = /^(con|prn|aux|nul|com\d|lpt\d)$/i
-export const VALID_SCENE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_\-\s]{1,62}[a-zA-Z0-9_\-]$/
+export const VALID_SCENE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9_\-]$/
 
 /**
  * Matches CSS imports & URLS.

--- a/packages/common/tests/regex.test.ts
+++ b/packages/common/tests/regex.test.ts
@@ -114,16 +114,7 @@ describe('regex.test', () => {
 
   describe('VALID_SCENE_NAME_REGEX', () => {
     it('should match valid scene names', () => {
-      const validSceneNames = [
-        'A123',
-        'file_name',
-        'user-name',
-        '12345',
-        'test file',
-        'my-file_123',
-        'Name123_456-789',
-        'a_b_c_d-e_f_g-h_i_j-k_l_m-n_o-p-q_r-s_t-u_v-w_x-y_z0123456789_-'
-      ]
+      const validSceneNames = ['A123', 'file-name', '12345', 'My-good-file']
       validSceneNames.forEach((filename) => {
         assert.ok(VALID_SCENE_NAME_REGEX.test(filename), `Expected '${filename}' to be valid scene names`)
       })
@@ -132,11 +123,13 @@ describe('regex.test', () => {
     it('should not match invalid scene names', () => {
       const invalidSceneNames = [
         'A1',
-        '_test',
+        '-test',
         'invalid!',
-        'very_long_string_that_is_definitely_not_going_to_match_the_regex_because_it_is_way_too_long_for_the_pattern',
+        'very-long-string-that-is-definitely-not-going-to-match-the-regex-because-it-is-way-too-long-for-the-pattern',
         '--double-hyphen',
-        '...'
+        '...',
+        'underscore_in_between',
+        'my-file_123'
       ]
       invalidSceneNames.forEach((filename) => {
         assert.ok(!VALID_SCENE_NAME_REGEX.test(filename), `Expected '${filename}' to be invalid scene names`)


### PR DESCRIPTION
## Summary

change the scenenameregex to allow this

## Subtasks Checklist

## Breaking Changes

## References

https://tsu.atlassian.net/browse/IR-2972

## QA Steps

![image](https://github.com/user-attachments/assets/38002f51-0519-479c-a9ca-44a8498f8207)
