### PR TITLE
int to stg: image caching fix

### DIFF
--- a/packages/engine/src/assets/loaders/gltf/extensions/CachedImageLoadExtension.ts
+++ b/packages/engine/src/assets/loaders/gltf/extensions/CachedImageLoadExtension.ts
@@ -35,7 +35,9 @@ class CachedImageLoadExtension extends ImporterExtension implements GLTFLoaderPl
 
   loadTexture(textureIndex) {
     const options = this.parser.options
-    if (!options.url?.endsWith('.gltf')) {
+    const baseURL = new URL(options.url)
+
+    if (!baseURL.pathname.endsWith('.gltf')) {
       return this.parser.loadTexture(textureIndex)
     }
     const json = this.parser.json


### PR DESCRIPTION
* Revert "Physics reactivity for collider component updates and order dependenc…" (#10876)

This reverts commit 33afb3b987eb9f5b1747257b7e8510f78914857f.

* fix collider reactivity (#10877)

* fix collider reactivity

* fix tests

* optimize

* fix duplicate new scene (#10880)

* rigidbody initialization quick fix (#10883)

* Upload drag drop files MT fix (#10881)

* Upload drag drop files MT fix

* Array length check

* LerpTransform from rigid body uses rigid body instead of scene entity (#10882)

* remove old workflows (#10886)

* fix rigidbody crash server (#10891)

* IR-3561: Magic Link template support for mobile and desktop  (#10889)

* feat: refactor magic link email template to support desktop and mobile
chore: layout template to reuse styles in other templates

* Fixed logo link

---------



* Fixed bugs in instanceserver connections (#10887)

* Fixed bugs in instanceserver connections

There were still some bugs surrounding a client connecting to an instanceserver if the instance record for that server no longer existed. updateInstance needed to return false in that situation.

This still led to a situation where the client would be stuck trying to authenticate forever. Added a step prior to authentication where the client listens for a message with { instanceReady: true }, which is sent by setupSocketFunctions. If the server isn't ready within 10 seconds, then it returns { instanceReady: false }, and the client will do a new instanceserver provision and hopefully connect properly this time.

* make eslint happy

---------



* ignore hash when checking cache validity (#10900)

---------

## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
