### PR TITLE
Left aligning the text in the "Add Component" and "Add Entity" menus

### DIFF
--- a/packages/ui/src/components/editor/panels/Properties/elementList/index.tsx
+++ b/packages/ui/src/components/editor/panels/Properties/elementList/index.tsx
@@ -78,10 +78,10 @@ const ComponentListItem = ({ item, onSelect }: { item: Component; onSelect: () =
       startIcon={<Icon className="h-4 w-4 text-[#B2B5BD]" />}
     >
       <div className="ml-4 w-full">
-        <Text className="mb-1 block text-center text-sm text-[#B2B5BD]">
+        <Text className="mb-1 block text-left text-sm text-[#B2B5BD]">
           {startCase(jsonName.replace('-', ' ').toLowerCase())}
         </Text>
-        <Text component="p" className="block text-center text-xs text-theme-secondary">
+        <Text component="p" className="block text-left text-xs text-theme-secondary">
           {t(`editor:layout.assetGrid.component-detail.${jsonName}`, '')}
         </Text>
       </div>
@@ -107,8 +107,8 @@ const PrefabListItem = ({ item, onSelect }: { item: PrefabShelfItem; onSelect: (
       startIcon={<IoMdAddCircle className="h-4 w-4 text-[#B2B5BD]" />}
     >
       <div className="ml-4 w-full">
-        <Text className="mb-1 block text-center text-sm text-[#B2B5BD]">{item.name}</Text>
-        <Text component="p" className="block text-center text-xs text-theme-secondary">
+        <Text className="mb-1 block text-left text-sm text-[#B2B5BD]">{item.name}</Text>
+        <Text component="p" className="block text-left text-xs text-theme-secondary">
           {item.detail}
         </Text>
       </div>


### PR DESCRIPTION
Adjusts the component names and descriptions in the Add Entity and Add Component menus to be left-aligned.

## References
closes [IR-3825](https://tsu.atlassian.net/browse/IR-3825)

[IR-3825]: https://tsu.atlassian.net/browse/IR-3825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ