### PR TITLE
Fix: Zendesk Authentication

### DIFF
--- a/packages/client-core/src/hooks/useZendesk.ts
+++ b/packages/client-core/src/hooks/useZendesk.ts
@@ -64,10 +64,10 @@ export const useZendesk = () => {
     script.async = true
     script.src = `https://static.zdassets.com/ekr/snippet.js?key=${config.client.zendesk.key}`
     document.body.appendChild(script)
-    initialized.set(true)
 
     script.addEventListener('load', () => {
       if ('zE' in window) {
+        initialized.set(true)
         hideWidget()
         authenticateUser()
       }


### PR DESCRIPTION
## Summary
Fixed race condition when Zendesk authentication is triggered and the widget is not initialized 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
