### PR TITLE
IR-3512 fixing file drag and drop into files tab

### DIFF
--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -343,14 +343,15 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
         await moveContent(data.fullName, newName, data.path, destinationPath, false)
       }
     } else {
-      const folder = destinationPath.substring(0, destinationPath.lastIndexOf('/') + 1)
+      const destinationPathCleaned = removeLeadingTrailingSlash(destinationPath)
+      const folder = destinationPathCleaned //destinationPathCleaned.substring(0, destinationPathCleaned.lastIndexOf('/') + 1)
       const projectName = folder.split('/')[1]
       const relativePath = folder.replace('projects/' + projectName + '/', '')
 
       await Promise.all(
         data.files.map(async (file) => {
-          const assetType = !file.type ? AssetLoader.getAssetType(file.name) : file.type
-          if (!assetType) {
+          const assetType = !file.type || file.type.length === 0 ? AssetLoader.getAssetType(file.name) : file.type
+          if (!assetType || assetType === file.name) {
             // creating directory
             await fileService.create(`${destinationPath}${file.name}`)
           } else {
@@ -360,7 +361,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
                 args: [
                   {
                     project: projectName,
-                    path: relativePath + name,
+                    path: relativePath + '/' + name,
                     contentType: file.type
                   }
                 ]
@@ -374,6 +375,16 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
     }
 
     await refreshDirectory()
+  }
+
+  function removeLeadingTrailingSlash(str) {
+    if (str.startsWith('/')) {
+      str = str.substring(1)
+    }
+    if (str.endsWith('/')) {
+      str = str.substring(0, str.length - 1)
+    }
+    return str
   }
 
   const onBackDirectory = () => {


### PR DESCRIPTION
## Summary
fixing file drag and drop into files tab

fixes path manipulation of destination path string, also correctly identifies directories dropped in (though they do not include any contents information)
