### PR TITLE
Update email regex to be more liberal to check TLDs

### DIFF
--- a/packages/common/src/regex/index.ts
+++ b/packages/common/src/regex/index.ts
@@ -65,7 +65,7 @@ export const USER_ID_REGEX = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-f
  * Email regex. Source: https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php
  */
 export const EMAIL_REGEX =
-  /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i
+  /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.[a-z]{2,10}|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i
 
 /**
  * This regex is useful for validating input that must be exactly 10 digits long, such as a phone number (without any separators or formatting).

--- a/packages/common/tests/regex.test.ts
+++ b/packages/common/tests/regex.test.ts
@@ -351,7 +351,6 @@ describe('regex.test', () => {
         'username@yahoo.com.',
         'username@yahoo..com',
         'username@yahoo.c',
-        'username@yahoo.corporate',
         'username@-example.com',
         'username@example.com-',
         'username@example..com',


### PR DESCRIPTION
## Summary
Previously, `EMAIL_REGEX` has a list of top level domains, that are most commonly used by people. That regex was picked from here: https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php

But there are actually lot of other top level domains in existence, and it's just not viable to put all of them into regex. Here's the list of all allowed top level domains: https://data.iana.org/TLD/tlds-alpha-by-domain.txt. There are 1447 top level domains registered till now.

Now, I'm updating regex to allow top level domains which follow this criteria:
- minimum length: 2
- maximum length: 10 (this is actually very long when considering regularly used TLDs like `.com`, `.io`. But to allow maximum TLDs, while still not allowing obscure TLDs, this figure is chosen)

Out of the 1447 TLDs, 1305 (90%) TLDs  follow this criteria.

New pattern is liberal than previous pattern. So it can have false positives. But I guess false positives are better than false negatives in case of email validation.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
