### PR TITLE
added condition to prevent the empty button from being displayed in the components category list

### DIFF
--- a/packages/ui/src/components/editor/panels/Properties/elementList/index.tsx
+++ b/packages/ui/src/components/editor/panels/Properties/elementList/index.tsx
@@ -261,14 +261,15 @@ export function ElementList({ type, onSelect }: { type: ElementsType; onSelect: 
               selected={selectedCategories.value.includes(index)}
             />
           ))}
-
-          <SceneElementListItem
-            categoryTitle="Empty"
-            onClick={() => {
-              EditorControlFunctions.createObjectFromSceneElement()
-              onSelect()
-            }}
-          />
+          {type !== 'components' && (
+            <SceneElementListItem
+              categoryTitle="Empty"
+              onClick={() => {
+                EditorControlFunctions.createObjectFromSceneElement()
+                onSelect()
+              }}
+            />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
added condition to prevent the empty button from being displayed in the components category list
https://tsu.atlassian.net/browse/IR-3742

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
