### PR TITLE
Added margin-top to UserMediaWindows on small-width devices

### DIFF
--- a/packages/client-core/src/components/UserMediaWindows/index.module.scss
+++ b/packages/client-core/src/components/UserMediaWindows/index.module.scss
@@ -69,7 +69,7 @@
     padding: 20px 20px 60px;
     top: -15px;
     right: -15px;
-    margin: 0;
+    margin: 50px 0 0 0;
 
     &::after {
       display: inline-block;


### PR DESCRIPTION
## Summary

On screen width under 768px, added a margin-top so that screenshare will never overlap the media controls.

Resolves IR-3550

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
