### PR TITLE
[IR-3769] studio: avoid crashing app when component.name is undefined

### DIFF
--- a/packages/ui/src/components/editor/panels/Properties/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Properties/container/index.tsx
@@ -65,7 +65,7 @@ const EntityEditor = (props: { entityUUID: EntityUUID; multiEdit: boolean }) => 
   const components: Component[] = []
   for (const jsonID of Object.keys(node.extensions.value!)) {
     const component = ComponentJSONIDMap.get(jsonID)!
-    if (!componentEditors[component.name]) continue
+    if (!componentEditors[component?.name]) continue
     components.push(component)
   }
 


### PR DESCRIPTION
## Summary
[IR-3769] avoids crashing app when user clicks on a `HierarchyTreeNode` and component.name is undefined

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
app no longer crashes when clicking on 'Settings' from Hierarchy Panel

[IR-3769]: https://tsu.atlassian.net/browse/IR-3769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ