### PR TITLE
IR-3341: Deselect material when clicking on already selected hierarchy panel node

### DIFF
--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -59,6 +59,7 @@ import { EditorState } from '@etherealengine/editor/src/services/EditorServices'
 import { SelectionState } from '@etherealengine/editor/src/services/SelectionServices'
 import { GLTFAssetState, GLTFSnapshotState } from '@etherealengine/engine/src/gltf/GLTFState'
 import { SourceComponent } from '@etherealengine/engine/src/scene/components/SourceComponent'
+import { MaterialSelectionState } from '@etherealengine/engine/src/scene/materials/MaterialLibraryState'
 import { GLTF } from '@gltf-transform/core'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { HiMagnifyingGlass, HiOutlinePlusCircle } from 'react-icons/hi2'
@@ -251,6 +252,8 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntityUUID: Entit
       if (e.detail === 1) {
         // Exit click placement mode when anything in the hierarchy is selected
         getMutableState(EditorHelperState).placementMode.set(PlacementMode.DRAG)
+        // Deselect material entity since we've just clicked on a hierarchy node
+        getMutableState(MaterialSelectionState).selectedMaterial.set(null)
         if (e.ctrlKey) {
           EditorControlFunctions.toggleSelection([getComponent(entity, UUIDComponent)])
         } else if (e.shiftKey && prevClickedNode) {


### PR DESCRIPTION
Fixes issue where if you select a hierarchy node, then go to material inspector and select a material, then go back to the hierarchy panel, you can only get the properties of the selected hierarchy node back by clicking away and clicking back. Now, the behavior is such that whatever has been clicked on last -- either a material or a hierarchy node, selected or not, will have its properties shown in the properties panel.

Closes https://tsu.atlassian.net/browse/IR-3341
