### PR TITLE
added tailwind class to break the line in the middle of words to prevent overflowing the allocated space

### DIFF
--- a/packages/ui/src/components/editor/panels/Properties/material/index.tsx
+++ b/packages/ui/src/components/editor/panels/Properties/material/index.tsx
@@ -220,7 +220,7 @@ export function MaterialEditor(props: { materialUUID: EntityUUID }) {
           <div className="justify-cneter flex items-center align-middle">
             <label>{t('editor:properties.mesh.material.path')}</label>
           </div>
-          <div>{getOptionalComponent(entity, SourceComponent) ?? 'None'}</div>
+          <div className="break-all">{getOptionalComponent(entity, SourceComponent) ?? 'None'}</div>
         </div>
       </InputGroup>
       <br />


### PR DESCRIPTION
added tailwind class to break the line in the middle of words to prevent overflowing the allocated space
https://tsu.atlassian.net/browse/IR-3789
## Summary

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
