### PR TITLE
[IR-3323] studio: fix VideoComponent not showing up

### DIFF
--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -275,7 +275,6 @@ function VideoReactor() {
     const videoEntity = videoMeshEntity.value
     video.videoMeshEntity.set(videoEntity)
     mesh.name.set(`video-group-${entity}`)
-    mesh.userData['ignoreOnExport'] = true
     setComponent(videoEntity, EntityTreeComponent, { parentEntity: entity })
     setComponent(videoEntity, NameComponent, mesh.name.value)
     return () => {

--- a/packages/engine/src/scene/components/VideoComponent.tsx
+++ b/packages/engine/src/scene/components/VideoComponent.tsx
@@ -108,7 +108,8 @@ export const VideoComponent = defineComponent({
       mediaUUID: '' as EntityUUID,
       // internal
       videoMeshEntity: UndefinedEntity,
-      texture: null as VideoTexturePriorityQueue | null
+      texture: null as VideoTexturePriorityQueue | null,
+      userData: { ignoreOnExport: true }
     }
   },
 


### PR DESCRIPTION
## Summary
[IR-3323]: fixes issue with VideoComponent not showing up by moving initialization of `mesh.userData['ignoreOnExport']` from VideoComponent's reactor to onInit

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-3323]: https://tsu.atlassian.net/browse/IR-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ