### PR TITLE
IR-2109: Fix material renaming + IO

### DIFF
--- a/packages/engine/src/assets/exporters/gltf/extensions/EEMaterialExporterExtension.ts
+++ b/packages/engine/src/assets/exporters/gltf/extensions/EEMaterialExporterExtension.ts
@@ -137,6 +137,7 @@ export default class EEMaterialExporterExtension extends ExporterExtension {
       plugins: plugins,
       args: result
     }
+    materialDef.name = getComponent(materialEntity, NameComponent)
     this.writer.extensionsUsed[this.name] = true
   }
 }

--- a/packages/ui/src/components/editor/panels/Properties/material/index.tsx
+++ b/packages/ui/src/components/editor/panels/Properties/material/index.tsx
@@ -153,7 +153,7 @@ export function MaterialEditor(props: { materialUUID: EntityUUID }) {
 
   useEffect(() => {
     clearThumbs().then(createThumbnails).then(checkThumbs)
-  }, [materialName, prototypeName])
+  }, [prototypeName, currentSelectedMaterial])
 
   const prototypeEntity = materialComponent.prototypeEntity.value!
   const prototype = useComponent(prototypeEntity, MaterialPrototypeComponent)
@@ -187,7 +187,7 @@ export function MaterialEditor(props: { materialUUID: EntityUUID }) {
   useEffect(() => {
     pluginValues.set({})
     pluginParameters.set({})
-  }, [materialName, selectedPlugin])
+  }, [selectedPlugin, currentSelectedMaterial])
 
   useEffect(() => {
     for (const pluginComponent of Object.values(MaterialPlugins)) {


### PR DESCRIPTION
Fixes bug in material editor UI which had thumbnails and plugins listening to material name rather than material UUID
Fixes material exporter to name exported material with materialEntity's NameComponent
Closes https://tsu.atlassian.net/browse/IR-2109