### PR TITLE
[IR-3571] studio: prevent scene from disappearing when double-clicking on hierarchy node

### DIFF
--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -23,7 +23,12 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { getComponent, getMutableComponent, useOptionalComponent } from '@etherealengine/ecs/src/ComponentFunctions'
+import {
+  getComponent,
+  getMutableComponent,
+  getOptionalComponent,
+  useOptionalComponent
+} from '@etherealengine/ecs/src/ComponentFunctions'
 import { AllFileTypes } from '@etherealengine/engine/src/assets/constants/fileTypes'
 import { getMutableState, getState, none, useHookstate, useMutableState } from '@etherealengine/hyperflux'
 import { NameComponent } from '@etherealengine/spatial/src/common/NameComponent'
@@ -276,9 +281,11 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
         }
         setPrevClickedNode(entity)
       } else if (e.detail === 2) {
-        const editorCameraState = getMutableComponent(Engine.instance.cameraEntity, CameraOrbitComponent)
-        editorCameraState.focusedEntities.set([entity])
-        editorCameraState.refocus.set(true)
+        if (entity && getOptionalComponent(entity, CameraOrbitComponent)) {
+          const editorCameraState = getMutableComponent(Engine.instance.cameraEntity, CameraOrbitComponent)
+          editorCameraState.focusedEntities.set([entity])
+          editorCameraState.refocus.set(true)
+        }
       }
     },
     [prevClickedNode, entityHierarchy]


### PR DESCRIPTION
## Summary
- [IR-3571] checks for a CameraOrbitComponent to prevent the scene from disappearing when double-clicking on a `HierarchyTreeNode` 

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps


[IR-3571]: https://tsu.atlassian.net/browse/IR-3571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ