### PR TITLE
Changes to fix client logs disabled

### DIFF
--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -167,15 +167,15 @@ const multiLogger = {
         }
       }
 
-      return config.client.logs.disabled === 'false'
-        ? {
+      return config.client.logs.disabled === 'true'
+        ? nullLogger
+        : {
             debug: send('debug'),
             info: send('info'),
             warn: send('warn'),
             error: send('error'),
             fatal: send('fatal')
           }
-        : nullLogger
     }
   }
 }


### PR DESCRIPTION
## Summary

Updated code so that if `VITE_DISABLE_LOG` is set to `true` only then client logs are disabled. Otherwise if its not defined or set to `false` then it should be sending the logs

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
