### PR TITLE
rename hierarchy node using hotkey

### DIFF
--- a/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
+++ b/packages/ui/src/components/editor/panels/Hierarchy/container/index.tsx
@@ -173,6 +173,14 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
     }
   })
 
+  useHotkeys(`${cmdOrCtrlString}+r`, (e) => {
+    e.preventDefault()
+    const selectedEntities = SelectionState.getSelectedEntities()
+    for (const entity of selectedEntities) {
+      onRenameNode(entity)
+    }
+  })
+
   const MemoTreeNode = useCallback(
     (props: HierarchyTreeNodeProps) => (
       <HierarchyTreeNode
@@ -574,6 +582,7 @@ function HierarchyPanelContents(props: { sceneURL: string; rootEntity: Entity; i
             variant="transparent"
             className="text-left text-xs"
             onClick={() => onRenameNode(contextSelectedItem!)}
+            endIcon={cmdOrCtrlString + ' + r'}
           >
             {t('editor:hierarchy.lbl-rename')}
           </Button>


### PR DESCRIPTION
## Summary

Use the ctrl+r (or cmd+r) functionality to rename selected nodes.

## References

https://tsu.atlassian.net/browse/IR-3876

## QA Steps

https://github.com/user-attachments/assets/6ef3d3f1-5432-4fe7-bdb4-f372130d24aa

