### PR TITLE
IR-3702 Hotfix incorrect gizmo start position on rigidbody entities

### DIFF
--- a/packages/editor/src/functions/gizmoHelper.ts
+++ b/packages/editor/src/functions/gizmoHelper.ts
@@ -533,7 +533,9 @@ function pointerDown(gizmoEntity) {
     const planeIntersect = intersectObjectWithRay(plane, _raycaster, true)
     if (planeIntersect) {
       const currenttransform = getComponent(targetEntity, TransformComponent)
-      currenttransform.matrix.decompose(_positionStart, _quaternionStart, _scaleStart)
+      _positionStart.copy(currenttransform.position)
+      _quaternionStart.copy(currenttransform.rotation)
+      _scaleStart.copy(currenttransform.scale)
       gizmoControlComponent.worldPositionStart.set(_positionStart)
       gizmoControlComponent.worldQuaternionStart.set(_quaternionStart)
 


### PR DESCRIPTION
## Summary
Rigidbody entities don't have the rigidbody's position written to their transform matrix, so this PR gets the transform data from the transform component's position, rotation, and scale values instead of its matrix.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
