### PR TITLE
Turn off input glow by default

### DIFF
--- a/packages/spatial/src/input/components/InputComponent.ts
+++ b/packages/spatial/src/input/components/InputComponent.ts
@@ -88,7 +88,7 @@ export const InputComponent = defineComponent({
     return {
       inputSinks: ['Self'] as EntityUUID[],
       activationDistance: 2,
-      highlight: true,
+      highlight: false,
       grow: false,
 
       //internal
@@ -98,6 +98,7 @@ export const InputComponent = defineComponent({
   },
 
   onSet(entity, component, json) {
+    console.trace(entity)
     if (!json) return
     if (Array.isArray(json.inputSinks)) component.inputSinks.set(json.inputSinks)
     if (typeof json.highlight === 'boolean') component.highlight.set(json.highlight)

--- a/packages/spatial/src/input/components/InputComponent.ts
+++ b/packages/spatial/src/input/components/InputComponent.ts
@@ -98,7 +98,6 @@ export const InputComponent = defineComponent({
   },
 
   onSet(entity, component, json) {
-    console.trace(entity)
     if (!json) return
     if (Array.isArray(json.inputSinks)) component.inputSinks.set(json.inputSinks)
     if (typeof json.highlight === 'boolean') component.highlight.set(json.highlight)


### PR DESCRIPTION
## Summary

After fixing highlights, avatars were glowing. We should disable the highlight effect by default, and enable it as needed.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
