### PR TITLE
Fixed issues with creating consumers

### DIFF
--- a/packages/client-core/src/components/UserMediaWindow/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindow/index.tsx
@@ -576,7 +576,7 @@ export const UserMediaWindow = ({ peerID, type }: Props): JSX.Element => {
           className={classNames({
             [styles['video-wrapper']]: !isScreen,
             [styles['screen-video-wrapper']]: isScreen,
-            [styles['border-lit']]: soundIndicatorOn && !audioStreamPaused
+            [styles['border-lit']]: soundIndicatorOn && (isSelf ? !audioProducerPaused : !audioStreamPaused)
           })}
         >
           {(videoStream == null ||

--- a/packages/client-core/src/media/PeerMedia.tsx
+++ b/packages/client-core/src/media/PeerMedia.tsx
@@ -162,7 +162,7 @@ export const NetworkProducer = (props: { networkID: InstanceID; producerID: stri
   const networkState = useHookstate(getMutableState(NetworkState).networks[networkID])
 
   useEffect(() => {
-    if (!networkState.ready.value) return
+    if (!networkState.ready?.value) return
 
     const peerID = producerState.peerID.value
     // dont need to request our own consumers
@@ -182,7 +182,7 @@ export const NetworkProducer = (props: { networkID: InstanceID; producerID: stri
         $to: network.hostPeerID
       })
     )
-  }, [networkState.ready.value])
+  }, [networkState.ready?.value])
 
   return null
 }

--- a/packages/client-core/src/networking/DataChannelSystem.tsx
+++ b/packages/client-core/src/networking/DataChannelSystem.tsx
@@ -159,7 +159,7 @@ export const DataChannel = (props: { networkID: InstanceID; dataChannelType: Dat
   const networkState = useHookstate(getMutableState(NetworkState).networks[networkID])
 
   useEffect(() => {
-    if (!networkState.ready.value) return
+    if (!networkState.ready?.value) return
 
     const network = getState(NetworkState).networks[networkID] as SocketWebRTCClientNetwork
     createDataProducer(network, { label: dataChannelType })
@@ -168,7 +168,7 @@ export const DataChannel = (props: { networkID: InstanceID; dataChannelType: Dat
     return () => {
       // todo - cleanup
     }
-  }, [networkState.ready.value])
+  }, [networkState.ready?.value])
 
   return null
 }

--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -714,7 +714,7 @@ const onDisconnection = (app: Application) => async (connection: PrimusConnectio
   if (identityProvider != null && identityProvider.id != null) {
     const userId = identityProvider.userId
     const user = await app.service(userPath).get(userId, { headers: connection.headers })
-    const instanceId = !config.kubernetes.enabled ? connection.instanceId : instanceServerState.instance?.id
+    const instanceId = instanceServerState.instance?.id
     let instance
     logger.info('On disconnect, instanceId: ' + instanceId)
     logger.info('Disconnecting user ', user.id)

--- a/packages/network/src/transports/mediasoup/MediasoupMediaProducerConsumerState.tsx
+++ b/packages/network/src/transports/mediasoup/MediasoupMediaProducerConsumerState.tsx
@@ -319,6 +319,8 @@ export const MediasoupMediaProducerConsumerState = defineState({
     onUpdatePeers: NetworkActions.updatePeers.receive((action) => {
       const state = getState(MediasoupMediaProducerConsumerState)
       const producers = state[action.$network]?.producers
+      const networkState = getState(NetworkState).networks[action.$network]
+      if (!networkState?.ready) return
       if (producers)
         for (const producer of Object.values(producers)) {
           const transport = getState(MediasoupTransportState)[action.$network]?.[producer.transportID]
@@ -478,7 +480,9 @@ export const NetworkMediaConsumer = (props: { networkID: InstanceID; consumerID:
 
   useEffect(() => {
     const consumer = consumerObjectState.value as any
-    if (!consumer || consumer.closed || consumer._closed) return
+    const producerID = consumerState.producerID.value
+    const producer = getState(MediasoupMediaProducersConsumersObjectsState).producers[producerID]
+    if (!consumer || consumer.closed || consumer._closed || !producer || producer?.closed || producer?._closed) return
 
     if (consumerState.paused.value && typeof consumer.pause === 'function') consumer.pause()
     if (!consumerState.paused.value && typeof consumer.resume === 'function') consumer.resume()


### PR DESCRIPTION
## Summary

There was a bug when joining an instance that already had producers from other users running - consumers were not created for those producers, and they would never be created since pausing/resuming a producer does not trigger a new creation of consumers if they do not exist.

Creation of consumers is triggered from the presence of producers in MediasoupMediaProducerConsumerState. onUpdatePeers removes producers that are not in MediasoupTransportState. onUpdatePeers was getting received by new clients before networks had been set up and were ready, so it was seeing no transports and removing all producers before their consumers could be created. The fix is to not run onUpdatePeers' logic if the network is not ready.

Added some hardening to resuming consumers to address some crashes seen in testing. For unclear reasons that stopped happening at all, one client being consumed by others that disconnected would trigger the useEffect that handles consumers getting paused or resumed, and the consumers of the now-not-running producers were trying to resume, causing Mediasoup to throw errors about the channel being resumed not existing. Hopefully checking whether the producer that that consumer is consuming exists and is not closed will avoid this.

In onDisconnection, updated local behavior to look for instanceId on instanceServerState. There were disconnection bugs where the instanceId was no longer on the connection object, and the user would not be removed from records.

Fixed visual bug with "user is speaking" green circle triggering for oneself even if one's audio is paused. The issue was that audioStreamPaused is not set to true for one's own audio; instead, that's audioProducerPaused.

Resolves IR-3207 and IR-3210

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
