### PR TITLE
IR-2343: add basic cache to asset loader, use to cache prefab shelf

### DIFF
--- a/packages/editor/src/components/prefabs/PrefabEditors.tsx
+++ b/packages/editor/src/components/prefabs/PrefabEditors.tsx
@@ -18,9 +18,9 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 import config from '@etherealengine/common/src/config'
-import { AssetLoader } from '@etherealengine/engine/src/assets/classes/AssetLoader'
+import { useGLTF } from '@etherealengine/engine/src/assets/functions/resourceLoaderHooks'
 import { defineState, getMutableState, useHookstate } from '@etherealengine/hyperflux'
-import React, { ReactNode, useEffect } from 'react'
+import React, { ReactNode } from 'react'
 import { FiHexagon } from 'react-icons/fi'
 
 export type PrefabShelfItem = {
@@ -152,12 +152,6 @@ export const PrefabShelfState = defineState({
 })
 
 const ShelfItemReactor = (props: { key: string; url: string }): JSX.Element | null => {
-  useEffect(() => {
-    AssetLoader.cacheAsset(props.url)
-    return () => {
-      AssetLoader.uncacheAsset(props.url)
-    }
-  }, [])
-
+  useGLTF(props.url)
   return null
 }

--- a/packages/editor/src/components/prefabs/PrefabEditors.tsx
+++ b/packages/editor/src/components/prefabs/PrefabEditors.tsx
@@ -18,8 +18,9 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 import config from '@etherealengine/common/src/config'
-import { defineState } from '@etherealengine/hyperflux'
-import React, { ReactNode } from 'react'
+import { AssetLoader } from '@etherealengine/engine/src/assets/classes/AssetLoader'
+import { defineState, getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import React, { ReactNode, useEffect } from 'react'
 import { FiHexagon } from 'react-icons/fi'
 
 export type PrefabShelfItem = {
@@ -143,5 +144,20 @@ export const PrefabShelfState = defineState({
         url: `${config.client.fileServer}/projects/default-project/assets/prefabs/fog.prefab.gltf`,
         category: 'Lookdev'
       }
-    ] as PrefabShelfItem[]
+    ] as PrefabShelfItem[],
+  reactor: () => {
+    const shelfState = useHookstate(getMutableState(PrefabShelfState))
+    return shelfState.value.map((shelfItem) => <ShelfItemReactor key={shelfItem.url} url={shelfItem.url} />)
+  }
 })
+
+const ShelfItemReactor = (props: { key: string; url: string }): JSX.Element | null => {
+  useEffect(() => {
+    AssetLoader.cacheAsset(props.url)
+    return () => {
+      AssetLoader.uncacheAsset(props.url)
+    }
+  }, [])
+
+  return null
+}

--- a/packages/engine/src/assets/classes/AssetLoader.ts
+++ b/packages/engine/src/assets/classes/AssetLoader.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import { AudioLoader } from 'three'
 
-import { defineState, getState } from '@etherealengine/hyperflux'
+import { getState } from '@etherealengine/hyperflux'
 import { isAbsolutePath } from '@etherealengine/spatial/src/common/functions/isAbsolutePath'
 import { EngineState } from '@etherealengine/spatial/src/EngineState'
 
@@ -91,11 +91,6 @@ export const getLoader = (assetType: AssetExt) => {
 }
 
 const getAbsolutePath = (url) => (isAbsolutePath(url) ? url : getState(EngineState).publicPath + url)
-
-const AssetLoaderCacheState = defineState({
-  name: 'AssetLoaderCacheState',
-  initial: () => ({}) as Record<string, any>
-})
 
 const loadAsset = async <T>(
   url: string,

--- a/packages/engine/src/assets/classes/AssetLoader.ts
+++ b/packages/engine/src/assets/classes/AssetLoader.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import { AudioLoader } from 'three'
 
-import { defineState, getMutableState, getState, NO_PROXY, none } from '@etherealengine/hyperflux'
+import { defineState, getState } from '@etherealengine/hyperflux'
 import { isAbsolutePath } from '@etherealengine/spatial/src/common/functions/isAbsolutePath'
 import { EngineState } from '@etherealengine/spatial/src/EngineState'
 
@@ -97,31 +97,13 @@ const AssetLoaderCacheState = defineState({
   initial: () => ({}) as Record<string, any>
 })
 
-const cacheAsset = (url: string) => {
-  loadAsset(
-    url,
-    () => {},
-    () => {},
-    () => {},
-    undefined,
-    undefined,
-    true
-  )
-}
-
-const uncacheAsset = (url: string) => {
-  const cacheState = getMutableState(AssetLoaderCacheState)
-  cacheState[url].set(none)
-}
-
 const loadAsset = async <T>(
   url: string,
   onLoad: (response: T) => void = () => {},
   onProgress: (request: ProgressEvent) => void = () => {},
   onError: (event: ErrorEvent | Error) => void = () => {},
   signal?: AbortSignal,
-  loader?: ReturnType<typeof getLoader>,
-  cache?: boolean
+  loader?: ReturnType<typeof getLoader>
 ) => {
   if (!url) {
     onError(new Error('URL is empty'))
@@ -129,28 +111,13 @@ const loadAsset = async <T>(
   }
   url = getAbsolutePath(url)
 
-  const cacheState = getMutableState(AssetLoaderCacheState)
-  if (cache && cacheState[url].value) {
-    onLoad(cacheState[url].get(NO_PROXY))
-    return
-  }
-
   if (!loader) {
     const assetExt = getAssetType(url)
     loader = getLoader(assetExt)
   }
 
-  const loadCallback = cache
-    ? (response: T) => {
-        if (cache) {
-          cacheState.merge({ [url]: response })
-        }
-        onLoad(response)
-      }
-    : onLoad
-
   try {
-    return loader.load(url, loadCallback, onProgress, onError, signal)
+    return loader.load(url, onLoad, onProgress, onError, signal)
   } catch (error) {
     onError(error)
   }
@@ -161,7 +128,5 @@ export const AssetLoader = {
   getAssetType,
   getAssetClass,
   /** @deprecated Use resourceLoaderHooks instead */
-  loadAsset,
-  cacheAsset,
-  uncacheAsset
+  loadAsset
 }


### PR DESCRIPTION
Caches prefab shelf assets so that they're only fetched once, when the prefab shelf is initialized.

Closes https://tsu.atlassian.net/browse/IR-2343