### PR TITLE
fixed gizmos not turning back on after screenshot

### DIFF
--- a/packages/editor/src/functions/takeScreenshot.ts
+++ b/packages/editor/src/functions/takeScreenshot.ts
@@ -193,7 +193,7 @@ export async function takeScreenshot(
   }
 
   const prevAspect = scenePreviewCamera.aspect
-
+  const prevLayersMask = scenePreviewCamera.layers.mask
   // Setting up scene preview camera
   scenePreviewCamera.aspect = width / height
   scenePreviewCamera.updateProjectionMatrix()
@@ -248,7 +248,9 @@ export async function takeScreenshot(
   )
 
   // restore
-  effectComposer.setMainCamera(getComponent(Engine.instance.cameraEntity, CameraComponent))
+  const camera = getComponent(Engine.instance.cameraEntity, CameraComponent)
+  camera.layers.mask = prevLayersMask
+  effectComposer.setMainCamera(camera)
   renderer.setPixelRatio(pixelRatio)
   effectComposer.setSize(originalSize.width, originalSize.height, false)
 

--- a/packages/editor/src/functions/takeScreenshot.ts
+++ b/packages/editor/src/functions/takeScreenshot.ts
@@ -241,12 +241,6 @@ export async function takeScreenshot(
 
   const canvas = getResizedCanvas(renderer.domElement, width, height)
 
-  const imageBlob = await getCanvasBlob(
-    canvas,
-    format === 'jpeg' ? 'image/jpeg' : 'image/png',
-    format === 'jpeg' ? 0.9 : 1
-  )
-
   // restore
   const camera = getComponent(Engine.instance.cameraEntity, CameraComponent)
   camera.layers.mask = prevLayersMask
@@ -257,6 +251,12 @@ export async function takeScreenshot(
   // Restoring previous state
   scenePreviewCamera.aspect = prevAspect
   scenePreviewCamera.updateProjectionMatrix()
+
+  const imageBlob = await getCanvasBlob(
+    canvas,
+    format === 'jpeg' ? 'image/jpeg' : 'image/png',
+    format === 'jpeg' ? 0.9 : 1
+  )
 
   return imageBlob
 }


### PR DESCRIPTION

## Summary
saved the previous layer mask so it could be restored after the screen shot

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
