### PR TITLE
Replace primitive geometry's constructor map with a factory map

### DIFF
--- a/packages/engine/src/scene/components/PrimitiveGeometryComponent.ts
+++ b/packages/engine/src/scene/components/PrimitiveGeometryComponent.ts
@@ -30,11 +30,11 @@ import { defineComponent, useComponent } from '@etherealengine/ecs/src/Component
 import { useEntityContext } from '@etherealengine/ecs/src/EntityFunctions'
 import { Geometry } from '@etherealengine/spatial/src/common/constants/Geometry'
 import { useMeshComponent } from '@etherealengine/spatial/src/renderer/components/MeshComponent'
-import { GeometryTypeEnum, GeometryTypeToClass } from '../constants/GeometryTypeEnum'
+import { GeometryTypeEnum, GeometryTypeToFactory } from '../constants/GeometryTypeEnum'
 
 const createGeometry = (geometryType: GeometryTypeEnum, geometryParams: Record<string, any>): Geometry => {
-  const GeometryClass = GeometryTypeToClass[geometryType]
-  const geometry = new GeometryClass(...Object.values(geometryParams))
+  const factory = GeometryTypeToFactory[geometryType]
+  const geometry = factory(geometryParams)
   return geometry
 }
 

--- a/packages/engine/src/scene/constants/GeometryTypeEnum.ts
+++ b/packages/engine/src/scene/constants/GeometryTypeEnum.ts
@@ -23,6 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+import { Geometry } from '@etherealengine/spatial/src/common/constants/Geometry'
 import {
   BoxGeometry,
   CapsuleGeometry,
@@ -69,4 +70,55 @@ export const GeometryTypeToClass = {
   [GeometryTypeEnum.OctahedronGeometry]: OctahedronGeometry,
   [GeometryTypeEnum.TetrahedronGeometry]: TetrahedronGeometry,
   [GeometryTypeEnum.TorusKnotGeometry]: TorusKnotGeometry
+}
+
+type GeometryFactory = (data: Record<string, any>) => Geometry
+
+export const GeometryTypeToFactory: Record<GeometryTypeEnum, GeometryFactory> = {
+  [GeometryTypeEnum.BoxGeometry]: (data) =>
+    new BoxGeometry(data.width, data.height, data.depth, data.widthSegments, data.heightSegments, data.depthSegments),
+  [GeometryTypeEnum.CapsuleGeometry]: (data) =>
+    new CapsuleGeometry(data.radius, data.length, data.capSegments, data.radialSegments),
+  [GeometryTypeEnum.CircleGeometry]: (data) =>
+    new CircleGeometry(data.radius, data.segments, data.thetaStart, data.thetaLength),
+  [GeometryTypeEnum.CylinderGeometry]: (data) =>
+    new CylinderGeometry(
+      data.radiusTop,
+      data.radiusBottom,
+      data.height,
+      data.radialSegments,
+      data.heightSegments,
+      data.openEnded,
+      data.thetaStart,
+      data.thetaLength
+    ),
+  [GeometryTypeEnum.DodecahedronGeometry]: (data) => new DodecahedronGeometry(data.radius, data.detail),
+  [GeometryTypeEnum.IcosahedronGeometry]: (data) => new IcosahedronGeometry(data.radius, data.detail),
+  [GeometryTypeEnum.OctahedronGeometry]: (data) => new OctahedronGeometry(data.radius, data.detail),
+  [GeometryTypeEnum.PlaneGeometry]: (data) =>
+    new PlaneGeometry(data.width, data.height, data.widthSegments, data.heightSegments),
+  [GeometryTypeEnum.RingGeometry]: (data) =>
+    new RingGeometry(
+      data.innerRadius,
+      data.outerRadius,
+      data.thetaSegments,
+      data.phiSegments,
+      data.thetaStart,
+      data.thetaLength
+    ),
+  [GeometryTypeEnum.SphereGeometry]: (data) =>
+    new SphereGeometry(
+      data.radius,
+      data.widthSegments,
+      data.heightSegments,
+      data.phiStart,
+      data.phiLength,
+      data.thetaStart,
+      data.thetaLength
+    ),
+  [GeometryTypeEnum.TetrahedronGeometry]: (data) => new TetrahedronGeometry(data.radius, data.detail),
+  [GeometryTypeEnum.TorusGeometry]: (data) =>
+    new TorusGeometry(data.radius, data.tube, data.radialSegments, data.tubularSegments, data.arc),
+  [GeometryTypeEnum.TorusKnotGeometry]: (data) =>
+    new TorusKnotGeometry(data.radius, data.tube, data.tubularSegments, data.radialSegments, data.p, data.q)
 }


### PR DESCRIPTION
We can't spread the values of `geometryParams` into the arguments of our primitive `BufferGeometry` subclasses; we need to pass each constructor's param in the correct order. This is done in a series of arrow functions that wrap their constructors in place of the original constructor map in `GeometryTypeEnum`.

closes [IR-3692](https://tsu.atlassian.net/browse/IR-3692)

[IR-3692]: https://tsu.atlassian.net/browse/IR-3692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ