### PR TITLE
Revert "Fixed a bug where peer video would not be hidden."

### DIFF
--- a/packages/client-core/src/components/MediaIconsBox/index.tsx
+++ b/packages/client-core/src/components/MediaIconsBox/index.tsx
@@ -70,7 +70,6 @@ export const MediaIconsBox = () => {
   const location = useLocation()
   const hasAudioDevice = useHookstate(false)
   const hasVideoDevice = useHookstate(false)
-  const numVideoDevices = useHookstate(0)
   const { topShelfStyle } = useShelfStyles()
 
   const currentLocation = useHookstate(getMutableState(LocationState).currentLocation.location)
@@ -109,7 +108,6 @@ export const MediaIconsBox = () => {
       .then((devices) => {
         hasAudioDevice.set(devices.filter((device) => device.kind === 'audioinput').length > 0)
         hasVideoDevice.set(devices.filter((device) => device.kind === 'videoinput').length > 0)
-        numVideoDevices.set(devices.filter((device) => device.kind === 'videoinput').length)
       })
       .catch((err) => logger.error(err, 'Could not get media devices.'))
   }, [])
@@ -184,7 +182,7 @@ export const MediaIconsBox = () => {
             onPointerEnter={() => AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.ui)}
             icon={<Icon type={isCamVideoEnabled ? 'Videocam' : 'VideocamOff'} />}
           />
-          {isCamVideoEnabled && numVideoDevices.value > 1 && (
+          {isCamVideoEnabled && hasVideoDevice.value && (
             <IconButtonWithTooltip
               id="FlipVideo"
               title={t('user:menu.cycleCamera')}

--- a/packages/client-core/src/media/PeerMedia.tsx
+++ b/packages/client-core/src/media/PeerMedia.tsx
@@ -93,7 +93,7 @@ const PeerMedia = (props: { consumerID: string; networkID: InstanceID }) => {
     if (!peerMediaChannelState) return
     if (isAudio) peerMediaChannelState.audioStreamPaused.set(!!consumerState.paused.value)
     else peerMediaChannelState.videoStreamPaused.set(!!consumerState.paused.value)
-  }, [consumerState.paused?.value])
+  }, [consumerState.paused])
 
   useEffect(() => {
     const globalMute = !!producerState.globalMute?.value
@@ -109,7 +109,7 @@ const PeerMedia = (props: { consumerID: string; networkID: InstanceID }) => {
       peerMediaChannelState.videoProducerPaused.set(paused)
       peerMediaChannelState.videoProducerGlobalMute.set(globalMute)
     }
-  }, [producerState.paused?.value])
+  }, [producerState.paused])
 
   return null
 }

--- a/packages/network/src/transports/mediasoup/MediasoupMediaProducerConsumerState.tsx
+++ b/packages/network/src/transports/mediasoup/MediasoupMediaProducerConsumerState.tsx
@@ -43,17 +43,8 @@ import {
   useMutableState
 } from '@etherealengine/hyperflux'
 
-import { PeerMediaChannelState } from '@etherealengine/client-core/src/transports/PeerMediaChannelState'
 import { DataChannelType } from '../../DataChannelRegistry'
-import {
-  MediaStreamAppData,
-  MediaTagType,
-  NetworkActions,
-  NetworkState,
-  screenshareAudioDataChannelType,
-  screenshareVideoDataChannelType,
-  webcamAudioDataChannelType
-} from '../../NetworkState'
+import { MediaStreamAppData, MediaTagType, NetworkActions, NetworkState } from '../../NetworkState'
 import {
   MediasoupTransportActions,
   MediasoupTransportObjectsState,
@@ -240,22 +231,7 @@ export const MediasoupMediaProducerConsumerState = defineState({
 
     onProducerPaused: MediasoupMediaProducerActions.producerPaused.receive((action) => {
       const state = getMutableState(MediasoupMediaProducerConsumerState)
-      const peerMediaState = getMutableState(PeerMediaChannelState)
       const networkID = action.$network
-      const matchingConsumer = state.value[networkID]
-        ? Object.values(state.value[networkID].consumers).find((consumer) => consumer.producerID === action.producerID)
-        : null
-      if (matchingConsumer) {
-        const type =
-          matchingConsumer.mediaTag === screenshareVideoDataChannelType || screenshareAudioDataChannelType
-            ? 'screen'
-            : 'cam'
-        const isAudio =
-          matchingConsumer.mediaTag === webcamAudioDataChannelType ||
-          matchingConsumer.mediaTag === screenshareAudioDataChannelType
-        if (isAudio) peerMediaState[action.$peer][type].audioProducerPaused.set(action.paused)
-        else peerMediaState[action.$peer][type].videoProducerPaused.set(action.paused)
-      }
       if (!state.value[networkID]?.producers[action.producerID]) return
 
       const producerState = state[networkID].producers[action.producerID]


### PR DESCRIPTION
Reverts EtherealEngine/etherealengine#10660

Overlooked that this imports something from client-core in the network package, and client-core is not present on the backend.