### PR TITLE
Unpinned version of @aws-sdk/client-s3

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-ecr": "^3.319.0",
-    "@aws-sdk/client-s3": "3.614.0",
+    "@aws-sdk/client-s3": "^3.319.0",
     "@feathersjs/errors": "5.0.5",
     "@feathersjs/feathers": "5.0.5",
     "@feathersjs/schema": "5.0.5",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.321.1",
     "@aws-sdk/client-ecr-public": "^3.316.0",
-    "@aws-sdk/client-s3": "3.614.0",
+    "@aws-sdk/client-s3": "^3.316.0",
     "@aws-sdk/client-sns": "^3.316.0",
     "@aws-sdk/credential-providers": "^3.549.0",
     "@aws-sdk/lib-storage": "^3.321.1",


### PR DESCRIPTION
## Summary

Pinned version was now causing type errors because it was out of sync with other aws-sdk packages, and latest versions do not have the call hang issues that made us pin it to begin with.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
