### PR TITLE
Made github-repo-access-refresh runnable as a job

### DIFF
--- a/packages/server-core/src/k8s-job-helper.ts
+++ b/packages/server-core/src/k8s-job-helper.ts
@@ -37,7 +37,8 @@ export const createExecutorJob = async (
   jobBody: k8s.V1Job,
   jobLabelSelector: string,
   timeout: number,
-  jobId: string
+  jobId: string,
+  waitForFinish = true
 ) => {
   const k8BatchClient = getState(ServerState).k8BatchClient
 
@@ -51,6 +52,7 @@ export const createExecutorJob = async (
   await k8BatchClient.createNamespacedJob('default', jobBody)
   let counter = 0
   return new Promise((resolve, reject) => {
+    if (!waitForFinish) resolve({})
     const interval = setInterval(async () => {
       counter++
 

--- a/packages/server-core/src/user/github-repo-access-refresh/github-repo-access-refresh.class.ts
+++ b/packages/server-core/src/user/github-repo-access-refresh/github-repo-access-refresh.class.ts
@@ -34,12 +34,44 @@ import {
   identityProviderPath,
   IdentityProviderType
 } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
+import * as k8s from '@kubernetes/client-node'
 
+import { UserID } from '@etherealengine/common/src/schemas/user/user.schema'
 import { Application } from '../../../declarations'
+import { getJobBody } from '../../k8s-job-helper'
 import { getUserRepos } from '../../projects/project/github-helper'
 import logger from '../../ServerLogger'
 
 export interface GithubRepoAccessRefreshParams extends KnexAdapterParams {}
+
+export async function getGithubRepoAccessRefreshJobBody(
+  app: Application,
+  jobId: string,
+  userId: UserID
+): Promise<k8s.V1Job> {
+  const command = [
+    'npx',
+    'cross-env',
+    'ts-node',
+    '--swc',
+    'scripts/refresh-gh-repo-access.ts',
+    '--userId',
+    userId,
+    '--jobId',
+    jobId
+  ]
+
+  const labels = {
+    'etherealengine/ghRepoAccessRefresh': 'true',
+    'etherealengine/autoUpdate': 'false',
+    'etherealengine/userId': userId,
+    'etherealengine/release': process.env.RELEASE_NAME!
+  }
+
+  const name = `${process.env.RELEASE_NAME}-gh-repo-refresh-${userId.slice(0, 8)}-update`
+
+  return getJobBody(app, command, name, labels)
+}
 
 /**
  * A class for Github Repo Access Refresh service

--- a/scripts/refresh-gh-repo-access.ts
+++ b/scripts/refresh-gh-repo-access.ts
@@ -1,0 +1,78 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import appRootPath from 'app-root-path'
+import cli from 'cli'
+import dotenv from 'dotenv-flow'
+
+import { apiJobPath, githubRepoAccessRefreshPath, userPath } from '@etherealengine/common/src/schema.type.module'
+import { getDateTimeSql } from '@etherealengine/common/src/utils/datetime-sql'
+import { ServerMode } from '@etherealengine/server-core/src/ServerState'
+import { createFeathersKoaApp, serverJobPipe } from '@etherealengine/server-core/src/createApp'
+import { updateAppConfig } from '@etherealengine/server-core/src/updateAppConfig'
+
+dotenv.config({
+  path: appRootPath.path,
+  silent: true
+})
+
+const db = {
+  username: process.env.MYSQL_USER ?? 'server',
+  password: process.env.MYSQL_PASSWORD ?? 'password',
+  database: process.env.MYSQL_DATABASE ?? 'etherealengine',
+  host: process.env.MYSQL_HOST ?? '127.0.0.1',
+  port: process.env.MYSQL_PORT ?? 3306,
+  dialect: 'mysql',
+  url: ''
+}
+
+db.url = process.env.MYSQL_URL ?? `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`
+
+cli.enable('status')
+
+const options = cli.parse({
+  userId: [false, 'ID of user updating project', 'string'],
+  jobId: [false, 'ID of Job record', 'string']
+})
+
+cli.main(async () => {
+  try {
+    await updateAppConfig()
+    const app = createFeathersKoaApp(ServerMode.API, serverJobPipe)
+    await app.setup()
+    const { userId, jobId } = options
+    const user = await app.service(userPath).get(userId)
+    await app.service(githubRepoAccessRefreshPath).find(Object.assign({}, {}, { user }))
+    const date = await getDateTimeSql()
+    await app.service(apiJobPath).patch(jobId, {
+      status: 'succeeded',
+      endTime: date
+    })
+    cli.exit(0)
+  } catch (err) {
+    console.log(err)
+    cli.fatal(err)
+  }
+})


### PR DESCRIPTION
## Summary

Logging in with GitHub was taking notably longer than other SSO methods because it was performing a refresh of the user's Github repo access. Made a new service to call this function that can be run as a job, and running it as a job on Kubernetes.

createExecutorJob now has an optional param to not wait for the job to finish before resolving for this and similar situations where you don't care to check if the job is finished. Default is to waitForFinish to be true.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
