### PR TITLE
Disabling screenshare if it's not supported.

### DIFF
--- a/packages/client-core/src/components/MediaIconsBox/index.tsx
+++ b/packages/client-core/src/components/MediaIconsBox/index.tsx
@@ -55,6 +55,7 @@ import IconButtonWithTooltip from '@etherealengine/ui/src/primitives/mui/IconBut
 
 import { FeatureFlags } from '@etherealengine/common/src/constants/FeatureFlags'
 import { FeatureFlagsState } from '@etherealengine/engine/src/FeatureFlagsState'
+import { isMobile } from '@etherealengine/spatial/src/common/functions/isMobile'
 import { VrIcon } from '../../common/components/Icons/VrIcon'
 import { RecordingUIState } from '../../systems/ui/RecordingsWidgetUI'
 import { MediaStreamService, MediaStreamState } from '../../transports/MediaStreams'
@@ -204,7 +205,11 @@ export const MediaIconsBox = () => {
           )}
         </>
       ) : null}
-      {screenshareEnabled && mediaNetworkReady && mediaNetworkState?.ready.value ? (
+      {!isMobile &&
+      !(typeof navigator.mediaDevices.getDisplayMedia === 'undefined') &&
+      screenshareEnabled &&
+      mediaNetworkReady &&
+      mediaNetworkState?.ready.value ? (
         <>
           <IconButtonWithTooltip
             id="UserScreenSharing"


### PR DESCRIPTION
## Summary

Mobile browsers do not support navigator.mediaDevices.getDisplayMedia, which is how one retrieves a display for screensharing over WebRTC. getDisplayMedia is undefined on all mobile browsers (or should be - older versions of most browsers it was exposed, but returned a NotAllowedError). Now hiding the screenshare button if isMobile is true or getDisplayMedia is undefined.

Resolves IR-3136

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
