### PR TITLE
ignore hash when checking cache validity

### DIFF
--- a/packages/engine/src/assets/loaders/gltf/extensions/CachedImageLoadExtension.ts
+++ b/packages/engine/src/assets/loaders/gltf/extensions/CachedImageLoadExtension.ts
@@ -35,7 +35,9 @@ class CachedImageLoadExtension extends ImporterExtension implements GLTFLoaderPl
 
   loadTexture(textureIndex) {
     const options = this.parser.options
-    if (!options.url?.endsWith('.gltf')) {
+    const baseURL = new URL(options.url)
+
+    if (!baseURL.pathname.endsWith('.gltf')) {
       return this.parser.loadTexture(textureIndex)
     }
     const json = this.parser.json


### PR DESCRIPTION
makes image caching extension ignore hash when checking if a file is a gltf or not. This will dramatically reduce our memory footprint when using .gltf files in our scenes