### PR TITLE
[IR-3214] studio: make GizmoTool draggable and fix viewport toolbar z-index 

### DIFF
--- a/packages/engine/src/scene/constants/transformConstants.ts
+++ b/packages/engine/src/scene/constants/transformConstants.ts
@@ -32,6 +32,7 @@ export const TransformPivot = {
   Origin: 'Origin' as const
 }
 export const TransformMode = {
+  pointer: 'pointer' as const,
   translate: 'translate' as const,
   rotate: 'rotate' as const,
   scale: 'scale' as const

--- a/packages/engine/src/scene/constants/transformConstants.ts
+++ b/packages/engine/src/scene/constants/transformConstants.ts
@@ -32,7 +32,6 @@ export const TransformPivot = {
   Origin: 'Origin' as const
 }
 export const TransformMode = {
-  pointer: 'pointer' as const,
   translate: 'translate' as const,
   rotate: 'rotate' as const,
   scale: 'scale' as const

--- a/packages/ui/src/components/editor/panels/Viewport/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/container/index.tsx
@@ -159,13 +159,14 @@ const ViewPortPanelContainer = () => {
   const clientSettings = clientSettingQuery.data[0]
 
   const ref = React.useRef<HTMLDivElement>(null)
+  const toolbarRef = React.useRef<HTMLDivElement>(null)
 
   useEngineCanvas(ref)
 
   return (
     <ViewportDnD>
       <div className="relative z-30 flex h-full w-full flex-col bg-theme-surface-main">
-        <div className="z-10 flex gap-1 bg-theme-primary p-1">
+        <div ref={toolbarRef} className="z-10 flex gap-1 bg-theme-primary p-1">
           <TransformSpaceTool />
           <TransformPivotTool />
           <GridTool />
@@ -175,7 +176,7 @@ const ViewPortPanelContainer = () => {
           <RenderModeTool />
           <PlayModeTool />
         </div>
-        {sceneName.value ? <GizmoTool /> : null}
+        {sceneName.value ? <GizmoTool viewportRef={ref} toolbarRef={toolbarRef} /> : null}
         {sceneName.value ? (
           <>
             {rootEntity.value && <SceneLoadingProgress key={rootEntity.value} rootEntity={rootEntity.value} />}

--- a/packages/ui/src/components/editor/panels/Viewport/tools/GizmoTool.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/tools/GizmoTool.tsx
@@ -57,6 +57,7 @@ export default function GizmoTool({
   const [position, setPosition] = useState({ x: 16, y: 56 })
   const [isDragging, setIsDragging] = useState(false)
   const gizmoRef = useRef<HTMLDivElement>(null)
+  const [pointerSelected, setPointerSelected] = useState(false)
 
   const [startingMouseX, setStartingMouseX] = useState(0)
   const [startingMouseY, setStartingMouseY] = useState(0)
@@ -113,12 +114,12 @@ export default function GizmoTool({
             variant="transparent"
             className={twMerge(
               'border-b border-b-theme-primary p-2 text-[#A3A3A3]',
-              transformMode === TransformMode.pointer && 'bg-theme-highlight text-white'
+              pointerSelected && 'bg-theme-highlight text-white'
             )}
             iconContainerClassName="m-0"
             startIcon={<TbPointer />}
             onClick={() => {
-              setTransformMode(TransformMode.pointer)
+              setPointerSelected(true)
               EditorControlFunctions.replaceSelection([])
             }}
           />
@@ -128,11 +129,14 @@ export default function GizmoTool({
             variant="transparent"
             className={twMerge(
               'border-b border-b-theme-primary p-2 text-[#A3A3A3]',
-              transformMode === TransformMode.translate && 'bg-theme-highlight text-white'
+              !pointerSelected && transformMode === TransformMode.translate && 'bg-theme-highlight text-white'
             )}
             iconContainerClassName="m-0"
             startIcon={<TbVector />}
-            onClick={() => setTransformMode(TransformMode.translate)}
+            onClick={() => {
+              setPointerSelected(false)
+              setTransformMode(TransformMode.translate)
+            }}
           />
         </Tooltip>
         <Tooltip title={t('editor:toolbar.gizmo.rotate')} position={'right center'}>
@@ -140,11 +144,14 @@ export default function GizmoTool({
             variant="transparent"
             className={twMerge(
               'border-b border-b-theme-primary p-2 text-[#A3A3A3]',
-              transformMode === TransformMode.rotate && 'bg-theme-highlight text-white'
+              !pointerSelected && transformMode === TransformMode.rotate && 'bg-theme-highlight text-white'
             )}
             iconContainerClassName="m-0"
             startIcon={<TbRefresh />}
-            onClick={() => setTransformMode(TransformMode.rotate)}
+            onClick={() => {
+              setPointerSelected(false)
+              setTransformMode(TransformMode.rotate)
+            }}
           />
         </Tooltip>
         <Tooltip title={t('editor:toolbar.gizmo.scale')} position={'right center'}>
@@ -152,11 +159,14 @@ export default function GizmoTool({
             variant="transparent"
             className={twMerge(
               'p-2 text-[#A3A3A3]',
-              transformMode === TransformMode.scale && 'bg-theme-highlight text-white'
+              !pointerSelected && transformMode === TransformMode.scale && 'bg-theme-highlight text-white'
             )}
             iconContainerClassName="m-0"
             startIcon={<TbWindowMaximize />}
-            onClick={() => setTransformMode(TransformMode.scale)}
+            onClick={() => {
+              setPointerSelected(false)
+              setTransformMode(TransformMode.scale)
+            }}
           />
         </Tooltip>
       </div>

--- a/packages/ui/src/components/editor/panels/Viewport/tools/GizmoTool.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/tools/GizmoTool.tsx
@@ -98,7 +98,7 @@ export default function GizmoTool({
   return (
     <div
       ref={gizmoRef}
-      className={`absolute z-10 flex flex-col items-center rounded-lg bg-black p-2`}
+      className={`absolute z-[5] flex flex-col items-center rounded-lg bg-black p-2`}
       style={{
         left: `${position.x}px`,
         top: `${position.y}px`

--- a/packages/ui/src/components/editor/panels/Viewport/tools/GizmoTool.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/tools/GizmoTool.tsx
@@ -132,7 +132,6 @@ export default function GizmoTool({
             )}
             iconContainerClassName="m-0"
             startIcon={<TbVector />}
-            title="Translate (key W)"
             onClick={() => setTransformMode(TransformMode.translate)}
           />
         </Tooltip>
@@ -145,7 +144,6 @@ export default function GizmoTool({
             )}
             iconContainerClassName="m-0"
             startIcon={<TbRefresh />}
-            title="Rotate (key E)"
             onClick={() => setTransformMode(TransformMode.rotate)}
           />
         </Tooltip>
@@ -158,7 +156,6 @@ export default function GizmoTool({
             )}
             iconContainerClassName="m-0"
             startIcon={<TbWindowMaximize />}
-            title="Scale (key R)"
             onClick={() => setTransformMode(TransformMode.scale)}
           />
         </Tooltip>


### PR DESCRIPTION
## Summary
[IR-3214]: (1) The GizmoTool should be draggable and placeable anywhere on the viewport, and (2) the viewport toolbar dropdowns should appear above the viewport and its elements

https://github.com/user-attachments/assets/dc438d1c-6c53-4239-95b7-050cdf17b2c5

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-3214]: https://tsu.atlassian.net/browse/IR-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ