### PR TITLE
Fix video freezing on new track

### DIFF
--- a/packages/engine/src/scene/components/MediaComponent.ts
+++ b/packages/engine/src/scene/components/MediaComponent.ts
@@ -34,7 +34,6 @@ import {
   getComponent,
   getMutableComponent,
   getOptionalComponent,
-  hasComponent,
   removeComponent,
   setComponent,
   useComponent,
@@ -321,7 +320,6 @@ export function MediaReactor() {
       clearErrors(entity, MediaComponent)
 
       const paths = media.resources.value
-
       for (const path of paths) {
         const assetClass = AssetLoader.getAssetClass(path).toLowerCase()
         if (path !== '' && assetClass !== 'audio' && assetClass !== 'video') {
@@ -356,22 +354,22 @@ export function MediaReactor() {
 
   useEffect(
     function updateMediaElement() {
-      if (!media.ended.value) {
-        // If current track is not ended, don't change the track
-        return
-      }
+      if (!media.ended.value) return // If current track is not ended, don't change the track
 
       if (!isClient) return
 
+      if (media.resources.value.every((resource) => !resource)) return // if all resources are empty, we dont move to next track
+
       const track = media.track.value
-      const nextTrack = getNextTrack(track, media.resources.length, media.playMode.value)
-
+      let nextTrack = getNextTrack(track, media.resources.length, media.playMode.value)
       if (nextTrack === -1) return
+      let path = media.resources[nextTrack].value
 
-      const path = media.resources[nextTrack].value
-      if (!path) {
-        if (hasComponent(entity, MediaElementComponent)) removeComponent(entity, MediaElementComponent)
-        return
+      while (!path) {
+        // we already remove the case where we dont have any track
+        // if current path is null, we simply skip over and move to next proper track
+        nextTrack = (nextTrack + 1) % media.resources.length
+        path = media.resources[nextTrack].value
       }
 
       const mediaElement = getOptionalComponent(entity, MediaElementComponent)


### PR DESCRIPTION
This pull request fixes the issue of video freezing on a new track. The code changes ensure that the track is not changed if the current track is not ended. Additionally, the pull request handles the case where all resources are empty and skips over null paths to move to the next proper track. This resolves the freezing issue and improves the overall functionality of the video player.