### PR TITLE
Feature flags for model and transform pivot

### DIFF
--- a/packages/common/src/constants/FeatureFlags.ts
+++ b/packages/common/src/constants/FeatureFlags.ts
@@ -36,10 +36,15 @@ export const FeatureFlags = {
     }
   },
   Studio: {
+    Model: {
+      Dereference: 'ir.studio.model.dereference',
+      GLTFTransform: 'ir.studio.model.gltfTransform'
+    },
     Panel: {
       VisualScript: 'ir.editor.panel.visualScript'
     },
     UI: {
+      TransformPivot: 'ir.editor.ui.transformPivot',
       Hierarchy: {
         ShowModelChildren: 'ir.editor.ui.hierarchy.showModelChildren'
       }

--- a/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/browserGrid/index.tsx
@@ -200,7 +200,7 @@ type FileBrowserItemType = {
   currentContent: MutableRefObject<{ item: FileDataType; isCopy: boolean }>
   openModelCompress: () => void
   openImageCompress: () => void
-  openFileProperties: () => void
+  openFileProperties: (item: FileDataType) => void
   openDeleteFileModal: () => void
   isFilesLoading: boolean
   projectName: string
@@ -418,7 +418,7 @@ export function FileBrowserItem({
             size="small"
             fullWidth
             onClick={() => {
-              openFileProperties()
+              openFileProperties(item)
               handleClose()
             }}
           >

--- a/packages/ui/src/components/editor/panels/Files/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Files/container/index.tsx
@@ -593,7 +593,15 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
                       fileProperties.value.map((file) => file.key)
                     )
                   }
-                  openFileProperties={() => {
+                  openFileProperties={(item) => {
+                    /** If the file is not in the list of files, add it */
+                    if (!(fileProperties.get(NO_PROXY) as FileDataType[]).includes(item)) {
+                      if (fileProperties.value.length > 1) {
+                        fileProperties.merge([item])
+                      } else {
+                        fileProperties.set([item])
+                      }
+                    }
                     PopoverState.showPopupover(
                       <FilePropertiesModal projectName={projectName} files={fileProperties.value} />
                     )

--- a/packages/ui/src/components/editor/panels/Viewport/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Viewport/container/index.tsx
@@ -26,6 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import { NotificationService } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { useEngineCanvas } from '@etherealengine/client-core/src/hooks/useEngineCanvas'
 import { uploadToFeathersService } from '@etherealengine/client-core/src/util/upload'
+import { FeatureFlags } from '@etherealengine/common/src/constants/FeatureFlags'
 import { clientSettingPath, fileBrowserUploadPath } from '@etherealengine/common/src/schema.type.module'
 import { processFileName } from '@etherealengine/common/src/utils/processFileName'
 import { getComponent, useComponent, useQuery } from '@etherealengine/ecs'
@@ -38,6 +39,7 @@ import { GLTFComponent } from '@etherealengine/engine/src/gltf/GLTFComponent'
 import { GLTFModifiedState } from '@etherealengine/engine/src/gltf/GLTFDocumentState'
 import { ResourcePendingComponent } from '@etherealengine/engine/src/gltf/ResourcePendingComponent'
 import { SourceComponent } from '@etherealengine/engine/src/scene/components/SourceComponent'
+import useFeatureFlags from '@etherealengine/engine/src/useFeatureFlags'
 import { getMutableState, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { TransformComponent } from '@etherealengine/spatial'
 import { useFind } from '@etherealengine/spatial/src/common/functions/FeathersHooks'
@@ -163,12 +165,14 @@ const ViewPortPanelContainer = () => {
 
   useEngineCanvas(ref)
 
+  const [transformPivotFeatureFlag] = useFeatureFlags([FeatureFlags.Studio.UI.TransformPivot])
+
   return (
     <ViewportDnD>
       <div className="relative z-30 flex h-full w-full flex-col">
         <div ref={toolbarRef} className="z-10 flex gap-1 bg-theme-studio-surface p-1">
           <TransformSpaceTool />
-          <TransformPivotTool />
+          {transformPivotFeatureFlag && <TransformPivotTool />}
           <GridTool />
           <TransformSnapTool />
           <SceneHelpersTool />


### PR DESCRIPTION
## Summary

- right clicking assets/files selects them intuitively when opening file properties menu
- add feature flags for model transform, model dereference and transform pivot

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
