### PR TITLE
Added a function to clean project names for k8s

### DIFF
--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -63,7 +63,7 @@ import { createExecutorJob } from '../../k8s-job-helper'
 import { getFileKeysRecursive } from '../../media/storageprovider/storageProviderUtils'
 import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { useGit } from '../../util/gitHelperFunctions'
-import { getProjectPushJobBody } from './project-helper'
+import { cleanProjectName, getProjectPushJobBody } from './project-helper'
 import { ProjectParams } from './project.class'
 
 // 30 MB. GitHub's documentation says that the blob upload cutoff is 50MB, but in testing, some files that were around
@@ -353,7 +353,7 @@ export const pushProjectToGithub = async (
       returnData: '',
       status: 'pending'
     })
-    const projectJobName = project.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+    const projectJobName = cleanProjectName(project.name)
     const jobBody = await getProjectPushJobBody(app, project, user, reset, newJob.id, commitSHA)
     await app.service(apiJobPath).patch(newJob.id, {
       name: jobBody.metadata!.name

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1042,7 +1042,7 @@ export async function getProjectUpdateJobBody(
     command.push(data.reset.toString())
   }
 
-  const projectJobName = data.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+  const projectJobName = cleanProjectName(data.name)
 
   const labels = {
     'etherealengine/projectUpdater': 'true',
@@ -1090,7 +1090,7 @@ export async function getProjectPushJobBody(
     command.push(storageProviderName)
   }
 
-  const projectJobName = project.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+  const projectJobName = cleanProjectName(project.name)
 
   const labels = {
     'etherealengine/projectPusher': 'true',
@@ -1104,7 +1104,7 @@ export async function getProjectPushJobBody(
 }
 
 export const getCronJobBody = (project: ProjectType, image: string): object => {
-  const projectJobName = project.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+  const projectJobName = cleanProjectName(project.name)
   return {
     metadata: {
       name: `${process.env.RELEASE_NAME}-${projectJobName}-auto-update`,
@@ -1180,7 +1180,7 @@ export async function getDirectoryArchiveJobBody(
     jobId
   ]
 
-  const projectJobName = projectName.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+  const projectJobName = cleanProjectName(projectName)
 
   const labels = {
     'etherealengine/directoryArchiver': 'true',
@@ -1537,7 +1537,7 @@ export const updateProject = async (
   returned.needsRebuild = typeof data.needsRebuild === 'boolean' ? data.needsRebuild : true
 
   if (returned.name !== projectName)
-    await app.service(projectPath).patch(existingProject!.id, {
+    await app.service(projectPath).patch(returned.id, {
       name: projectName
     })
 
@@ -1857,4 +1857,11 @@ export const uploadLocalProjectToProvider = async (
   logger.info(`uploadLocalProjectToProvider for project "${projectName}" ended at "${new Date()}".`)
   const assetsOnly = !fs.existsSync(path.join(projectRootPath, 'xrengine.config.ts'))
   return { files: results.filter((success) => !!success) as string[], assetsOnly }
+}
+
+export const cleanProjectName = (name: string) => {
+  const returned = name.toLowerCase().replace(/[^a-zA-Z0-9-.]/g, '-')
+  if (!/[a-zA-Z0-9]/.test(returned[0])) return cleanProjectName(name.slice(1))
+  if (!/[a-zA-Z0-9]/.test(returned[returned.length - 1])) return cleanProjectName(name.slice(0, returned.length - 1))
+  return returned
 }

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -74,6 +74,7 @@ import logger from '../../ServerLogger'
 import { useGit } from '../../util/gitHelperFunctions'
 import { checkAppOrgStatus, checkUserOrgWriteStatus, checkUserRepoWriteStatus } from './github-helper'
 import {
+  cleanProjectName,
   deleteProjectFilesInStorageProvider,
   engineVersion,
   getProjectConfig,
@@ -550,7 +551,7 @@ const updateProjectJob = async (context: HookContext) => {
       returnData: '',
       status: 'pending'
     })
-    const projectJobName = data.name.toLowerCase().replace(/[^a-z0-9-.]/g, '-')
+    const projectJobName = cleanProjectName(data.name)
     const jobBody = await getProjectUpdateJobBody(
       data,
       context.app,


### PR DESCRIPTION
## Summary

Current solution was leaving dashes at the start or end of labels if they started or ended with invalid characters. The characters were replaced by dashes, but k8s does not allow dashes at the start or end.

Fixed a bug where new projects where existingProject.id was being read from even if existingProject didn't exist. Now reading from returned.id; returned always exists.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
