### PR TITLE
Fixing the text color tailwind class names attributed to X/Y/Z property field names

### DIFF
--- a/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
+++ b/packages/client-core/src/admin/components/locations/AddEditLocationModal.tsx
@@ -209,7 +209,7 @@ export default function AddEditLocationModal(props: { location?: LocationType; s
                 }
               >
                 <div
-                  className="cursor-pointer text-blue-primary hover:underline"
+                  className="text-blue-primary cursor-pointer hover:underline"
                   onClick={() => window.open(new URL(location.url))}
                 >
                   {location.url}

--- a/packages/client-core/src/admin/components/server/index.tsx
+++ b/packages/client-core/src/admin/components/server/index.tsx
@@ -87,13 +87,13 @@ export default function Servers() {
           <div
             key={info.id}
             className={`flex h-16 w-44 cursor-pointer items-start justify-between rounded-2xl bg-theme-surface-main p-4 ${
-              serverType.value === info.id && 'border-b-2 border-b-blue-primary'
+              serverType.value === info.id && 'border-b-blue-primary border-b-2'
             }`}
             onClick={() => serverType.set(info.id)}
           >
             <Text fontSize="sm">{info.label}</Text>
             <Badge
-              className="h-6 rounded-[90px] bg-blue-primary text-white"
+              className="bg-blue-primary h-6 rounded-[90px] text-white"
               label={`${info.pods.filter((inf) => inf.status === 'Running').length}/${info.pods.length}`}
             />
           </div>

--- a/packages/editor/src/components/assets/ModelCompressionPanel.tsx
+++ b/packages/editor/src/components/assets/ModelCompressionPanel.tsx
@@ -290,9 +290,7 @@ export default function ModelCompressionPanel({
               <Button
                 variant="transparent"
                 className={`rounded-none px-1 pb-4 text-sm font-medium ${
-                  selectedLODIndex.value === index
-                    ? 'border-b border-blue-primary text-blue-primary'
-                    : 'text-theme-input'
+                  selectedLODIndex.value === index ? 'border-blue-primary text-blue-primary border-b' : 'text-[#9CA0AA]'
                 }`}
                 onClick={() => selectedLODIndex.set(Math.min(index, lods.length - 1))}
               >

--- a/packages/ui/src/components/editor/input/Vector3/index.tsx
+++ b/packages/ui/src/components/editor/input/Vector3/index.tsx
@@ -46,11 +46,11 @@ export const Vector3Scrubber = ({ axis, onChange, onPointerUp, value, children, 
   const color = (() => {
     switch (axis) {
       case 'x':
-        return 'blue-primary'
+        return 'red-500'
       case 'y':
-        return 'pink-primary'
+        return 'green-400'
       case 'z':
-        return 'purple-primary'
+        return 'blue-400'
       default:
         return 'inherit'
     }

--- a/packages/ui/src/components/editor/panels/Assets/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Assets/container/index.tsx
@@ -179,7 +179,7 @@ const ResourceFile = (props: {
     >
       <span
         className={`mx-4 mb-3 mt-2 h-40 w-40 font-['Figtree'] ${
-          selected ? 'rounded-lg border border-blue-primary bg-theme-studio-surface' : ''
+          selected ? 'border-blue-primary rounded-lg border bg-theme-studio-surface' : ''
         }`}
       >
         <FileIcon thumbnailURL={resource.thumbnailURL} type={assetType} />

--- a/packages/ui/src/primitives/tailwind/Progress/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Progress/index.tsx
@@ -42,7 +42,7 @@ export interface ProgressProps extends React.HTMLAttributes<HTMLProgressElement>
 
 const Progress = ({ className, barClassName, value, size = 'default' }: ProgressProps) => {
   const twClassName = twMerge(sizes[size], 'w-full rounded-full bg-gray-200 dark:bg-gray-700', className)
-  const twBarClassName = twMerge(sizes[size], 'rounded-full bg-blue-primary', barClassName)
+  const twBarClassName = twMerge(sizes[size], 'bg-blue-primary rounded-full', barClassName)
 
   return (
     <div className={twClassName}>

--- a/packages/ui/src/primitives/tailwind/Radio/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Radio/index.tsx
@@ -58,7 +58,7 @@ export const RadioRoot = ({
           name={label}
           onChange={onChange}
           disabled={disabled}
-          className="mr-2 h-4 w-4 shrink-0 appearance-none rounded-full border border-[#212226] bg-[#141619] bg-clip-content checked:border-blue-primary checked:bg-blue-500 checked:p-[2px] indeterminate:hover:border-[#9CA0AA]  focus:ring-blue-primary disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-gray-800"
+          className="text-blue-primary checked:border-blue-primary focus:ring-blue-primary shrink-0 rounded-full border-gray-200 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:focus:ring-offset-gray-800"
         />
         {label}
       </label>

--- a/packages/ui/src/primitives/tailwind/Tabs/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Tabs/index.tsx
@@ -137,7 +137,7 @@ const Tabs = ({
               key={index}
               className={twMerge(
                 twTabClassName,
-                currentTab.value === index ? 'border-b border-b-blue-primary font-semibold text-theme-primary' : '',
+                currentTab.value === index ? 'border-b-blue-primary border-b font-semibold text-theme-primary' : '',
                 tab.disabled ? 'border-none' : ''
               )}
               disabled={tab.disabled}

--- a/packages/ui/src/primitives/tailwind/Toggle/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Toggle/index.tsx
@@ -57,7 +57,7 @@ const Toggle = ({
 }: ToggleProps) => {
   const twClassName = twMerge(
     "peer relative cursor-pointer rounded-full bg-gray-200 after:absolute after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']",
-    'peer-checked:bg-blue-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:bg-blue-primary peer-focus:ring-4 dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:bg-blue-primary',
+    'peer-checked:bg-blue-primary peer-focus:bg-blue-primary dark:peer-focus:bg-blue-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:ring-4 dark:border-gray-600 dark:bg-gray-700',
     'peer-disabled:pointer-events-none peer-disabled:opacity-50',
     className,
     sizeMap[size ?? 'md']

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -77,10 +77,6 @@ module.exports = {
         }
       },
       colors: {
-        'blue-primary': '#375DAF',
-        'blue-secondary': '#162546',
-        'pink-primary': '#A24482',
-        'purple-primary': '#8261D2'
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## References
closes https://tsu.atlassian.net/browse/IR-3409

## QA Steps

Make sure the X, Y and Z property labels are red, green, and blue like so in the Transform components in the property panel of selected entities:

![image](https://github.com/user-attachments/assets/b73dd35f-8e54-4ea2-a0dc-39f87dc7a115)
