### PR TITLE
Fixed bugs in identity-provider service (#10917)

### DIFF
--- a/packages/server-core/src/projects/project-branches/project-branches.test.ts
+++ b/packages/server-core/src/projects/project-branches/project-branches.test.ts
@@ -31,11 +31,12 @@ import { projectBranchesPath } from '@etherealengine/common/src/schemas/projects
 import { ScopeType } from '@etherealengine/common/src/schemas/scope/scope.schema'
 import { avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schema'
 import { identityProviderPath } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
-import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
+import { UserApiKeyType, userApiKeyPath } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 
 describe('project-branches.test', () => {
@@ -70,12 +71,15 @@ describe('project-branches.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project-builder-tags/project-builder-tags.test.ts
+++ b/packages/server-core/src/projects/project-builder-tags/project-builder-tags.test.ts
@@ -31,12 +31,13 @@ import { projectBuilderTagsPath } from '@etherealengine/common/src/schemas/proje
 import { ScopeType } from '@etherealengine/common/src/schemas/scope/scope.schema'
 import { avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schema'
 import { identityProviderPath } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
-import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
+import { UserApiKeyType, userApiKeyPath } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 
 describe('project-builder-tags.test', () => {
   let app: Application
@@ -70,12 +71,15 @@ describe('project-builder-tags.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project-check-source-destination-match/project-check-source-destination-match.test.ts
+++ b/packages/server-core/src/projects/project-check-source-destination-match/project-check-source-destination-match.test.ts
@@ -36,8 +36,9 @@ import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schem
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 import { getRepoManifestJson1, getRepoManifestJson2 } from '../../util/mockOctokitResponses'
 
 describe('project-check-source-destination-match.test', () => {
@@ -80,12 +81,15 @@ describe('project-check-source-destination-match.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project-check-unfetched-commit/project-check-unfetched-commit.test.ts
+++ b/packages/server-core/src/projects/project-check-unfetched-commit/project-check-unfetched-commit.test.ts
@@ -31,12 +31,13 @@ import { projectCheckUnfetchedCommitPath } from '@etherealengine/common/src/sche
 import { ScopeType } from '@etherealengine/common/src/schemas/scope/scope.schema'
 import { avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schema'
 import { identityProviderPath } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
-import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
+import { UserApiKeyType, userApiKeyPath } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 import { getRepoManifestJson1, getTestRepoCommit } from '../../util/mockOctokitResponses'
 
 describe('project-check-unfetched-commit.test', () => {
@@ -71,12 +72,15 @@ describe('project-check-unfetched-commit.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project-commits/project-commits.test.ts
+++ b/packages/server-core/src/projects/project-commits/project-commits.test.ts
@@ -31,12 +31,13 @@ import { projectCommitsPath } from '@etherealengine/common/src/schemas/projects/
 import { ScopeType } from '@etherealengine/common/src/schemas/scope/scope.schema'
 import { avatarPath } from '@etherealengine/common/src/schemas/user/avatar.schema'
 import { identityProviderPath } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
-import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
+import { UserApiKeyType, userApiKeyPath } from '@etherealengine/common/src/schemas/user/user-api-key.schema'
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 import { getRepoManifestJson1, getTestRepoCommits, getTestRepoData } from '../../util/mockOctokitResponses'
 
 describe('project-commits.test', () => {
@@ -69,12 +70,15 @@ describe('project-commits.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project-destination-check/project-destination-check.test.ts
+++ b/packages/server-core/src/projects/project-destination-check/project-destination-check.test.ts
@@ -39,8 +39,9 @@ import {
 } from '@etherealengine/common/src/schema.type.module'
 import { destroyEngine } from '@etherealengine/ecs'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 import {
   getRepoManifestJson1,
   getRepoManifestJson2,
@@ -78,12 +79,15 @@ describe('project-destination-check.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project-github-push/project-github-push.test.ts
+++ b/packages/server-core/src/projects/project-github-push/project-github-push.test.ts
@@ -37,8 +37,9 @@ import { userApiKeyPath, UserApiKeyType } from '@etherealengine/common/src/schem
 import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 
 describe('project-github-push.test', () => {
   let app: Application
@@ -73,13 +74,16 @@ describe('project-github-push.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id,
-        oauthToken: `test-oauthtoken-${Math.round(Math.random() * 1000)}`
-      },
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id,
+          oauthToken: `test-oauthtoken-${Math.round(Math.random() * 1000)}`
+        },
+        {} as HookContext
+      ),
       getParams()
     )
   })

--- a/packages/server-core/src/projects/project/project.test.ts
+++ b/packages/server-core/src/projects/project/project.test.ts
@@ -40,8 +40,9 @@ import { UserName, userPath } from '@etherealengine/common/src/schemas/user/user
 import { copyFolderRecursiveSync, deleteFolderRecursive } from '@etherealengine/common/src/utils/fsHelperFunctions'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { Application } from '../../../declarations'
+import { Application, HookContext } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
+import { identityProviderDataResolver } from '../../user/identity-provider/identity-provider.resolvers'
 import { useGit } from '../../util/gitHelperFunctions'
 
 const cleanup = async (app: Application, projectName: string) => {
@@ -83,13 +84,15 @@ describe('project.test', () => {
 
     testUserApiKey = await app.service(userApiKeyPath).create({ userId: testUser.id })
 
-    await app.service(identityProviderPath).create(
-      {
-        type: 'github',
-        token: `test-token-${Math.round(Math.random() * 1000)}`,
-        userId: testUser.id
-      },
-      getParams()
+    await app.service(identityProviderPath)._create(
+      await identityProviderDataResolver.resolve(
+        {
+          type: 'github',
+          token: `test-token-${Math.round(Math.random() * 1000)}`,
+          userId: testUser.id
+        },
+        {} as HookContext
+      )
     )
   })
 

--- a/packages/server-core/src/user/identity-provider/identity-provider.test.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.test.ts
@@ -30,7 +30,7 @@ import {
   identityProviderPath,
   IdentityProviderType
 } from '@etherealengine/common/src/schemas/user/identity-provider.schema'
-import { UserID } from '@etherealengine/common/src/schemas/user/user.schema'
+import { UserID, userPath } from '@etherealengine/common/src/schemas/user/user.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
 import { Application } from '../../../declarations'
@@ -38,6 +38,7 @@ import { createFeathersKoaApp } from '../../createApp'
 
 describe('identity-provider.service', () => {
   let userId: UserID
+  let accessToken: string
   let app: Application
   let providers: IdentityProviderType[] = []
 
@@ -63,6 +64,7 @@ describe('identity-provider.service', () => {
     providers.push(createdIdentityProvider)
 
     userId = createdIdentityProvider.userId
+    accessToken = createdIdentityProvider.accessToken as string
 
     assert.equal(createdIdentityProvider.type, type)
     assert.equal(createdIdentityProvider.token, token)
@@ -74,11 +76,18 @@ describe('identity-provider.service', () => {
     const type = 'email'
     const token = uuidv4()
 
-    const createdIdentityProvider = await app.service(identityProviderPath).create({
-      type,
-      token,
-      userId
-    })
+    const createdIdentityProvider = await app.service(identityProviderPath).create(
+      {
+        type,
+        token,
+        userId
+      },
+      {
+        authentication: {
+          accessToken
+        }
+      }
+    )
 
     providers.push(createdIdentityProvider)
 
@@ -92,11 +101,18 @@ describe('identity-provider.service', () => {
     const type = 'password'
     const token = uuidv4()
 
-    const createdIdentityProvider = await app.service(identityProviderPath).create({
-      type,
-      token,
-      userId
-    })
+    const createdIdentityProvider = await app.service(identityProviderPath).create(
+      {
+        type,
+        token,
+        userId
+      },
+      {
+        authentication: {
+          accessToken
+        }
+      }
+    )
 
     providers.push(createdIdentityProvider)
 
@@ -131,11 +147,19 @@ describe('identity-provider.service', () => {
   })
 
   it('should not be able to remove identity providers by user id', async () => {
-    assert.rejects(
-      () =>
-        app.service(identityProviderPath).remove(null, {
+    await assert.rejects(
+      async () =>
+        await app.service(identityProviderPath).remove(null, {
           query: {
             userId
+          },
+          provider: 'rest',
+          headers: {
+            authorization: `Bearer ${accessToken}`
+          },
+          authentication: {
+            strategy: 'jwt',
+            accessToken: accessToken
           }
         }),
       {
@@ -152,7 +176,7 @@ describe('identity-provider.service', () => {
       {
         type,
         token,
-        userId
+        userId: '' as UserID
       },
       {}
     )
@@ -160,21 +184,137 @@ describe('identity-provider.service', () => {
     assert.ok(() => app.service(identityProviderPath).remove(foundIdentityProvider.id))
   })
 
-  it('should not be able to remove the only identity provider as a user', async () => {
-    const type = 'user'
+  it('should not be able to remove the only non-guest identity provider as a user', async () => {
+    const type = 'github'
     const token = uuidv4()
 
     const foundIdentityProvider = await app.service(identityProviderPath).create(
       {
         type,
         token,
-        userId
+        userId: '' as UserID
       },
       {}
     )
 
-    assert.rejects(() => app.service(identityProviderPath).remove(foundIdentityProvider.id), {
-      name: 'MethodNotAllowed'
+    await app.service(userPath)._patch(foundIdentityProvider.userId, {
+      isGuest: false
     })
+
+    console.log('foundIdentityProvider', foundIdentityProvider)
+    await assert.rejects(
+      async () =>
+        await app.service(identityProviderPath).remove(foundIdentityProvider.id, {
+          provider: 'rest',
+          headers: {
+            authorization: `Bearer ${foundIdentityProvider.accessToken}`
+          },
+          authentication: {
+            strategy: 'jwt',
+            accessToken: foundIdentityProvider.accessToken
+          }
+        }),
+      {
+        name: 'MethodNotAllowed'
+      }
+    )
+  })
+
+  it('should not be able to make an identity provider on a user with no authentication', async () => {
+    const type = 'guest'
+    const token = uuidv4()
+
+    await assert.rejects(
+      async () =>
+        await app.service(identityProviderPath).create({
+          type,
+          token,
+          userId
+        }),
+      {
+        name: 'BadRequest'
+      }
+    )
+  })
+
+  it('should not be able to make an identity provider on a different user than the authenticated user', async () => {
+    const type = 'guest'
+    const token = uuidv4()
+
+    const foundIdentityProvider = await app.service(identityProviderPath).create(
+      {
+        type,
+        token,
+        userId: '' as UserID
+      },
+      {}
+    )
+
+    await assert.rejects(
+      async () =>
+        await app.service(identityProviderPath).create(
+          {
+            type,
+            token,
+            userId
+          },
+          {
+            provider: 'rest',
+            headers: {
+              authorization: `Bearer ${foundIdentityProvider.accessToken}`
+            },
+            authentication: {
+              strategy: 'jwt',
+              accessToken: foundIdentityProvider.accessToken
+            }
+          }
+        ),
+      {
+        name: 'BadRequest',
+        message: 'Cannot make identity-providers on other users'
+      }
+    )
+  })
+
+  it('should not be able to make a guest identity provider on an existing user', async () => {
+    const type = 'guest'
+    const token = uuidv4()
+    let userId2
+
+    const foundIdentityProvider = await app.service(identityProviderPath).create(
+      {
+        type,
+        token,
+        userId: '' as UserID
+      },
+      {}
+    )
+
+    userId2 = foundIdentityProvider.userId
+
+    await assert.rejects(
+      async () =>
+        await app.service(identityProviderPath).create(
+          {
+            type,
+            token,
+            userId: userId2
+          },
+          {
+            provider: 'rest',
+            headers: {
+              authorization: `Bearer ${foundIdentityProvider.accessToken}`
+            },
+            authentication: {
+              strategy: 'jwt',
+              accessToken: foundIdentityProvider.accessToken
+            }
+          }
+        ),
+      {
+        name: 'BadRequest',
+        message: 'Cannot create a guest identity-provider on an existing user'
+      }
+    )
   })
 })


### PR DESCRIPTION
## Summary

Users were able to create an identity-provider on another user. This would return a valid JWT for that other user that could authenticate requests as them. Enhanced identity-provider hooks for creation so that users can only create identity-providers for themselves, and unauthenticated requests cannot create identity-providers on existing users.

Also prevented the creation of guest identity-providers on existing users, because there's no reason for it and it seems like something that could introduce bugs.

Added tests to ensure that one cannot create an identity-provider on another user. Updated a number of tests to work around some issues this causes - oauth providers are seen as 'guest' providers, so tests that were creating github sign-ins were now failing.

Some identity-provider tests were not actually running to completion. assert.rejects needs to take in an async function whose contents are await'ed, and the assert.rejects itself needs to be await'ed, or else the test suite will mistakenly assume it succeeded when it's still running.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
