### PR TITLE
IR-3119: Fix thumbnail generation with particle systems

### DIFF
--- a/packages/client-core/src/common/services/FileThumbnailJobState.tsx
+++ b/packages/client-core/src/common/services/FileThumbnailJobState.tsx
@@ -49,7 +49,6 @@ import { DirectionalLightComponent, TransformComponent } from '@etherealengine/s
 import { CameraComponent } from '@etherealengine/spatial/src/camera/components/CameraComponent'
 import { NameComponent } from '@etherealengine/spatial/src/common/NameComponent'
 import { RendererComponent } from '@etherealengine/spatial/src/renderer/WebGLRendererSystem'
-import { GroupComponent } from '@etherealengine/spatial/src/renderer/components/GroupComponent'
 import { ObjectLayerMaskComponent } from '@etherealengine/spatial/src/renderer/components/ObjectLayerComponent'
 import { SceneComponent } from '@etherealengine/spatial/src/renderer/components/SceneComponents'
 import { VisibleComponent } from '@etherealengine/spatial/src/renderer/components/VisibleComponent'
@@ -60,7 +59,7 @@ import {
 } from '@etherealengine/spatial/src/transform/components/BoundingBoxComponents'
 import { computeTransformMatrix } from '@etherealengine/spatial/src/transform/systems/TransformSystem'
 import React, { useEffect } from 'react'
-import { Color, Euler, MathUtils, Matrix4, Quaternion, Scene, Sphere, Vector3 } from 'three'
+import { Color, Euler, MathUtils, Matrix4, Quaternion, Sphere, Vector3 } from 'three'
 
 import { ErrorComponent } from '@etherealengine/engine/src/scene/components/ErrorComponent'
 import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
@@ -449,11 +448,6 @@ const ThumbnailJobReactor = () => {
 
       viewCamera.layers.mask = getComponent(cameraEntity, ObjectLayerMaskComponent)
       setComponent(cameraEntity, SceneComponent, { children: [modelEntity, lightEntity] })
-
-      const scene = new Scene()
-      scene.children = getComponent(cameraEntity, SceneComponent)
-        .children.map((entity) => getComponent(entity, GroupComponent))
-        .flat()
       const canvas = getComponent(cameraEntity, RendererComponent).canvas
       const maxTryCount = 10
       function doRender(tryCount = 0) {

--- a/packages/engine/src/scene/systems/ParticleSystemSystem.ts
+++ b/packages/engine/src/scene/systems/ParticleSystemSystem.ts
@@ -31,9 +31,12 @@ import { ParticleState } from '../components/ParticleSystemComponent'
 import { SceneObjectSystem } from './SceneObjectSystem'
 
 const execute = () => {
-  const batchRenderer = getState(ParticleState).batchRenderer
-  const deltaSeconds = getState(ECSState).deltaSeconds
-  batchRenderer.update(deltaSeconds)
+  const renderers = getState(ParticleState).renderers
+  for (const rendererInstance of Object.values(renderers)) {
+    const batchRenderer = rendererInstance.renderer
+    const deltaSeconds = getState(ECSState).deltaSeconds
+    batchRenderer.update(deltaSeconds)
+  }
 }
 
 export const ParticleSystem = defineSystem({


### PR DESCRIPTION
Fixes bug with generating thumbnails for particle system prefabs.
Particle systems now have a designated renderer per scene, rather than one at the scene root. This fixes the issue where loading a particle system prefab for thumbnail rendering created that particle system in the current scene.
