### PR TITLE
Call encodeURI on path when creating Cloudfront invalidation

### DIFF
--- a/scripts/run-batch-invalidation.ts
+++ b/scripts/run-batch-invalidation.ts
@@ -59,23 +59,25 @@ const options = cli.parse({
 })
 
 const encodeCloudfrontInvalidation = (uri: string) =>
-  uri
-    .replaceAll('%', '%25')
-    .replaceAll(' ', '%20')
-    .replaceAll('"', '%22')
-    .replaceAll('#', '%23')
-    .replaceAll('<', '%3C')
-    .replaceAll('>', '%3E')
-    .replaceAll('[', '%5B')
-    .replaceAll('\\', '%5C')
-    .replaceAll(']', '%5D')
-    .replaceAll('^', '%5E')
-    .replaceAll('`', `%60`)
-    .replaceAll('{', '%7B')
-    .replaceAll('|', '%7C')
-    .replaceAll('}', '%7D')
-    .replaceAll('~', '%7E')
-    .replaceAll("'", '%27')
+  encodeURI(
+    uri
+      .replaceAll('%', '%25')
+      .replaceAll(' ', '+')
+      .replaceAll('"', '%22')
+      .replaceAll('#', '%23')
+      .replaceAll('<', '%3C')
+      .replaceAll('>', '%3E')
+      .replaceAll('[', '%5B')
+      .replaceAll('\\', '%5C')
+      .replaceAll(']', '%5D')
+      .replaceAll('^', '%5E')
+      .replaceAll('`', `%60`)
+      .replaceAll('{', '%7B')
+      .replaceAll('|', '%7C')
+      .replaceAll('}', '%7D')
+      .replaceAll('~', '%7E')
+      .replaceAll("'", '%27')
+  )
 
 cli.main(async () => {
   try {


### PR DESCRIPTION
## Summary

Ran into issues where non-ASCII characters were being used in file names, which Cloudfront invalidations do not handle unencoded. Now calling encodeURI on the path after doing manual character replacements. encodeURI does not encode some unsafe characters that need to be encoded, and one particular character, the space, needs to be converted to a plus for CF Invalidations for some reason, and encodeURI will encode that as %20, which will not be a match. This had not been noticed or handled correctly before.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
