### PR TITLE
IR-3921: Copying resource should create a static-resource entry

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -244,14 +244,37 @@ export class FileBrowserService
     const results = [] as StaticResourceType[]
     for (const resource of staticResources) {
       const newKey = resource.key.replace(path.join(oldDirectory, oldName), path.join(newDirectory, fileName))
-      const result = await this.app.service(staticResourcePath).patch(
-        resource.id,
-        {
-          key: newKey
-        },
-        { isInternal: true }
-      )
-      results.push(result)
+
+      if (data.isCopy) {
+        const result = await this.app.service(staticResourcePath).create(
+          {
+            key: newKey,
+            hash: resource.hash,
+            mimeType: resource.mimeType,
+            project: data.newProject,
+            stats: resource.stats,
+            type: resource.type,
+            tags: resource.tags,
+            dependencies: resource.dependencies,
+            licensing: resource.licensing,
+            description: resource.description,
+            attribution: resource.attribution,
+            thumbnailKey: resource.thumbnailKey,
+            thumbnailMode: resource.thumbnailMode
+          },
+          { isInternal: true }
+        )
+        results.push(result)
+      } else {
+        const result = await this.app.service(staticResourcePath).patch(
+          resource.id,
+          {
+            key: newKey
+          },
+          { isInternal: true }
+        )
+        results.push(result)
+      }
     }
 
     if (config.fsProjectSyncEnabled) {

--- a/packages/server-core/src/media/file-browser/file-browser.test.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.test.ts
@@ -28,7 +28,7 @@ import assert from 'assert'
 import { fileBrowserPath } from '@etherealengine/common/src/schemas/media/file-browser.schema'
 import { destroyEngine } from '@etherealengine/ecs/src/Engine'
 
-import { ProjectType, projectPath } from '@etherealengine/common/src/schema.type.module'
+import { ProjectType, projectPath, staticResourcePath } from '@etherealengine/common/src/schema.type.module'
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 import { getStorageProvider } from '../storageprovider/storageprovider'
@@ -227,18 +227,35 @@ describe('file-browser.test', () => {
     })
 
     it('copies file', async () => {
+      const oldPath = 'projects/' + testProjectName2 + '/public/'
+      const newPath = 'projects/' + testProjectName + '/public/'
+
       const copyFileResult = await app.service(fileBrowserPath).update(null, {
         oldProject: testProjectName2,
         newProject: testProjectName,
         oldName: testFileName2,
         newName: testFileName2,
-        oldPath: 'projects/' + testProjectName2 + '/public/',
-        newPath: 'projects/' + testProjectName + '/public/',
+        oldPath,
+        newPath,
         isCopy: true
       })
 
       assert.equal(copyFileResult.length, 1)
-      assert(copyFileResult[0].key === 'projects/' + testProjectName + '/public/' + testFileName2)
+      assert(copyFileResult[0].key === newPath + testFileName2)
+
+      const originalResource = await app.service(staticResourcePath).find({
+        query: {
+          key: oldPath + testFileName2
+        }
+      })
+      assert.ok(originalResource.data.length === 1, 'Original resource not found')
+
+      const copiedResource = await app.service(staticResourcePath).find({
+        query: {
+          key: newPath + testFileName2
+        }
+      })
+      assert.ok(copiedResource.data.length === 1, 'Copied resource not found')
     })
 
     it('copies directory', async () => {


### PR DESCRIPTION
## Summary
Currently, if we copy/paste a resource in studio's file browser, it does not create an entry in static-resource table. But it updates the existing entry with new key. This PR fixes it by identifying copy operations and creating a fresh entry for them.


## Subtasks Checklist

## Breaking Changes

## References
closes https://tsu.atlassian.net/browse/IR-3921

## QA Steps
