### PR TITLE
Remove close button

### DIFF
--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -169,16 +169,6 @@ const ResourceFile = (props: {
             ]}
           />
           {/* TODO: add more actions (compressing images/models, editing tags, etc) here as desired  */}
-          <MenuDivider />
-          <Button
-            fullWidth
-            size="small"
-            variant="transparent"
-            className="text-s text-left hover:bg-theme-surfaceInput"
-            onClick={() => () => setAnchorEvent(undefined)}
-          >
-            {t('editor:visualScript.modal.buttons.close')}
-          </Button>
         </div>
       </ContextMenu>
     </div>


### PR DESCRIPTION
This pull request removes the close button from the ResourceFile component. The close button was previously included in the context menu, but it is no longer needed. This change simplifies the UI and improves the user experience.