### PR TITLE
Fix viewport freeze on redocking

### DIFF
--- a/packages/spatial/src/input/systems/ClientInputSystem.tsx
+++ b/packages/spatial/src/input/systems/ClientInputSystem.tsx
@@ -229,7 +229,8 @@ const execute = () => {
   for (const eid of pointers()) {
     const pointer = getComponent(eid, InputPointerComponent)
     const inputSource = getComponent(eid, InputSourceComponent)
-    const camera = getComponent(pointer.cameraEntity, CameraComponent)
+    const camera = getOptionalComponent(pointer.cameraEntity, CameraComponent)
+    if (!camera) continue //when we reparent viewport we lose the camera temporarily
     pointer.movement.copy(pointer.position).sub(pointer.lastPosition)
     pointer.lastPosition.copy(pointer.position)
     inputSource.raycaster.setFromCamera(pointer.position, camera)


### PR DESCRIPTION
This pull request fixes the issue of viewport freezing when redocking. The fix involves checking if the camera component exists before proceeding with the operation. If the camera component is not found, the operation is skipped. This prevents the freezing of the viewport when reparenting.