### PR TITLE
[IR-3126] studio: fix table pagination in asset panel (no decimals)

### DIFF
--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -427,7 +427,7 @@ const AssetPanel = () => {
         .find({ query })
         .then((resources) => {
           searchedStaticResources.set(resources.data)
-          staticResourcesPagination.merge({ totalPages: resources.total / 10 })
+          staticResourcesPagination.merge({ totalPages: Math.ceil(resources.total / 10) })
         })
         .then(() => {
           loading.set(false)


### PR DESCRIPTION
## Summary
[IR-3126] avoid showing decimal page numbers by rounding totalPages calculation up to nearest integer

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-3126]: https://tsu.atlassian.net/browse/IR-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ