### PR TITLE
Fix regression with instance startup

### DIFF
--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -322,6 +322,8 @@ const handleUserAttendance = async (app: Application, userId: UserID, headers: o
     headers
   })) as Paginated<ChannelType>
 
+  console.log('\n\n\n\n\nhandleUserAttendance', { channel }, '\n\n\n\n')
+
   /** Only a world server gets assigned a channel, since it has chat. A media server uses a channel but does not have one itself */
   if (channel.data.length > 0) {
     const existingChannelUser = (await app.service(channelUserPath).find({
@@ -403,6 +405,7 @@ const updateInstance = async ({
     instanceStarted = true
     const initialized = await initializeInstance({ app, status, headers, userId })
     if (initialized) await loadEngine({ app, sceneId, headers })
+    return true
   } else {
     try {
       if (!getState(InstanceServerState).ready)

--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -322,8 +322,6 @@ const handleUserAttendance = async (app: Application, userId: UserID, headers: o
     headers
   })) as Paginated<ChannelType>
 
-  console.log('\n\n\n\n\nhandleUserAttendance', { channel }, '\n\n\n\n')
-
   /** Only a world server gets assigned a channel, since it has chat. A media server uses a channel but does not have one itself */
   if (channel.data.length > 0) {
     const existingChannelUser = (await app.service(channelUserPath).find({


### PR DESCRIPTION
## Summary

Fixes first user in an instance not being given a `channel-user` table entry, disallowing them from accessing chat
https://tsu.atlassian.net/browse/IR-3204

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
