### PR TITLE
assets panel: move nature out of kit category

### DIFF
--- a/packages/editor/src/components/assets/AssetsPanelCategories.ts
+++ b/packages/editor/src/components/assets/AssetsPanelCategories.ts
@@ -55,7 +55,7 @@ export const AssetsPanelCategories = defineState({
         Cottage: {},
         Scifi: {},
         Modern: {},
-        Nature: {},
+
         Ecommerce: {}
       },
       Prop: {
@@ -64,7 +64,8 @@ export const AssetsPanelCategories = defineState({
         //   Showcase: {},
         //   Displays: {}
         // }
-      }
+      },
+      Nature: {}
       // Terrain: {}
     },
     Material: {


### PR DESCRIPTION
The nature pack is not a kit, it's more akin to props in being a separate category of 3d models. This PR simply moves the nature category one level higher in the assets panel category tree to reflect that