### PR TITLE
move "template" category under "model"

### DIFF
--- a/packages/editor/src/components/assets/AssetsPanelCategories.ts
+++ b/packages/editor/src/components/assets/AssetsPanelCategories.ts
@@ -29,14 +29,15 @@ export const AssetsPanelCategories = defineState({
   name: 'AssetsPanelCategories',
   initial: {
     'Default Prefab': {},
-    Template: {
-      Backdrop: {},
-      Stage: {}
-    },
+
     Model: {
       // NPC: {},
       // Avatar: {},
       // Animal: {},
+      Template: {
+        // Backdrop: {},
+        // Stage: {}
+      },
       Architectural: {
         Floor: {},
         Ceiling: {},


### PR DESCRIPTION
Required to get templates showing up in assets panel
