### PR TITLE
assets breadcrumb click navigation

### DIFF
--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -23,7 +23,7 @@ Original Code is the Ethereal Engine team.
 All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
 Ethereal Engine. All Rights Reserved.
 */
-import { clone, debounce, isEmpty, last } from 'lodash'
+import { clone, debounce, isEmpty } from 'lodash'
 import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -40,7 +40,7 @@ import { inputFileWithAddToScene } from '@etherealengine/editor/src/functions/as
 import { EditorState } from '@etherealengine/editor/src/services/EditorServices'
 import { ClickPlacementState } from '@etherealengine/editor/src/systems/ClickPlacementSystem'
 import { AssetLoader } from '@etherealengine/engine/src/assets/classes/AssetLoader'
-import { State, getState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
+import { NO_PROXY, State, getState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { useDrag } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import {
@@ -71,33 +71,29 @@ type Category = {
   depth: number
 }
 
-const generateAssetsBreadcrumb = (categories: Category[], target: string) => {
-  let path: string[] = []
-
-  function findCategory(category: any, currentPath: string[]) {
-    for (const key in category) {
+const generateParentBreadcrumbCategories = (categories: readonly Category[], target: string) => {
+  const findNestingCategories = (nestedCategory: Record<string, any>, parentCategory: string): Category[] => {
+    for (const key in nestedCategory) {
       if (key === target) {
-        path = currentPath.concat(key)
-        return true
-      }
-      if (
-        typeof category[key] === 'object' &&
-        category[key] !== null &&
-        findCategory(category[key], currentPath.concat(key))
-      ) {
-        return true
+        return [categories.find((c) => c.name === parentCategory)!]
+      } else if (typeof nestedCategory[key] === 'object' && nestedCategory[key] !== null) {
+        const nestedCategories = findNestingCategories(nestedCategory[key], key)
+        if (nestedCategories.length) {
+          return [categories.find((c) => c.name === parentCategory)!, ...nestedCategories]
+        }
       }
     }
-    return false
+    return []
   }
 
   for (const category of categories) {
-    if (findCategory(category.object, [category.name])) {
-      return path
+    const parentCategories = findNestingCategories(category.object, category.name)
+    if (parentCategories.length) {
+      return parentCategories
     }
   }
 
-  return categories.filter(({ name }) => name === target).map(({ name }) => name)
+  return []
 }
 
 const ResourceFile = (props: {
@@ -270,18 +266,29 @@ const AssetCategory = (props: {
   )
 }
 
-type AssetsBreadcrumbProps = {
-  path: string
-}
-export function AssetsBreadcrumb({ path }: AssetsBreadcrumbProps) {
+export function AssetsBreadcrumb({
+  parentCategories,
+  selectedCategory,
+  onSelectCategory
+}: {
+  parentCategories: Category[]
+  selectedCategory: Category | null
+  onSelectCategory: (c: Category) => void
+}) {
   return (
-    <div className="flex h-[28px] items-center gap-2 rounded-[4px] border border-[#42454D] bg-[#141619] px-2 ">
+    <div className="flex h-[28px] items-center gap-2 rounded-[4px] border border-[#42454D] bg-[#141619] px-2">
       <HiOutlineFolder className="text-xs text-[#A3A3A3]" />
-      <span
-        className="overflow-hidden overflow-ellipsis whitespace-nowrap text-xs text-[#A3A3A3]"
-        style={{ direction: 'rtl' }}
-      >
-        {path}
+      {parentCategories.map((category) => (
+        <span
+          key={category.name}
+          className="cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap text-xs text-[#A3A3A3] hover:underline"
+          onClick={() => onSelectCategory(category)}
+        >
+          {category.name + ' > '}
+        </span>
+      ))}
+      <span className="overflow-hidden overflow-ellipsis whitespace-nowrap text-xs text-[#A3A3A3]">
+        {selectedCategory?.name}
       </span>
     </div>
   )
@@ -342,10 +349,10 @@ const AssetPanel = () => {
   const loading = useHookstate(false)
   const searchedStaticResources = useHookstate<StaticResourceType[]>([])
   const searchText = useHookstate('')
-  const breadcrumbPath = useHookstate('')
   const originalPath = useMutableState(EditorState).projectName.value
   const staticResourcesPagination = useHookstate({ totalPages: -1, currentPage: 0 })
   const assetsPreviewContext = useHookstate({ selectAssetURL: '' })
+  const parentCategories = useHookstate<Category[]>([])
 
   const mapCategories = () => {
     const result: Category[] = []
@@ -372,17 +379,15 @@ const AssetPanel = () => {
   useEffect(mapCategories, [collapsedCategories])
 
   useEffect(() => {
-    const assetsBreadcrumb = generateAssetsBreadcrumb(
-      categories.value as Category[],
-      selectedCategory.value?.name as string
-    )?.join(' > ')
-    breadcrumbPath.set(assetsBreadcrumb)
+    if (!selectedCategory.value?.name) return
+    const parentCategoryBreadcrumbs = generateParentBreadcrumbCategories(categories.value, selectedCategory.value.name)
+    parentCategories.set(parentCategoryBreadcrumbs)
   }, [categories, selectedCategory])
 
   useEffect(() => {
     const staticResourcesFindApi = () => {
       const tags = selectedCategory.value
-        ? [selectedCategory.value.name, ...iterativelyListTags(selectedCategory.value.object)]
+        ? [selectedCategory.value.name, ...iterativelyListTags(clone(selectedCategory.value.object))]
         : []
 
       const query = {
@@ -470,22 +475,12 @@ const AssetPanel = () => {
   }
 
   const handleBack = () => {
-    if (isEmpty(breadcrumbPath.value)) {
-      return
-    }
-
-    const paths: string[] = breadcrumbPath.value
-      .split('>')
-      .slice(0, -1)
-      .map((item) => item.trim())
-
-    if (isEmpty(paths)) {
+    if (!parentCategories.length) {
       selectedCategory.set(null)
       collapsedCategories.set({})
       return
     }
-    const selected = categories?.find((category) => category.name.value === last(paths))
-    selectedCategory.set(clone(selected?.value) as Category)
+    selectedCategory.set(clone(parentCategories.value.at(-1)!))
   }
 
   const handleRefresh = () => {
@@ -530,7 +525,11 @@ const AssetPanel = () => {
 
         <div className="align-center flex h-7 flex-1 justify-center gap-2 pr-2">
           <div className="h-full flex-1">
-            <AssetsBreadcrumb path={breadcrumbPath.value} />
+            <AssetsBreadcrumb
+              parentCategories={parentCategories.get(NO_PROXY) as Category[]}
+              selectedCategory={selectedCategory.value}
+              onSelectCategory={handleSelectCategory}
+            />
           </div>
           <Input
             placeholder={t('editor:layout.scene-assets.search-placeholder')}

--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -387,7 +387,7 @@ const AssetPanel = () => {
   useEffect(() => {
     const staticResourcesFindApi = () => {
       const tags = selectedCategory.value
-        ? [selectedCategory.value.name, ...iterativelyListTags(clone(selectedCategory.value.object))]
+        ? [selectedCategory.value.name, ...iterativelyListTags(selectedCategory.value.object)]
         : []
 
       const query = {


### PR DESCRIPTION
## Summary

previously the breadcrumbs were displayed just as text on the assets panels
now they are made clickable and navigable (refactored the `generateAssetsBreadcrumb` function)

## Subtasks Checklist

## Breaking Changes

## References

https://tsu.atlassian.net/browse/IR-3163

## QA Steps



https://github.com/user-attachments/assets/3c33ba9f-bbbc-4dab-a63a-dec52d22ffc3

