### PR TITLE
IR-2940 Show materials by source in material library panel

### DIFF
--- a/packages/engine/src/scene/materials/systems/MaterialLibrarySystem.tsx
+++ b/packages/engine/src/scene/materials/systems/MaterialLibrarySystem.tsx
@@ -32,6 +32,7 @@ import {
   PresentationSystemGroup,
   QueryReactor,
   removeEntity,
+  setComponent,
   UndefinedEntity,
   useComponent,
   useEntityContext,
@@ -82,11 +83,18 @@ const MeshReactor = () => {
   const entity = useEntityContext()
   const materialComponent = useOptionalComponent(entity, MaterialInstanceComponent)
   const meshComponent = useComponent(entity, MeshComponent)
+
+  const createAndSourceMaterial = (material: Material) => {
+    const materialEntity = createAndAssignMaterial(entity, material)
+    const source = getOptionalComponent(entity, SourceComponent)
+    if (source) setComponent(materialEntity, SourceComponent, source)
+  }
+
   useEffect(() => {
     if (materialComponent) return
     const material = meshComponent.material.value as Material
-    if (!isArray(material)) createAndAssignMaterial(entity, material)
-    else for (const mat of material) createAndAssignMaterial(entity, mat)
+    if (!isArray(material)) createAndSourceMaterial(material)
+    else for (const mat of material) createAndSourceMaterial(mat)
   }, [])
   return null
 }

--- a/packages/spatial/src/renderer/materials/materialFunctions.ts
+++ b/packages/spatial/src/renderer/materials/materialFunctions.ts
@@ -256,6 +256,7 @@ export const createMaterialEntity = (material: Material): Entity => {
 export const createAndAssignMaterial = (user: Entity, material: Material, index = 0) => {
   const materialEntity = createMaterialEntity(material)
   assignMaterial(user, materialEntity, index)
+  return materialEntity
 }
 
 export const getMaterialIndices = (entity: Entity, materialUUID: EntityUUID) => {


### PR DESCRIPTION
## Summary
This PR for materials by asset source cherry picks material sourcing logic without the changes to the UUID. Rather than using a delimiting character we guess where an asset source name starts using the last backslash. 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
