### PR TITLE
Hardened instanceserver initialization

### DIFF
--- a/packages/instanceserver/src/InstanceServerState.ts
+++ b/packages/instanceserver/src/InstanceServerState.ts
@@ -41,6 +41,7 @@ export const InstanceServerState = defineState({
     ready: false,
     instance: null! as InstanceType,
     isMediaInstance: false,
-    instanceServer: null! as AgonesGameServer
+    instanceServer: null! as AgonesGameServer,
+    port: 3031
   }
 })

--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -79,7 +79,7 @@ export const setupIPs = async () => {
   // Set up our instanceserver according to our current environment
   const announcedIp = config.kubernetes.enabled
     ? instanceServerState.instanceServer.value.status.address
-    : (await getLocalServerIp(instanceServerState.isMediaInstance.value)).ipAddress
+    : await getLocalServerIp()
 
   // @todo put this in hyperflux state
   mediaConfig.mediasoup.webRtcTransport.listenIps = [

--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -182,10 +182,11 @@ const initializeInstance = async ({
 }) => {
   logger.info('Initializing new instance')
 
-  const serverState = getState(ServerState)
-  const localIp = await getLocalServerIp(serverState.port === 3032)
+  const instanceServerState = getState(InstanceServerState)
   const selfIpAddress = `${status.address}:${status.portsList[0].port}`
-  const ipAddress = config.kubernetes.enabled ? selfIpAddress : `${localIp.ipAddress}:${localIp.port}`
+  const ipAddress = config.kubernetes.enabled
+    ? selfIpAddress
+    : `${await getLocalServerIp()}:${instanceServerState.port}`
   const existingInstanceQuery = {
     ipAddress: ipAddress,
     ended: false

--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -30,7 +30,6 @@ import '@feathersjs/transport-commons'
 import { decode } from 'jsonwebtoken'
 
 import {
-  ChannelID,
   channelPath,
   ChannelType,
   channelUserPath,
@@ -130,22 +129,16 @@ const createNewInstance = async (app: Application, newInstance: InstanceData, he
  * Updates the existing 'instance' table entry
  * @param app
  * @param existingInstance
- * @param channelId
- * @param locationId
  * @param headers
  */
 
 const assignExistingInstance = async ({
   app,
   existingInstance,
-  channelId,
-  headers,
-  locationId
+  headers
 }: {
   app: Application
   existingInstance: InstanceType
-  channelId: ChannelID
-  locationId: LocationID
   headers: object
 }) => {
   const serverState = getState(ServerState)
@@ -153,12 +146,11 @@ const assignExistingInstance = async ({
 
   await serverState.agonesSDK.allocate()
   instanceServerState.instance.set(existingInstance)
+  instanceServerState.isMediaInstance.set(existingInstance.channelId != null)
   await app.service(instancePath).patch(
     existingInstance.id,
     {
       currentUsers: existingInstance.currentUsers + 1,
-      channelId: channelId,
-      locationId: locationId,
       podName: config.kubernetes.enabled ? instanceServerState.instanceServer.value?.objectMeta?.name : 'local',
       assigned: false,
       assignedAt: null!
@@ -172,8 +164,6 @@ const assignExistingInstance = async ({
  * - Should only initialize an instance once per the lifecycle of an instance server
  * @param app
  * @param status
- * @param locationId
- * @param channelId
  * @param headers
  * @param userId
  * @returns
@@ -182,39 +172,28 @@ const assignExistingInstance = async ({
 const initializeInstance = async ({
   app,
   status,
-  locationId,
-  channelId,
   headers,
   userId
 }: {
   app: Application
   status: InstanceserverStatus
-  locationId: LocationID
-  channelId: ChannelID
   headers: object
   userId?: UserID
 }) => {
   logger.info('Initializing new instance')
 
   const serverState = getState(ServerState)
-  const instanceServerState = getMutableState(InstanceServerState)
-
-  const isMediaInstance = !!channelId
-  instanceServerState.isMediaInstance.set(isMediaInstance)
-
-  const localIp = await getLocalServerIp(isMediaInstance)
+  const localIp = await getLocalServerIp(serverState.port === 3032)
   const selfIpAddress = `${status.address}:${status.portsList[0].port}`
   const ipAddress = config.kubernetes.enabled ? selfIpAddress : `${localIp.ipAddress}:${localIp.port}`
   const existingInstanceQuery = {
     ipAddress: ipAddress,
     ended: false
   } as any
-  if (locationId) existingInstanceQuery.locationId = locationId
-  else if (channelId) existingInstanceQuery.channelId = channelId
 
   /**
-   * The instance record should be created when the instance is provisioned by the API server,
-   * here we check that this is the case, as it may be altered, for example by another service or an admin
+   * The instance record should be created when the instance is provisioned by the API server.
+   * If it's not, then throw an error and don't connect, because something is wrong.
    */
 
   const existingInstanceResult = (await app.service(instancePath).find({
@@ -223,18 +202,10 @@ const initializeInstance = async ({
   })) as Paginated<InstanceType>
   logger.info('existingInstanceResult: %o', existingInstanceResult.data)
 
-  if (existingInstanceResult.total === 0) {
-    const newInstance = {
-      currentUsers: 1,
-      locationId: locationId,
-      channelId: channelId,
-      ipAddress: ipAddress,
-      podName: config.kubernetes.enabled ? instanceServerState.instanceServer.value?.objectMeta?.name : 'local'
-    } as InstanceData
-    await createNewInstance(app, newInstance, headers)
-  } else {
+  if (existingInstanceResult.total > 0) {
     const instance = existingInstanceResult.data[0]
-    if (locationId) {
+    if (userId && !(await authorizeUserToJoinServer(app, instance, userId))) return false
+    if (instance.locationId) {
       const existingChannel = (await app.service(channelPath).find({
         query: {
           instanceId: instance.id,
@@ -248,16 +219,15 @@ const initializeInstance = async ({
         })
       }
     }
-    await serverState.agonesSDK.allocate()
-    if (!instanceServerState.instance.value) instanceServerState.instance.set(instance)
-    if (userId && !(await authorizeUserToJoinServer(app, instance, userId))) return
     await assignExistingInstance({
       app,
       existingInstance: instance,
-      channelId,
-      headers,
-      locationId
+      headers
     })
+    return true
+  } else {
+    logger.error('Missing active instanceserver record for ' + ipAddress)
+    return false
   }
 }
 
@@ -399,26 +369,20 @@ let instanceStarted = false
  * Creates a new 'instance' entry or updates the current one with a connecting user, and handles initializing the instance server
  * @param app
  * @param status
- * @param locationId
- * @param channelId
  * @param sceneId
  * @param headers
  * @param userId
  * @returns
  */
-const createOrUpdateInstance = async ({
+const updateInstance = async ({
   app,
   status,
-  locationId,
-  channelId,
   sceneId,
   headers,
   userId
 }: {
   app: Application
   status: InstanceserverStatus
-  locationId: LocationID
-  channelId: ChannelID
   sceneId?: string
   headers: object
   userId?: UserID
@@ -429,15 +393,14 @@ const createOrUpdateInstance = async ({
   logger.info('Creating new instance server or updating current one.')
   logger.info(`agones state is ${status.state}`)
   logger.info('app instance is %o', instanceServerState.instance)
-  logger.info(`instanceLocationId: ${instanceServerState.instance?.locationId}, locationId: ${locationId}`)
 
   const isReady = status.state === 'Ready'
   const isNeedingNewServer = !config.kubernetes.enabled && !instanceStarted
 
   if (isReady || isNeedingNewServer) {
     instanceStarted = true
-    await initializeInstance({ app, status, locationId, channelId, headers, userId })
-    await loadEngine({ app, sceneId, headers })
+    const initialized = await initializeInstance({ app, status, headers, userId })
+    if (initialized) await loadEngine({ app, sceneId, headers })
   } else {
     try {
       if (!getState(InstanceServerState).ready)
@@ -450,7 +413,7 @@ const createOrUpdateInstance = async ({
           }, 1000)
         })
       const instance = await app.service(instancePath).get(instanceServerState.instance.id, { headers })
-      if (userId && !(await authorizeUserToJoinServer(app, instance, userId))) return
+      if (userId && !(await authorizeUserToJoinServer(app, instance, userId))) return false
 
       logger.info(`Authorized user ${userId} to join server`)
       await serverState.agonesSDK.allocate()
@@ -464,8 +427,10 @@ const createOrUpdateInstance = async ({
         },
         { headers }
       )
+      return true
     } catch (err) {
       logger.info('Could not update instance, likely because it is a local one that does not exist.')
+      return false
     }
   }
 }
@@ -705,22 +670,22 @@ export const onConnection = (app: Application) => async (connection: PrimusConne
   const isResult = await serverState.agonesSDK.getGameServer()
   const status = isResult.status as InstanceserverStatus
 
-  await createOrUpdateInstance({
+  const updated = await updateInstance({
     app,
     status,
-    locationId,
-    channelId,
     sceneId: sceneID,
     headers: connection.headers,
     userId
   })
 
-  if (instanceServerState.instance) {
-    connection.instanceId = instanceServerState.instance.id
-    app.channel(`instanceIds/${instanceServerState.instance.id}`).join(connection)
-  }
+  if (updated) {
+    if (instanceServerState.instance) {
+      connection.instanceId = instanceServerState.instance.id
+      app.channel(`instanceIds/${instanceServerState.instance.id}`).join(connection)
+    }
 
-  await handleUserAttendance(app, userId, connection.headers)
+    await handleUserAttendance(app, userId, connection.headers)
+  }
 }
 
 const onDisconnection = (app: Application) => async (connection: PrimusConnectionType) => {
@@ -812,11 +777,9 @@ export default (app: Application): void => {
       return
     }
 
-    await createOrUpdateInstance({
+    await updateInstance({
       app,
       status,
-      locationId,
-      channelId: null!,
       headers: params.headers,
       sceneId
     })

--- a/packages/instanceserver/src/start.ts
+++ b/packages/instanceserver/src/start.ts
@@ -185,6 +185,7 @@ export const start = async (): Promise<Application> => {
   server.on('listening', () =>
     logger.info('Feathers application started on %s://%s:%d', useSSL ? 'https' : 'http', config.server.hostname, port)
   )
+  serverState.port.set(port)
   await new Promise((resolve) => {
     const primusWaitInterval = setInterval(() => {
       if (app.primus) {

--- a/packages/instanceserver/src/start.ts
+++ b/packages/instanceserver/src/start.ts
@@ -44,6 +44,7 @@ import { ServerMode, ServerState } from '@etherealengine/server-core/src/ServerS
 
 import { startTimer } from '@etherealengine/spatial/src/startTimer'
 import channels from './channels'
+import { InstanceServerState } from './InstanceServerState'
 import { setupSocketFunctions } from './SocketFunctions'
 
 const logger = multiLogger.child({ component: 'instanceserver' })
@@ -185,7 +186,7 @@ export const start = async (): Promise<Application> => {
   server.on('listening', () =>
     logger.info('Feathers application started on %s://%s:%d', useSSL ? 'https' : 'http', config.server.hostname, port)
   )
-  serverState.port.set(port)
+  getMutableState(InstanceServerState).port.set(port)
   await new Promise((resolve) => {
     const primusWaitInterval = setInterval(() => {
       if (app.primus) {

--- a/packages/instanceserver/tests/InstanceLoad.test.ts
+++ b/packages/instanceserver/tests/InstanceLoad.test.ts
@@ -84,10 +84,10 @@ describe('InstanceLoad', () => {
       }
     })
 
-    const localIp = await getLocalServerIp(false)
+    const localIp = await getLocalServerIp()
     console.log('localIp', localIp)
     await app.service(instancePath).create({
-      ipAddress: `${localIp.ipAddress}:${localIp.port}`,
+      ipAddress: `${localIp}:3031`,
       currentUsers: 0,
       locationId: skyStationScene.data[0].id,
       assigned: false,

--- a/packages/instanceserver/tests/InstanceLoad.test.ts
+++ b/packages/instanceserver/tests/InstanceLoad.test.ts
@@ -23,17 +23,26 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+import getLocalServerIp from '@etherealengine/server-core/src/util/get-local-server-ip'
 import appRootPath from 'app-root-path'
 import assert from 'assert'
 import { ChildProcess } from 'child_process'
 import { v4 as uuidv4 } from 'uuid'
 
-import { identityProviderPath, locationPath, UserID } from '@etherealengine/common/src/schema.type.module'
+import {
+  identityProviderPath,
+  InstanceData,
+  instancePath,
+  locationPath,
+  RoomCode,
+  UserID
+} from '@etherealengine/common/src/schema.type.module'
 import { destroyEngine, Engine } from '@etherealengine/ecs/src/Engine'
 import { getState } from '@etherealengine/hyperflux'
 import { NetworkState } from '@etherealengine/network'
 import { Application } from '@etherealengine/server-core/declarations'
 
+import { toDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
 import { StartTestFileServer } from '../../server-core/src/createFileServer'
 import { onConnection } from '../src/channels'
 import { InstanceServerState } from '../src/InstanceServerState'
@@ -74,6 +83,17 @@ describe('InstanceLoad', () => {
         slugifiedName: 'sky-station'
       }
     })
+
+    const localIp = await getLocalServerIp(false)
+    console.log('localIp', localIp)
+    await app.service(instancePath).create({
+      ipAddress: `${localIp.ipAddress}:${localIp.port}`,
+      currentUsers: 0,
+      locationId: skyStationScene.data[0].id,
+      assigned: false,
+      assignedAt: toDateTimeSql(new Date()),
+      roomCode: '' as RoomCode
+    } as InstanceData)
 
     const query = {
       provider: 'test',

--- a/packages/server-core/src/ServerState.ts
+++ b/packages/server-core/src/ServerState.ts
@@ -43,6 +43,7 @@ export const ServerState = defineState({
     k8AppsClient: null! as k8s.AppsV1Api,
     k8BatchClient: null! as k8s.BatchV1Api,
     agonesSDK: null! as Record<any, any>,
-    serverMode: null! as ServerTypeMode
+    serverMode: null! as ServerTypeMode,
+    port: 3030
   }
 })

--- a/packages/server-core/src/ServerState.ts
+++ b/packages/server-core/src/ServerState.ts
@@ -43,7 +43,6 @@ export const ServerState = defineState({
     k8AppsClient: null! as k8s.AppsV1Api,
     k8BatchClient: null! as k8s.BatchV1Api,
     agonesSDK: null! as Record<any, any>,
-    serverMode: null! as ServerTypeMode,
-    port: 3030
+    serverMode: null! as ServerTypeMode
   }
 })

--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -96,8 +96,8 @@ export async function getFreeInstanceserver({
     //Clear any instance assignments older than 30 seconds - those assignments have not been
     //used, so they should be cleared and the IS they were attached to can be used for something else.
     logger.info('Local server spinning up new instance')
-    const localIp = await getLocalServerIp(channelId != null)
-    const stringIp = `${localIp.ipAddress}:${localIp.port}`
+    const localIp = await getLocalServerIp()
+    const stringIp = `${localIp}:${channelId ? '3032' : '3031'}`
     return checkForDuplicatedAssignments({
       app,
       headers,
@@ -532,11 +532,12 @@ export class InstanceProvisionService implements ServiceInterface<InstanceProvis
     const instance = instanceUserSort[0]
     if (!config.kubernetes.enabled) {
       logger.info('Resetting local instance to ' + instance.id)
-      const localIp = await getLocalServerIp(channelId != null)
+      const localIp = await getLocalServerIp()
       return {
         id: instance.id,
         roomCode: instance.roomCode,
-        ...localIp
+        ipAddress: localIp,
+        port: channelId ? '3032' : '3031'
       }
     }
     const isCleanup = await this.isCleanup(instance)
@@ -800,11 +801,12 @@ export class InstanceProvisionService implements ServiceInterface<InstanceProvis
         //   const maxInstance = await this.app.service(instancePath).get(maxInstanceId)
         //   if (!config.kubernetes.enabled) {
         //     logger.info('Resetting local instance to ' + maxInstanceId)
-        //     const localIp = await getLocalServerIp(false)
+        //     const localIp = await getLocalServerIp()
         //     return {
         //       id: maxInstanceId,
         //       roomCode: instance.roomCode,
-        //       ...localIp
+        //       ipAddress: localIp,
+        //       port: 3031
         //     }
         //   }
         //   const ipAddressSplit = maxInstance.ipAddress.split(':')

--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -478,8 +478,9 @@ export class InstanceProvisionService implements ServiceInterface<InstanceProvis
   }
 
   /**
-   * A method which gets and instance of Instanceserver
+   * A method which gets an instance of Instanceserver
    * @param availableLocationInstances for Instanceserver
+   * @param headers
    * @param locationId
    * @param channelId
    * @param roomCode

--- a/packages/server-core/src/util/get-local-server-ip.ts
+++ b/packages/server-core/src/util/get-local-server-ip.ts
@@ -27,15 +27,8 @@ import internalIp from 'internal-ip'
 
 import configFile from '../appconfig'
 
-export interface ServerAddress {
-  ipAddress: string
-  port: string
-}
-
-export default async (isMediaInstance: boolean): Promise<ServerAddress> => {
-  const ip = configFile.instanceserver.domain === 'localhost' ? await internalIp.v4() : configFile.instanceserver.domain
-  return {
-    ipAddress: ip!,
-    port: isMediaInstance ? '3032' : '3031'
-  }
+export default async () => {
+  return configFile.instanceserver.domain === 'localhost'
+    ? ((await internalIp.v4()) as string)
+    : configFile.instanceserver.domain
 }


### PR DESCRIPTION
## Summary

Instanceserver initialization was making new instance records if it couldn't find one that matched the IP address and location/channel ID provided by the connecting user. This could be abused by a malicious actor. Now, the instanceserver just checks if there is a record for itself, and does nothing if it can't find one.

Moved the initial authorizeUserToJoinServer call earlier so that nothing else happens if the user shouldn't be on the server in the first place. loadEngine is not called if the server isn't initialized for any reason. User doesn't join the instanceserver if not authorized to do so. Cleaned up some duplicate logic.

Resolves IR-2671

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
