### PR TITLE
Fixed a bug with project PUTs without commit SHAs

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1452,6 +1452,7 @@ export const updateProject = async (
   try {
     const branchExists = await git.raw(['ls-remote', '--heads', repoPath, `${branchName}`])
     if (data.commitSHA) await git.checkout(data.commitSHA)
+    else if (data.sourceBranch) await git.checkout(data.sourceBranch)
     if (branchExists.length === 0 || data.reset) {
       try {
         await git.deleteLocalBranch(branchName)


### PR DESCRIPTION
## Summary

If a project PUT had a sourceBranch but no commit SHA, it was not checking out anything and staying with the default branch's tip. Now a PUT with a sourceBranch and no SHA checks out that branch. Specifying a commit will always checkout that commit.

Resolves IR-3820

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
