### PR TITLE
Force deselect entity on prefab creation to prevent errors

### DIFF
--- a/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
+++ b/packages/editor/src/components/dialogs/CreatePrefabPanelDialog.tsx
@@ -89,7 +89,7 @@ export default function CreatePrefabPanel({ entity }: { entity: Entity }) {
         scale: new Vector3(1, 1, 1)
       })
       setComponent(entity, EntityTreeComponent, { parentEntity: prefabEntity })
-
+      getMutableState(SelectionState).selectedEntities.set([])
       await exportRelativeGLTF(prefabEntity, srcProject, fileName)
 
       const resources = await Engine.instance.api.service(staticResourcePath).find({


### PR DESCRIPTION
## Summary
todo, figure out why exportRelativeGLTF updates something in this case causing entities to become undefined

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
