### PR TITLE
Fix ignore geometry to not delete all meshes

### DIFF
--- a/packages/engine/src/assets/exporters/gltf/extensions/IgnoreGeometryExporterExtension.ts
+++ b/packages/engine/src/assets/exporters/gltf/extensions/IgnoreGeometryExporterExtension.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import { Mesh, Object3D } from 'three'
 
-import { Entity, hasComponent, removeComponent } from '@etherealengine/ecs'
+import { Entity, getComponent, hasComponent, removeComponent } from '@etherealengine/ecs'
 import { MeshComponent } from '@etherealengine/spatial/src/renderer/components/MeshComponent'
 import { iterateEntityNode } from '@etherealengine/spatial/src/transform/components/EntityTree'
 
@@ -47,11 +47,13 @@ export default class IgnoreGeometryExporterExtension extends ExporterExtension i
   beforeParse(input: Object3D | Object3D[]) {
     const root = (Array.isArray(input) ? input[0] : input) as Object3D
     iterateEntityNode(root.entity, (entity) => {
+      if (!hasComponent(entity, MeshComponent)) return
+      const mesh = getComponent(entity, MeshComponent)
       const removeMesh =
         hasComponent(entity, PrimitiveGeometryComponent) ||
         hasComponent(entity, GroundPlaneComponent) ||
         hasComponent(entity, ImageComponent) ||
-        hasComponent(entity, MeshComponent)
+        !!mesh.userData['ignoreOnExport']
       if (!removeMesh) return
       removeComponent(entity, MeshComponent)
     })

--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -275,6 +275,7 @@ function VideoReactor() {
     const videoEntity = videoMeshEntity.value
     video.videoMeshEntity.set(videoEntity)
     mesh.name.set(`video-group-${entity}`)
+    mesh.userData['ignoreOnExport'] = true
     setComponent(videoEntity, EntityTreeComponent, { parentEntity: entity })
     setComponent(videoEntity, NameComponent, mesh.name.value)
     return () => {


### PR DESCRIPTION
Recent change to gltf exporter causes all meshes to get deleted. This fixes the issue and preserves ignoring video component meshes on export