### PR TITLE
Camera is not guaranteed to exist at load for clientInputSystem

### DIFF
--- a/packages/spatial/src/input/systems/ClientInputSystem.tsx
+++ b/packages/spatial/src/input/systems/ClientInputSystem.tsx
@@ -229,10 +229,11 @@ const execute = () => {
   for (const eid of pointers()) {
     const pointer = getComponent(eid, InputPointerComponent)
     const inputSource = getComponent(eid, InputSourceComponent)
-    const camera = getComponent(pointer.cameraEntity, CameraComponent)
+    const camera = getOptionalComponent(pointer.cameraEntity, CameraComponent)
+    if (!camera) return
     pointer.movement.copy(pointer.position).sub(pointer.lastPosition)
     pointer.lastPosition.copy(pointer.position)
-    inputSource.raycaster.setFromCamera(pointer.position, camera)
+    inputSource.raycaster.setFromCamera(pointer.position, camera!)
     TransformComponent.position.x[eid] = inputSource.raycaster.ray.origin.x
     TransformComponent.position.y[eid] = inputSource.raycaster.ray.origin.y
     TransformComponent.position.z[eid] = inputSource.raycaster.ray.origin.z


### PR DESCRIPTION
InputSystems run before rendering systems so it's not guaranteed that rendering elements will be defined at execution of ClientInputSystem startup. I don't think this is the best solution. There could be a core architectural decision here on alleviating this issue. So this will just stand as a discussion place. 