### PR TITLE
3239 - Model compression added to FileBrowserContentPanel

### DIFF
--- a/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowser/FileBrowserContentPanel.tsx
@@ -76,6 +76,7 @@ import { ToolButton } from '../../toolbar/ToolButton'
 import { AssetSelectionChangePropsType } from '../AssetsPreviewPanel'
 import ImageCompressionPanel from '../ImageCompressionPanel'
 import ImageConvertPanel from '../ImageConvertPanel'
+import ModelCompressionPanel from '../ModelCompressionPanel'
 import styles from '../styles.module.scss'
 import { FileBrowserItem, FileTableWrapper, canDropItemOverFolder } from './FileBrowserGrid'
 import { FilesViewModeSettings, FilesViewModeState, availableTableColumns } from './FileBrowserState'
@@ -677,6 +678,13 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
       {openCompress.value && fileProperties.value && filesConsistOfContentType(fileProperties.value, 'image') && (
         <ImageCompressionPanel selectedFiles={fileProperties.value} refreshDirectory={refreshDirectory} />
       )}
+
+      {openCompress.value &&
+        fileProperties.value &&
+        (filesConsistOfContentType(fileProperties.value, 'glb') ||
+          filesConsistOfContentType(fileProperties.value, 'gltf')) && (
+          <ModelCompressionPanel selectedFiles={fileProperties.value} refreshDirectory={refreshDirectory} />
+        )}
 
       {openProperties.value && fileProperties.value && (
         <FilePropertiesPanel openProperties={openProperties} fileProperties={fileProperties} />


### PR DESCRIPTION
## Summary
Model compression was not enabled in FileBrowserContentPanel.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
