### PR TITLE
fix tooltip css applied to all popups

### DIFF
--- a/packages/ui/src/primitives/tailwind/Tooltip/index.tsx
+++ b/packages/ui/src/primitives/tailwind/Tooltip/index.tsx
@@ -44,6 +44,10 @@ const Tooltip = ({ title, titleClassName, content, children, className, ...rest 
       keepTooltipInside
       repositionOnResize
       arrow={false}
+      contentStyle={{
+        animation: 'expandFromCenter 0.3s cubic-bezier(0.38, 0.1, 0.36, 0.9) forwards',
+        transformOrigin: 'center'
+      }}
       {...rest}
     >
       <div className="-mt-1 grid text-wrap shadow-lg transition-all">

--- a/packages/ui/src/primitives/tailwind/Tooltip/tooltip.css
+++ b/packages/ui/src/primitives/tailwind/Tooltip/tooltip.css
@@ -12,9 +12,3 @@
     opacity: 1;
   }
 }
-
-.popup-content {
-  animation: expandFromCenter 0.3s cubic-bezier(0.38, 0.1, 0.36, 0.9) forwards;
-  -webkit-animation: expandFromCenter 0.3s cubic-bezier(0.38, 0.1, 0.36, 0.9) forwards;
-  transform-origin: center;
-}


### PR DESCRIPTION
## Summary

popup `content` class was applied whenever **any** type of popup was opened

it should only apply for tooltip. fixed using inline styles

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps

#### Earlier



https://github.com/user-attachments/assets/d2137584-4ad9-4c48-a5da-5377b8ad3811


#### Now

https://github.com/user-attachments/assets/a51d0a63-6adb-4f9e-828f-03d3e0cfaef4



