### PR TITLE
IR-3495: Fixes duplicate row write to `static-resource` on SaveAs

### DIFF
--- a/packages/editor/src/functions/assetFunctions.ts
+++ b/packages/editor/src/functions/assetFunctions.ts
@@ -89,7 +89,7 @@ export const inputFileWithAddToScene = ({
     el.click()
   })
 
-export const uploadProjectFiles = (projectName: string, files: File[], paths: string[], onProgress?) => {
+export const uploadProjectFiles = (projectName: string, files: File[], paths: string[], args?: object) => {
   const promises: CancelableUploadPromiseReturnType<string>[] = []
 
   for (let i = 0; i < files.length; i++) {
@@ -97,14 +97,9 @@ export const uploadProjectFiles = (projectName: string, files: File[], paths: st
     const fileDirectory = paths[i].replace('projects/' + projectName + '/', '')
     const filePath = fileDirectory ? pathJoin(fileDirectory, file.name) : file.name
     promises.push(
-      uploadToFeathersService(
-        fileBrowserUploadPath,
-        [file],
-        {
-          args: [{ project: projectName, path: filePath, contentType: '' }]
-        },
-        onProgress
-      )
+      uploadToFeathersService(fileBrowserUploadPath, [file], {
+        args: [{ project: projectName, path: filePath, contentType: '', ...args }]
+      })
     )
   }
 

--- a/packages/editor/src/functions/sceneFunctions.tsx
+++ b/packages/editor/src/functions/sceneFunctions.tsx
@@ -27,12 +27,7 @@ import i18n from 'i18next'
 
 import config from '@etherealengine/common/src/config'
 import multiLogger from '@etherealengine/common/src/logger'
-import {
-  StaticResourceData,
-  StaticResourceType,
-  fileBrowserPath,
-  staticResourcePath
-} from '@etherealengine/common/src/schema.type.module'
+import { StaticResourceType, fileBrowserPath, staticResourcePath } from '@etherealengine/common/src/schema.type.module'
 import { cleanString } from '@etherealengine/common/src/utils/cleanString'
 import { EntityUUID, UUIDComponent, UndefinedEntity } from '@etherealengine/ecs'
 import { getComponent, setComponent } from '@etherealengine/ecs/src/ComponentFunctions'
@@ -119,7 +114,14 @@ export const saveSceneGLTF = async (
   const blob = [JSON.stringify(encodedGLTF, null, 2)]
   const file = new File(blob, `${sceneName}.gltf`)
 
-  const [[newPath]] = await Promise.all(uploadProjectFiles(projectName, [file], [currentSceneDirectory]).promises)
+  const currentScene = await Engine.instance.api.service(staticResourcePath).get(sceneAssetID)
+  const [[newPath]] = await Promise.all(
+    uploadProjectFiles(projectName, [file], [currentSceneDirectory], {
+      type: 'scene',
+      contentType: 'model/gltf+json',
+      thumbnailKey: currentScene.thumbnailKey
+    }).promises
+  )
 
   const newURL = new URL(newPath)
   newURL.hash = ''
@@ -142,22 +144,19 @@ export const saveSceneGLTF = async (
     return
   }
 
-  const currentScene = await Engine.instance.api.service(staticResourcePath).get(sceneAssetID)
+  const result = await Engine.instance.api.service(staticResourcePath).find({
+    query: { key: assetURL, $limit: 1 }
+  })
 
-  const newSceneData: StaticResourceData = {
-    key: assetURL,
-    project: projectName,
-    type: 'scene',
-    thumbnailKey: currentScene.thumbnailKey
+  if (result.total !== 1) {
+    throw new Error(i18n.t('editor:errors.sceneSaveFailed'))
   }
-
-  const result = await Engine.instance.api.service(staticResourcePath).create(newSceneData)
 
   getMutableState(EditorState).merge({
     sceneName,
     scenePath: assetURL,
     projectName,
-    sceneAssetID: result.id
+    sceneAssetID: result.data[0].id
   })
 }
 

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.class.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.class.ts
@@ -27,7 +27,7 @@ import { ServiceInterface } from '@feathersjs/feathers/lib/declarations'
 import { KnexAdapterParams } from '@feathersjs/knex'
 
 import { UploadFile } from '@etherealengine/common/src/interfaces/UploadAssetInterface'
-import { fileBrowserPath } from '@etherealengine/common/src/schemas/media/file-browser.schema'
+import { FileBrowserPatch, fileBrowserPath } from '@etherealengine/common/src/schemas/media/file-browser.schema'
 
 import { Application } from '../../../declarations'
 
@@ -51,13 +51,24 @@ export class FileBrowserUploadService implements ServiceInterface<string[], any,
       await Promise.all(
         params.files.map((file, i) => {
           const args = data[i]
-          return this.app.service(fileBrowserPath).patch(null, {
+
+          const patchArgs: FileBrowserPatch = {
             ...args,
             project: args.project,
             path: args.path,
             body: file.buffer as Buffer,
-            contentType: file.mimetype
-          })
+            contentType: args.contentType || file.mimetype
+          }
+
+          if (args.thumbnailKey) {
+            patchArgs.thumbnailKey = args.thumbnailKey
+          }
+
+          if (args.tags) {
+            patchArgs.tags = args.tags
+          }
+
+          return this.app.service(fileBrowserPath).patch(null, patchArgs)
         })
       )
     ).map((result) => result.url)


### PR DESCRIPTION
## Summary
Currently, On **Save As** operation, two rows are written to `static-resource` table.
- One row has `type` column set to `file`
- Other has `scene`
Both rows has the same key (path), and same hash.

This PR removes the duplicate write that occurs during **Save** & **SaveAs** operations.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
