### PR TITLE
IR-3192-MT-INT-Studio-No-warning-notification-when-switching-between-unsaved-scenes

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -1338,7 +1338,8 @@
       "title": "Save",
       "lbl-thumbnail": "Generate thumbnail & envmap",
       "lbl-confirm": "Save Scene",
-      "info-confirm": "Are you sure you want to save the scene?"
+      "info-confirm": "Are you sure you want to save the scene?",
+      "info-question": "Do you want to save the current scene?"
     },
     "saveNewScene": {
       "title": "Save As",

--- a/packages/editor/src/components/toolbar/Toolbar2.tsx
+++ b/packages/editor/src/components/toolbar/Toolbar2.tsx
@@ -60,7 +60,56 @@ const onImportAsset = async () => {
   }
 }
 
-const onCloseProject = () => {
+const onClickNewScene = async () => {
+  const isModified = EditorState.isModified()
+
+  if (isModified) {
+    const confirm = await new Promise((resolve) => {
+      PopoverState.showPopupover(
+        <SaveSceneDialog
+          isExiting
+          onConfirm={() => {
+            resolve(true)
+          }}
+          onCancel={() => {
+            resolve(false)
+          }}
+        />
+      )
+    })
+    if (!confirm) return
+  }
+
+  onNewScene()
+
+  const newSceneUIAddons = getState(EditorState).uiAddons.newScene
+  if (Object.keys(newSceneUIAddons).length > 0) {
+    PopoverState.showPopupover(<CreateSceneDialog />)
+  } else {
+    onNewScene()
+  }
+}
+
+const onCloseProject = async () => {
+  const isModified = EditorState.isModified()
+
+  if (isModified) {
+    const confirm = await new Promise((resolve) => {
+      PopoverState.showPopupover(
+        <SaveSceneDialog
+          isExiting
+          onConfirm={() => {
+            resolve(true)
+          }}
+          onCancel={() => {
+            resolve(false)
+          }}
+        />
+      )
+    })
+    if (!confirm) return
+  }
+
   const editorState = getMutableState(EditorState)
   getMutableState(GLTFModifiedState).set({})
   editorState.projectName.set(null)
@@ -84,14 +133,7 @@ const generateToolbarMenu = () => {
   return [
     {
       name: t('editor:menubar.newScene'),
-      action: () => {
-        const newSceneUIAddons = getState(EditorState).uiAddons.newScene
-        if (Object.keys(newSceneUIAddons).length > 0) {
-          PopoverState.showPopupover(<CreateSceneDialog />)
-        } else {
-          onNewScene()
-        }
-      }
+      action: onClickNewScene
     },
     {
       name: t('editor:menubar.saveScene'),


### PR DESCRIPTION
## Summary

Adds optional onConfirm and onCancel callbacks to enable async flows for conditionally logic based on whether the user saves or not. Also adds an alternative message.

https://tsu.atlassian.net/browse/IR-3192

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
