### PR TITLE
addMediaNode now returns the entity UUID | null of whatever media was added

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -250,7 +250,7 @@ const createObjectFromSceneElement = (
   componentJson: ComponentJsonType[] = [],
   parentEntity = getState(EditorState).rootEntity,
   beforeEntity?: Entity
-) => {
+): { entityUUID: EntityUUID; sceneID: string } => {
   const scenes = getSourcesForEntities([parentEntity])
   const entityUUID: EntityUUID =
     componentJson.find((comp) => comp.name === UUIDComponent.jsonID)?.props.uuid ?? generateEntityUUID()


### PR DESCRIPTION
`addMediaNode` can provide context about what it added by returning the new node's entity UUID.

This is used in the IR wizard, and part of the work on ticket https://tsu.atlassian.net/browse/IR-3981