### PR TITLE
IR-3516 Fix avatar previews by preventing animations being overwritten on vrm load

### DIFF
--- a/packages/engine/src/scene/components/ModelComponent.tsx
+++ b/packages/engine/src/scene/components/ModelComponent.tsx
@@ -148,7 +148,6 @@ function ModelReactor() {
     /**if we've loaded or converted to vrm, create animation component whose mixer's root is the normalized rig */
     if (boneMatchedAsset instanceof VRM)
       setComponent(entity, AnimationComponent, {
-        animations: gltf.animations,
         mixer: new AnimationMixer(boneMatchedAsset.humanoid.normalizedHumanBonesRoot)
       })
 


### PR DESCRIPTION
## Summary
VRM gltfs never have an animation array exported with them, so there's no reason to be setting that in the model component reactor for loaded vrms.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
